### PR TITLE
feat(filter): implement unsharp masking fast functions

### DIFF
--- a/crates/leptonica-filter/src/edge.rs
+++ b/crates/leptonica-filter/src/edge.rs
@@ -1,7 +1,7 @@
 //! Edge detection and enhancement operations
 
-use crate::{FilterError, FilterResult, Kernel, convolve_gray};
-use leptonica_core::{Pix, PixelDepth};
+use crate::{FilterError, FilterResult, Kernel, blockconv_gray, convolve_gray};
+use leptonica_core::{Pix, PixelDepth, pix::RgbComponent};
 
 /// Edge detection orientation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -171,6 +171,104 @@ pub fn unsharp_mask(pix: &Pix, radius: u32, amount: f32) -> FilterResult<Pix> {
     Ok(out_mut.into())
 }
 
+/// Fast unsharp masking using block convolution
+///
+/// Uses block convolution for faster blurring instead of Gaussian convolution.
+/// Only supports halfwidth=1 (3x3) or halfwidth=2 (5x5) for speed.
+///
+/// # Arguments
+/// * `pix` - Input image (8 bpp grayscale for grayfast, 32 bpp for color)
+/// * `halfwidth` - Kernel half-width (1 or 2; kernel size = 2*halfwidth+1)
+/// * `amount` - Sharpening strength (typically 0.2-0.7)
+pub fn unsharp_masking_fast(pix: &Pix, halfwidth: u32, amount: f32) -> FilterResult<Pix> {
+    let depth = pix.depth();
+
+    // Check supported depths
+    if depth != PixelDepth::Bit8 && depth != PixelDepth::Bit32 {
+        return Err(FilterError::UnsupportedDepth {
+            expected: "8 or 32 bpp",
+            actual: depth.bits(),
+        });
+    }
+
+    // If 8bpp, dispatch to gray_fast
+    if depth == PixelDepth::Bit8 {
+        return unsharp_masking_gray_fast(pix, halfwidth, amount);
+    }
+
+    // 32bpp: extract R, G, B channels, apply gray_fast to each, recombine
+    let pix_r = pix.get_rgb_component(RgbComponent::Red)?;
+    let pix_g = pix.get_rgb_component(RgbComponent::Green)?;
+    let pix_b = pix.get_rgb_component(RgbComponent::Blue)?;
+
+    let pix_rs = unsharp_masking_gray_fast(&pix_r, halfwidth, amount)?;
+    let pix_gs = unsharp_masking_gray_fast(&pix_g, halfwidth, amount)?;
+    let pix_bs = unsharp_masking_gray_fast(&pix_b, halfwidth, amount)?;
+
+    let mut result = Pix::create_rgb_image(&pix_rs, &pix_gs, &pix_bs)?;
+
+    // If the original had alpha channel (spp=4), copy it
+    if pix.spp() == 4 {
+        let pix_a = pix.get_rgb_component(RgbComponent::Alpha)?;
+        let mut result_mut = result.try_into_mut().unwrap();
+        result_mut.set_rgb_component(&pix_a, RgbComponent::Alpha)?;
+        result = result_mut.into();
+    }
+
+    Ok(result)
+}
+
+/// Fast unsharp masking for grayscale images
+///
+/// Uses block convolution for faster blurring.
+pub fn unsharp_masking_gray_fast(pix: &Pix, halfwidth: u32, amount: f32) -> FilterResult<Pix> {
+    // Validate input
+    if pix.depth() != PixelDepth::Bit8 {
+        return Err(FilterError::UnsupportedDepth {
+            expected: "8-bpp grayscale",
+            actual: pix.depth().bits(),
+        });
+    }
+
+    // If amount <= 0.0, return a clone (no sharpening)
+    if amount <= 0.0 {
+        return Ok(pix.clone());
+    }
+
+    // Validate halfwidth
+    if halfwidth != 1 && halfwidth != 2 {
+        return Err(FilterError::InvalidParameters(
+            "halfwidth must be 1 or 2".to_string(),
+        ));
+    }
+
+    let w = pix.width();
+    let h = pix.height();
+
+    // Use block convolution for fast blurring
+    // blockconv_gray(pix, None, wc, hc) where kernel size = 2*halfwidth+1
+    let blurred = blockconv_gray(pix, None, halfwidth, halfwidth)?;
+
+    // Compute: result = original + amount * (original - blurred)
+    let out_pix = Pix::new(w, h, PixelDepth::Bit8)?;
+    let mut out_mut = out_pix.try_into_mut().unwrap();
+
+    for y in 0..h {
+        for x in 0..w {
+            let orig = pix.get_pixel_unchecked(x, y) as f32;
+            let blur = blurred.get_pixel_unchecked(x, y) as f32;
+
+            let diff = orig - blur;
+            let result = orig + amount * diff;
+            let result = result.round().clamp(0.0, 255.0) as u32;
+
+            out_mut.set_pixel_unchecked(x, y, result);
+        }
+    }
+
+    Ok(out_mut.into())
+}
+
 /// Apply emboss effect
 ///
 /// Output values are centered around 128 (flat regions produce ~128,
