### PR TITLE
Update function-level comparison for Phase 1 and 2

### DIFF
--- a/docs/rebuild/comparison/core.md
+++ b/docs/rebuild/comparison/core.md
@@ -92,8 +92,8 @@ Rust版は**Pix/PixMut二層モデル**を採用しているため、C版の一�
 |-------|------|----------|------|
 | pixGetPixel | ✅ | Pix::get_pixel() | |
 | pixSetPixel | ✅ | PixMut::set_pixel() | |
-| pixGetRGBPixel | ❌ | - | RGBコンポーネント分離は未実装 |
-| pixSetRGBPixel | ❌ | - | |
+| pixGetRGBPixel | ✅ | rgb.rs get_rgb_pixel() | |
+| pixSetRGBPixel | ✅ | rgb.rs set_rgb_pixel() | |
 | pixSetCmapPixel | ❌ | - | |
 | pixGetRandomPixel | ❌ | - | |
 | pixClearPixel | ❌ | - | set_pixel(x, y, 0)で可 |
@@ -112,26 +112,26 @@ Rust版は**Pix/PixMut二層モデル**を採用しているため、C版の一�
 | pixSetPadBits | ❌ | - | |
 | pixSetPadBitsBand | ❌ | - | |
 | pixSetOrClearBorder | ❌ | - | |
-| pixSetBorderVal | ❌ | - | |
+| pixSetBorderVal | ✅ | border.rs set_border_val() | |
 | pixSetBorderRingVal | ❌ | - | |
 | pixSetMirroredBorder | ❌ | - | |
 | pixCopyBorder | ❌ | - | |
-| pixAddBorder | ❌ | - | border.rsに部分実装あり |
-| pixAddBlackOrWhiteBorder | ❌ | - | |
-| pixAddBorderGeneral | ❌ | - | |
+| pixAddBorder | ✅ | border.rs add_border() | |
+| pixAddBlackOrWhiteBorder | ✅ | border.rs add_black_or_white_border() | |
+| pixAddBorderGeneral | ✅ | border.rs add_border_general() | |
 | pixAddMultipleBlackWhiteBorders | ❌ | - | |
-| pixRemoveBorder | ❌ | - | |
-| pixRemoveBorderGeneral | ❌ | - | |
+| pixRemoveBorder | ✅ | border.rs remove_border() | |
+| pixRemoveBorderGeneral | ✅ | border.rs remove_border_general() | |
 | pixRemoveBorderToSize | ❌ | - | |
-| pixAddMirroredBorder | ❌ | - | |
-| pixAddRepeatedBorder | ❌ | - | |
+| pixAddMirroredBorder | ✅ | border.rs add_mirrored_border() | |
+| pixAddRepeatedBorder | ✅ | border.rs add_repeated_border() | |
 | pixAddMixedBorder | ❌ | - | |
 | pixAddContinuedBorder | ❌ | - | |
 | pixShiftAndTransferAlpha | ❌ | - | |
 | pixDisplayLayersRGBA | ❌ | - | |
-| pixCreateRGBImage | ❌ | - | |
-| pixGetRGBComponent | ❌ | - | |
-| pixSetRGBComponent | ❌ | - | |
+| pixCreateRGBImage | ✅ | rgb.rs create_rgb_image() | |
+| pixGetRGBComponent | ✅ | rgb.rs get_rgb_component() | |
+| pixSetRGBComponent | ✅ | rgb.rs set_rgb_component() | |
 | pixGetRGBComponentCmap | ❌ | - | |
 | pixCopyRGBComponent | ❌ | - | |
 | composeRGBPixel | ❌ | - | |
@@ -151,15 +151,15 @@ Rust版は**Pix/PixMut二層モデル**を採用しているため、C版の一�
 
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| pixSetMasked | ❌ | - | |
+| pixSetMasked | ✅ | mask.rs set_masked() | |
 | pixSetMaskedGeneral | ❌ | - | |
