### PR TITLE
Configure nextest slow-timeout for long-running tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.default]
+slow-timeout = { period = "10s", terminate-after = 6 }
+
+[profile.default.junit]
+path = "tests/regout/nextest-junit.xml"


### PR DESCRIPTION
## 概要
テスト実行時間の監視を改善するため、nextest の slow-timeout を設定します。

## 変更点
- `.config/nextest.toml` を新規作成
- slow-timeout を 10 秒に設定（最大 6 回の警告後にテスト終了）
- JUnit 出力の出力先を設定

## 効果
- 長時間実行テストの検出を自動化
- パフォーマンス回帰を早期に発見
- CI での遅いテストの追跡が容易に

## テスト
✅ bilateral テストで slow-timeout 警告が正常に表示されることを確認