### PR TITLE
chore: configure nextest slow-timeout for long-running tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.default]
+slow-timeout = { period = "10s", terminate-after = 6 }
+
+[profile.default.junit]
+path = "tests/regout/nextest-junit.xml"


### PR DESCRIPTION
## Summary

- `.config/nextest.toml` に `slow-timeout = "10s"` を設定
- graymorph 回帰テスト等の長時間テストが slow warning を出さなくなる
- 根本対策 (vHGW algorithm) 完了までの一時的緩和策

## Test plan

- [x] `cargo nextest run --workspace` で設定が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)