-| pixCombineMasked | ❌ | - | |
+| pixCombineMasked | ✅ | mask.rs combine_masked() | |
 | pixCombineMaskedGeneral | ❌ | - | |
-| pixPaintThroughMask | ❌ | - | |
+| pixPaintThroughMask | ✅ | mask.rs paint_through_mask() | |
 | pixCopyWithBoxa | ❌ | - | |
 | pixPaintSelfThroughMask | ❌ | - | |
-| pixMakeMaskFromVal | ❌ | - | |
-| pixMakeMaskFromLUT | ❌ | - | |
+| pixMakeMaskFromVal | ✅ | mask.rs make_mask_from_val() | |
+| pixMakeMaskFromLUT | ✅ | mask.rs make_mask_from_lut() | |
 | pixMakeArbMaskFromRGB | ❌ | - | |
 | pixSetUnderTransparency | ❌ | - | |
 | pixMakeAlphaFromMask | ❌ | - | |
@@ -170,18 +170,18 @@ Rust版は**Pix/PixMut二層モデル**を採用しているため、C版の一�
 | pixAnd | ✅ | ops.rsに実装 | |
 | pixXor | ✅ | ops.rsに実装 | |
 | pixSubtract | ✅ | ops.rsに実装 | |
-| pixZero | ❌ | - | |
-| pixForegroundFraction | ❌ | - | |
+| pixZero | ✅ | statistics.rs is_zero() | |
+| pixForegroundFraction | ✅ | statistics.rs foreground_fraction() | |
 | pixaCountPixels | ❌ | - | |
 | pixCountPixels | ❌ | - | statistics.rsに関連実装あり |
-| pixCountPixelsInRect | ❌ | - | |
-| pixCountByRow | ❌ | - | |
-| pixCountByColumn | ❌ | - | |
+| pixCountPixelsInRect | ✅ | statistics.rs count_pixels_in_rect() | |
+| pixCountByRow | ✅ | statistics.rs count_by_row() | |
+| pixCountByColumn | ✅ | statistics.rs count_by_column() | |
 | pixCountPixelsByRow | ❌ | - | |
 | pixCountPixelsByColumn | ❌ | - | |
 | pixCountPixelsInRow | ❌ | - | |
 | pixGetMomentByColumn | ❌ | - | |
-| pixThresholdPixelSum | ❌ | - | |
+| pixThresholdPixelSum | ✅ | statistics.rs threshold_pixel_sum() | |
 | pixAverageByRow | ❌ | - | |
 | pixAverageByColumn | ❌ | - | |
 | pixAverageInRect | ❌ | - | |
@@ -816,16 +816,16 @@ convert.rsに一部実装あり。多くの関数は未実装。
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
 | pixThreshold8 | ❌ | - | |
-| pixRemoveColormapGeneral | ❌ | - | |
-| pixRemoveColormap | ❌ | - | |
-| pixAddGrayColormap8 | ❌ | - | |
-| pixAddMinimalGrayColormap8 | ❌ | - | |
-| pixConvertRGBToLuminance | ❌ | - | |
-| pixConvertRGBToGrayGeneral | ❌ | - | |
-| pixConvertRGBToGray | ❌ | - | |
-| pixConvertRGBToGrayFast | ❌ | - | |
-| pixConvertRGBToGrayMinMax | ❌ | - | |
-| pixConvertRGBToGraySatBoost | ❌ | - | |
+| pixRemoveColormapGeneral | ✅ | convert.rs remove_colormap_general() | |
+| pixRemoveColormap | ✅ | convert.rs remove_colormap() | |
+| pixAddGrayColormap8 | ✅ | convert.rs add_gray_colormap8() | |
+| pixAddMinimalGrayColormap8 | ✅ | convert.rs add_minimal_gray_colormap8() | |
+| pixConvertRGBToLuminance | ✅ | convert.rs convert_rgb_to_luminance() | |
+| pixConvertRGBToGrayGeneral | ✅ | convert.rs convert_rgb_to_gray_general() | |
+| pixConvertRGBToGray | ✅ | convert.rs convert_rgb_to_gray() | |
+| pixConvertRGBToGrayFast | ✅ | convert.rs convert_rgb_to_gray_fast() | |
+| pixConvertRGBToGrayMinMax | ✅ | convert.rs convert_rgb_to_gray_min_max() | |
+| pixConvertRGBToGraySatBoost | ✅ | convert.rs convert_rgb_to_gray_sat_boost() | |
 | pixConvertRGBToGrayArb | ❌ | - | |
 | pixConvertRGBToBinaryArb | ❌ | - | |
 | pixConvertGrayToColormap | ❌ | - | |
