### PR TITLE
feat(color): HSV range masks, 2D histograms, and YUV image conversion

### DIFF
--- a/crates/leptonica-color/src/colorspace.rs
+++ b/crates/leptonica-color/src/colorspace.rs
@@ -782,7 +782,7 @@ pub fn make_histo_hs(pix: &Pix, factor: i32) -> ColorResult<Pix> {
             let hsv = color::rgb_to_hsv(r, g, b);
             // rgb_to_hsv guarantees: h∈[0,239], s∈[0,255]
             let count = histo_mut.get_pixel_unchecked(hsv.s as u32, hsv.h as u32);
-            histo_mut.set_pixel_unchecked(hsv.s as u32, hsv.h as u32, count + 1);
+            histo_mut.set_pixel_unchecked(hsv.s as u32, hsv.h as u32, count.saturating_add(1));
         }
     }
 
@@ -820,7 +820,7 @@ pub fn make_histo_hv(pix: &Pix, factor: i32) -> ColorResult<Pix> {
             let hsv = color::rgb_to_hsv(r, g, b);
             // rgb_to_hsv guarantees: h∈[0,239], v∈[0,255]
             let count = histo_mut.get_pixel_unchecked(hsv.v as u32, hsv.h as u32);
-            histo_mut.set_pixel_unchecked(hsv.v as u32, hsv.h as u32, count + 1);
+            histo_mut.set_pixel_unchecked(hsv.v as u32, hsv.h as u32, count.saturating_add(1));
         }
     }
 
@@ -858,7 +858,7 @@ pub fn make_histo_sv(pix: &Pix, factor: i32) -> ColorResult<Pix> {
             let hsv = color::rgb_to_hsv(r, g, b);
             // rgb_to_hsv guarantees: s∈[0,255], v∈[0,255]
             let count = histo_mut.get_pixel_unchecked(hsv.v as u32, hsv.s as u32);
-            histo_mut.set_pixel_unchecked(hsv.v as u32, hsv.s as u32, count + 1);
+            histo_mut.set_pixel_unchecked(hsv.v as u32, hsv.s as u32, count.saturating_add(1));
         }
     }
 

