### PR TITLE
feat(core): add clip, edge detection, and threshold extension functions

### DIFF
--- a/crates/leptonica-core/tests/pix_clip_advanced_ext_reg.rs
+++ b/crates/leptonica-core/tests/pix_clip_advanced_ext_reg.rs
@@ -67,6 +67,24 @@ fn test_scan_for_edge_from_top() {
     assert!((loc as i32 - 25).abs() <= 2);
 }
 
+#[test]
+fn test_scan_for_edge_from_bottom() {
+    let pix = Pix::new(50, 100, PixelDepth::Bit8).unwrap();
+    let mut pm = pix.to_mut();
+    for y in 0..75u32 {
+        for x in 0..50 {
+            pm.set_pixel_unchecked(x, y, 200);
+        }
+    }
+    let pix: Pix = pm.into();
+
+    let region = Box::new(0, 0, 50, 100).unwrap();
+    let loc = pix
+        .scan_for_edge(&region, 50, 150, 5, 1, ScanDirection::FromBot)
+        .unwrap();
+    assert!((loc as i32 - 74).abs() <= 2);
+}
+
 // ============================================================================
 // Pix::clip_box_to_edges
 // ============================================================================


### PR DESCRIPTION
## 概要

Phase 6 の残り関数として、クリッピング・エッジ検出・マスク生成・閾値分析の5関数を追加。

## 変更点

- `scan_for_edge`: 8bpp画像の列/行ピクセル合計値でエッジスキャン（C版 `pixScanForEdge` の8bpp適応）
- `clip_box_to_edges`: 4方向からのエッジスキャンによる反復的ボックス縮小
- `clip_masked`: 1bppマスクでの領域抽出、マスク外をoutvalで塗りつぶし
- `make_symmetric_mask`: `make_frame_mask`に委譲する対称マスク生成
- `threshold_for_fg_bg`: 閾値による前景/背景の平均ピクセル値計算

## TDD

- RED: `#[ignore = "not yet implemented"]`付き9テスト + スタブ関数
- GREEN: 全5関数を実装し、9テスト全通過

## テスト

- [x] `cargo test --workspace` 全通過
- [x] `cargo clippy -p leptonica-core -- -D warnings` 警告なし
- [x] `cargo fmt --all -- --check` フォーマット準拠