@@ -834,42 +834,42 @@ convert.rsに一部実装あり。多くの関数は未実装。
 | pixConvertRGBToColormap | ❌ | - | |
 | pixConvertCmapTo1 | ❌ | - | |
 | pixQuantizeIfFewColors | ❌ | - | |
-| pixConvert16To8 | ❌ | - | |
+| pixConvert16To8 | ✅ | convert.rs convert_16_to_8() | |
 | pixConvertGrayToFalseColor | ❌ | - | |
-| pixUnpackBinary | ❌ | - | |
-| pixConvert1To16 | ❌ | - | |
-| pixConvert1To32 | ❌ | - | |
-| pixConvert1To2Cmap | ❌ | - | |
-| pixConvert1To2 | ❌ | - | |
-| pixConvert1To4Cmap | ❌ | - | |
-| pixConvert1To4 | ❌ | - | |
-| pixConvert1To8Cmap | ❌ | - | |
-| pixConvert1To8 | ❌ | - | |
+| pixUnpackBinary | ✅ | convert.rs unpack_binary() | |
+| pixConvert1To16 | ✅ | convert.rs convert_1_to_16() | |
+| pixConvert1To32 | ✅ | convert.rs convert_1_to_32() | |
+| pixConvert1To2Cmap | ✅ | convert.rs convert_1_to_2_cmap() | |
+| pixConvert1To2 | ✅ | convert.rs convert_1_to_2() | |
+| pixConvert1To4Cmap | ✅ | convert.rs convert_1_to_4_cmap() | |
+| pixConvert1To4 | ✅ | convert.rs convert_1_to_4() | |
+| pixConvert1To8Cmap | ✅ | convert.rs convert_1_to_8_cmap() | |
+| pixConvert1To8 | ✅ | convert.rs convert_1_to_8() | |
 | pixConvert2To8 | ❌ | - | |
 | pixConvert4To8 | ❌ | - | |
-| pixConvert8To16 | ❌ | - | |
+| pixConvert8To16 | ✅ | convert.rs convert_8_to_16() | |
 | pixConvertTo2 | ❌ | - | |
 | pixConvert8To2 | ❌ | - | |
 | pixConvertTo4 | ❌ | - | |
 | pixConvert8To4 | ❌ | - | |
 | pixConvertTo1Adaptive | ❌ | - | |
-| pixConvertTo1 | ❌ | - | |
+| pixConvertTo1 | ✅ | convert.rs convert_to_1() | |
 | pixConvertTo1BySampling | ❌ | - | |
 | pixConvertTo8 | ❌ | - | |
 | pixConvertTo8BySampling | ❌ | - | |
 | pixConvertTo8Colormap | ❌ | - | |
-| pixConvertTo16 | ❌ | - | |
+| pixConvertTo16 | ✅ | convert.rs convert_to_16() | |
 | pixConvertTo32 | ❌ | - | |
 | pixConvertTo32BySampling | ❌ | - | |
-| pixConvert8To32 | ❌ | - | |
-| pixConvertTo8Or32 | ❌ | - | |
+| pixConvert8To32 | ✅ | convert.rs convert_8_to_32() | |
+| pixConvertTo8Or32 | ✅ | convert.rs convert_to_8_or_32() | |
 | pixConvert24To32 | ❌ | - | |
 | pixConvert32To24 | ❌ | - | |
 | pixConvert32To16 | ❌ | - | |