--- a/crates/leptonica-color/src/lib.rs
+++ b/crates/leptonica-color/src/lib.rs
@@ -63,7 +63,6 @@ pub use colorspace::{
     pix_convert_to_gray,
     pix_convert_yuv_to_rgb,
     pix_extract_channel,
-    // Pixel-level conversions
     rgb_to_gray,
     rgb_to_hsv,
     rgb_to_lab,

--- a/crates/leptonica-color/tests/colorspace_hsv_reg.rs
+++ b/crates/leptonica-color/tests/colorspace_hsv_reg.rs
@@ -51,7 +51,6 @@ fn make_tricolor(w: u32, h: u32) -> Pix {
 // ============================================================================
 
 #[test]
-
 fn test_range_mask_hs_include_red() {
     // Pure red: H=0 in Leptonica HSV, S=255
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
@@ -67,7 +66,6 @@ fn test_range_mask_hs_include_red() {
 }
 
 #[test]
-
 fn test_range_mask_hs_exclude_red() {
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
     let mask = make_range_mask_hs(&pix, 0, 20, 200, 100, RegionFlag::Exclude).unwrap();
@@ -79,7 +77,6 @@ fn test_range_mask_hs_exclude_red() {
 }
 
 #[test]
-
 fn test_range_mask_hs_no_match() {
     // Pure red: H=0
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
@@ -93,7 +90,6 @@ fn test_range_mask_hs_no_match() {
 }
 
 #[test]
-
 fn test_range_mask_hs_gray_excluded() {
     // Gray: S=0, so saturation range [100..255] shouldn't match
     let pix = make_uniform_rgb(128, 128, 128, 20, 20);
@@ -106,7 +102,6 @@ fn test_range_mask_hs_gray_excluded() {
 }
 
 #[test]
-
 fn test_range_mask_hs_invalid_depth() {
     let pix = Pix::new(10, 10, PixelDepth::Bit8).unwrap();
     assert!(make_range_mask_hs(&pix, 0, 20, 128, 128, RegionFlag::Include).is_err());
@@ -117,7 +112,6 @@ fn test_range_mask_hs_invalid_depth() {
 // ============================================================================
 
 #[test]
-
 fn test_range_mask_hv_include_red() {
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
     // Red: H=0, V=255
@@ -130,7 +124,6 @@ fn test_range_mask_hv_include_red() {
 }
 
 #[test]
-
 fn test_range_mask_hv_exclude() {
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
     let mask = make_range_mask_hv(&pix, 0, 20, 200, 100, RegionFlag::Exclude).unwrap();
@@ -146,7 +139,6 @@ fn test_range_mask_hv_exclude() {
 // ============================================================================
 
 #[test]
-
 fn test_range_mask_sv_include() {
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
     // Red: S=255, V=255
@@ -159,7 +151,6 @@ fn test_range_mask_sv_include() {
 }
 
 #[test]
-
 fn test_range_mask_sv_gray_low_saturation() {
     let pix = make_uniform_rgb(128, 128, 128, 20, 20);
     // Gray: S=0, V=128. Select high saturation [200..255] → no match
@@ -176,7 +167,6 @@ fn test_range_mask_sv_gray_low_saturation() {
 // ============================================================================
 
 #[test]
-
 fn test_histo_hs_uniform() {
     // All pixels are red: H=0, S=255
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
@@ -190,7 +180,6 @@ fn test_histo_hs_uniform() {
 }
 
 #[test]
-
 fn test_histo_hs_tricolor() {
     let pix = make_tricolor(30, 10);
     let histo = make_histo_hs(&pix, 1).unwrap();
@@ -204,7 +193,6 @@ fn test_histo_hs_tricolor() {
 }
 
 #[test]
-
 fn test_histo_hs_invalid_depth() {
     let pix = Pix::new(10, 10, PixelDepth::Bit8).unwrap();
     assert!(make_histo_hs(&pix, 1).is_err());
@@ -215,7 +203,6 @@ fn test_histo_hs_invalid_depth() {
 // ============================================================================
 
 #[test]
-
 fn test_histo_hv_uniform() {
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
     let histo = make_histo_hv(&pix, 1).unwrap();
@@ -231,7 +218,6 @@ fn test_histo_hv_uniform() {
 // ============================================================================
 
 #[test]
-
 fn test_histo_sv_uniform() {
     let pix = make_uniform_rgb(255, 0, 0, 20, 20);
     let histo = make_histo_sv(&pix, 1).unwrap();
@@ -247,7 +233,6 @@ fn test_histo_sv_uniform() {
 // ============================================================================
 
 #[test]
-
 fn test_yuv_roundtrip() {
     let pix = make_tricolor(30, 10);
     let yuv = pix_convert_rgb_to_yuv(&pix).unwrap();
@@ -270,7 +255,6 @@ fn test_yuv_roundtrip() {
 }
 
 #[test]
-
 fn test_yuv_known_values() {
     // White (255,255,255) → Y≈235, U≈128, V≈128 in video range
     let pix = make_uniform_rgb(255, 255, 255, 10, 10);
@@ -287,7 +271,6 @@ fn test_yuv_known_values() {
 }
 
 #[test]
-
 fn test_yuv_black_known_values() {
     // Black (0,0,0) → Y≈16, U≈128, V≈128
     let pix = make_uniform_rgb(0, 0, 0, 10, 10);
@@ -302,7 +285,6 @@ fn test_yuv_black_known_values() {
 }
 
 #[test]
-
 fn test_yuv_invalid_depth() {
     let pix = Pix::new(10, 10, PixelDepth::Bit8).unwrap();
     assert!(pix_convert_rgb_to_yuv(&pix).is_err());


### PR DESCRIPTION
## 概要

Phase 7.2: HSV色空間の範囲マスク生成、2Dヒストグラム計算、画像レベルYUV変換を実装。
C Leptonica `colorspace.c` の8関数に対応。

## 変更点

### HSV範囲マスク（RGB入力 → 1bpp マスク出力）
- `make_range_mask_hs`: 色相-彩度範囲マスク（色相はLeptonica [0..239] でwrap-around対応）
- `make_range_mask_hv`: 色相-明度範囲マスク
- `make_range_mask_sv`: 彩度-明度範囲マスク（wrap-aroundなし）
- `RegionFlag` enum: Include/Exclude モード

### 2D HSVヒストグラム（RGB入力 → 32bppカウント画像）
- `make_histo_hs`: 256×240 色相-彩度ヒストグラム
- `make_histo_hv`: 256×240 色相-明度ヒストグラム
- `make_histo_sv`: 256×256 彩度-明度ヒストグラム

### 画像レベルYUV変換（Leptonica video-range BT.601）
- `pix_convert_rgb_to_yuv`: Y[16..235], U[16..240], V[16..240]
- `pix_convert_yuv_to_rgb`: 逆変換（クランプ付き）

### 内部ヘルパー
- `make_hue_lut`: wrap-around対応の色相LUT生成
- `make_linear_lut`: 線形範囲LUT生成
- `convert_rgb_to_yuv_leptonica` / `convert_yuv_to_rgb_leptonica`: C版と同じ係数のpixel-level変換

## テスト

18テスト追加（`colorspace_hsv_reg.rs`）:
- 範囲マスク: include/exclude/no-match/gray/invalid-depth
- ヒストグラム: uniform/tricolor/invalid-depth
- YUV: roundtrip/known-values(white/black)/invalid-depth

```
cargo test -p leptonica-color --test colorspace_hsv_reg  # 18 passed
cargo test --workspace                                    # all passed
cargo clippy --workspace -- -D warnings                   # clean
```