@@ -300,7 +398,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_unsharp_masking_gray_fast_basic() {
         let pix = create_test_image();
 
@@ -313,7 +410,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_unsharp_masking_gray_fast_halfwidth2() {
         let pix = create_test_image();
 
@@ -325,7 +421,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_unsharp_masking_gray_fast_no_op() {
         let pix = create_test_image();
 
@@ -338,7 +433,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_unsharp_masking_gray_fast_rejects_non_8bpp() {
         let pix = Pix::new(10, 10, PixelDepth::Bit32).unwrap();
 
@@ -348,7 +442,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_unsharp_masking_fast_8bpp() {
         let pix = create_test_image();
 
@@ -361,7 +454,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_unsharp_masking_fast_32bpp_rgb() {
         // Create a 32bpp RGB test image
         let pix = Pix::new(10, 10, PixelDepth::Bit32).unwrap();

--- a/crates/leptonica-filter/src/lib.rs
+++ b/crates/leptonica-filter/src/lib.rs
@@ -32,7 +32,10 @@ pub use adaptmap::{
 pub use bilateral::{bilateral_exact, bilateral_gray_exact, make_range_kernel};
 pub use block_conv::{blockconv, blockconv_accum, blockconv_gray, blockconv_gray_unnormalized};
 pub use convolve::{box_blur, convolve, convolve_color, convolve_gray, gaussian_blur};
-pub use edge::{EdgeOrientation, emboss, laplacian_edge, sharpen, sobel_edge, unsharp_mask};
+pub use edge::{
+    EdgeOrientation, emboss, laplacian_edge, sharpen, sobel_edge, unsharp_mask,
+    unsharp_masking_fast, unsharp_masking_gray_fast,
+};
 pub use enhance::{
     TrcLut, color_shift_rgb, contrast_trc, contrast_trc_masked, contrast_trc_pix, darken_gray,
     equalize_trc, equalize_trc_pix, gamma_trc, gamma_trc_masked, gamma_trc_pix,


### PR DESCRIPTION
## Summary
- Add `unsharp_masking_fast()` for fast unsharp masking using block convolution (8/32 bpp)
- Add `unsharp_masking_gray_fast()` for grayscale fast unsharp masking (8bpp only)
- Support halfwidth=1 (3x3) and halfwidth=2 (5x5) kernels only for speed
- RGB version processes each channel independently with alpha preservation

## Changes
- `crates/leptonica-filter/src/edge.rs`: Implement unsharp masking fast functions
- `crates/leptonica-filter/src/lib.rs`: Export new functions

## Implementation Details
- Uses `blockconv_gray()` for faster blurring vs Gaussian convolution
- Dispatches to grayscale version for 32bpp RGB images
- Preserves alpha channel for RGBA images
- Returns clone if amount <= 0.0 (no sharpening)

## Test plan
- [x] All 6 unit tests pass (8bpp basic, halfwidth=2, no-op, non-8bpp error, 8bpp dispatch, 32bpp RGB)
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)