-| pixConvert32To8 | ❌ | - | |
-| pixRemoveAlpha | ❌ | - | |
+| pixConvert32To8 | ✅ | convert.rs convert_32_to_8() | |
+| pixRemoveAlpha | ✅ | convert.rs remove_alpha() | |
 | pixAddAlphaTo1bpp | ❌ | - | |
-| pixConvertLossless | ❌ | - | |
+| pixConvertLossless | ✅ | convert.rs convert_lossless() | |
 | pixConvertForPSWrap | ❌ | - | |
 | pixConvertToSubpixelRGB | ❌ | - | |
 | pixConvertGrayToSubpixelRGB | ❌ | - | |

--- a/docs/rebuild/comparison/filter.md
+++ b/docs/rebuild/comparison/filter.md
@@ -57,32 +57,32 @@
 
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| pixGammaTRC | ❌ 未実装 | - | ガンマTRCマッピング |
-| pixGammaTRCMasked | ❌ 未実装 | - | マスク付きガンマTRC |
-| pixGammaTRCWithAlpha | ❌ 未実装 | - | アルファチャンネル付きガンマTRC |
-| numaGammaTRC | ❌ 未実装 | - | ガンマTRC NUMA生成 (returns NUMA*) |
-| pixContrastTRC | ❌ 未実装 | - | コントラストTRC |
-| pixContrastTRCMasked | ❌ 未実装 | - | マスク付きコントラストTRC |
-| numaContrastTRC | ❌ 未実装 | - | コントラストTRC NUMA生成 (returns NUMA*) |
-| pixEqualizeTRC | ❌ 未実装 | - | ヒストグラム均等化TRC |
-| numaEqualizeTRC | ❌ 未実装 | - | 均等化TRC NUMA生成 (returns NUMA*) |
-| pixTRCMap | ❌ 未実装 | - | 汎用TRCマッパー (returns l_int32, in-place) |
-| pixTRCMapGeneral | ❌ 未実装 | - | 汎用TRCマッパー(一般) (returns l_int32, in-place) |
+| pixGammaTRC | ✅ 同等 | gamma_trc_pix() | ガンマTRCマッピング |
+| pixGammaTRCMasked | ✅ 同等 | gamma_trc_masked() | マスク付きガンマTRC |
+| pixGammaTRCWithAlpha | ✅ 同等 | gamma_trc_with_alpha() | アルファチャンネル付きガンマTRC |
+| numaGammaTRC | ✅ 同等 | gamma_trc() | TrcLut([u8;256])を返す |
+| pixContrastTRC | ✅ 同等 | contrast_trc_pix() | コントラストTRC |
+| pixContrastTRCMasked | ✅ 同等 | contrast_trc_masked() | マスク付きコントラストTRC |
+| numaContrastTRC | ✅ 同等 | contrast_trc() | TrcLut([u8;256])を返す |
+| pixEqualizeTRC | ✅ 同等 | equalize_trc_pix() | ヒストグラム均等化TRC |
+| numaEqualizeTRC | ✅ 同等 | equalize_trc() | TrcLut([u8;256])を返す |
+| pixTRCMap | ✅ 同等 | trc_map() | 汎用TRCマッパー |
+| pixTRCMapGeneral | ✅ 同等 | trc_map_general() | R,G,B個別LUT適用 |
 | pixUnsharpMasking | ❌ 未実装 | - | アンシャープマスキング(カラー対応) |
 | pixUnsharpMaskingGray | ✅ 同等 | unsharp_mask() | グレースケールアンシャープマスキング |
 | pixUnsharpMaskingFast | ❌ 未実装 | - | 高速アンシャープマスキング(カラー対応) |
 | pixUnsharpMaskingGrayFast | ❌ 未実装 | - | 高速グレースケールアンシャープマスキング |
 | pixUnsharpMaskingGray1D | ❌ 未実装 | - | 1Dグレースケールアンシャープマスキング |
 | pixUnsharpMaskingGray2D | ❌ 未実装 | - | 2Dグレースケールアンシャープマスキング |
-| pixModifyHue | ❌ 未実装 | - | 色相変更 |
-| pixModifySaturation | ❌ 未実装 | - | 彩度変更 |
-| pixMeasureSaturation | ❌ 未実装 | - | 彩度測定 (returns l_int32) |
-| pixModifyBrightness | ❌ 未実装 | - | 明度変更 |
+| pixModifyHue | ✅ 同等 | modify_hue() | 色相変更 |
+| pixModifySaturation | ✅ 同等 | modify_saturation() | 彩度変更 |
+| pixMeasureSaturation | ✅ 同等 | measure_saturation() | 彩度測定 |
+| pixModifyBrightness | ✅ 同等 | modify_brightness() | 明度変更 |
 | pixMosaicColorShiftRGB | ❌ 未実装 | - | モザイク色シフト |
-| pixColorShiftRGB | ❌ 未実装 | - | 色シフト |
-| pixDarkenGray | ❌ 未実装 | - | グレーピクセル暗色化 |
-| pixMultConstantColor | ❌ 未実装 | - | 定数乗算カラー変換 |
-| pixMultMatrixColor | ❌ 未実装 | - | 行列乗算カラー変換 |
+| pixColorShiftRGB | ✅ 同等 | color_shift_rgb() | 色シフト |
+| pixDarkenGray | ✅ 同等 | darken_gray() | グレーピクセル暗色化 |
+| pixMultConstantColor | ✅ 同等 | mult_constant_color() | 定数乗算カラー変換 |
+| pixMultMatrixColor | ✅ 同等 | mult_matrix_color() | 行列乗算カラー変換 |
 | pixHalfEdgeByBandpass | ❌ 未実装 | - | バンドパスによるハーフエッジ |
 
 ### bilateral.c

--- a/docs/rebuild/feature-comparison.md
+++ b/docs/rebuild/feature-comparison.md
@@ -17,16 +17,16 @@ C版の全public関数を抽出し、Rust版での実装状況を3段階で分�
 
 | クレート | ✅ 同等 | 🔄 異なる | ❌ 未実装 | 合計 | カバレッジ |
 |---------|--------|----------|---------|------|-----------|
-| [leptonica-core](comparison/core.md) | 82 | 24 | 742 | 848 | 12.5% |
+| [leptonica-core](comparison/core.md) | 134 | 24 | 690 | 848 | 18.6% |
 | [leptonica-io](comparison/io.md) | 32 | 15 | 99 | 146 | 32.2% |
 | [leptonica-transform](comparison/transform.md) | 39 | 12 | 101 | 152 | 33.6% |
 | [leptonica-morph](comparison/morph.md) | 34 | 8 | 78 | 120 | 35.0% |
-| [leptonica-filter](comparison/filter.md) | 11 | 0 | 83 | 94 | 11.7% |
+| [leptonica-filter](comparison/filter.md) | 30 | 0 | 64 | 94 | 31.9% |
 | [leptonica-color](comparison/color.md) | 18 | 12 | 109 | 139 | 21.6% |
 | [leptonica-region](comparison/region.md) | 28 | 8 | 68 | 104 | 34.6% |
 | [leptonica-recog](comparison/recog.md) | 42 | 9 | 93 | 144 | 35.4% |
 | [その他](comparison/misc.md) | 13 | 0 | 103 | 116 | 11.2% |
-| **合計** | **299** | **88** | **1,476** | **1,863** | **20.8%** |
+| **合計** | **370** | **88** | **1,405** | **1,863** | **24.6%** |
 
 ### 分類基準
 


### PR DESCRIPTION
## Summary

- Phase 1 (leptonica-core) の52関数の実装状態を ❌→✅ に更新
- Phase 2 (leptonica-filter enhance.c) の19関数の実装状態を ❌→✅ に更新
- 全体カバレッジ: 299→370 ✅ (20.8%→24.6%)

## Test plan

- [x] ドキュメントのみの変更、コード変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)