### PR TITLE
Fix review comments on box selection functions (Phase 14.3)

### DIFF
--- a/crates/leptonica-core/src/box_/select.rs
+++ b/crates/leptonica-core/src/box_/select.rs
@@ -315,6 +315,16 @@ mod tests {
         assert_eq!(ind, vec![true, true, false, true]);
     }
 
+    #[test]
+    fn test_make_wh_ratio_indicator_zero_height() {
+        let mut boxa = Boxa::new();
+        boxa.push(Box::new(0, 0, 100, 0).unwrap());
+        boxa.push(Box::new(0, 0, 100, 50).unwrap());
+        let ind = boxa.make_wh_ratio_indicator(1.0, SizeRelation::GreaterThan);
+        // Zero-height box returns false, 100/50=2.0 > 1.0
+        assert_eq!(ind, vec![false, true]);
+    }
+
     // -- Boxa::select_with_indicator --
 
     #[test]
@@ -413,5 +423,11 @@ mod tests {
         assert_eq!(min_h, 5);
         assert_eq!(max_w, 30);
         assert_eq!(max_h, 20);
+    }
+
+    #[test]
+    fn test_boxaa_size_range_empty() {
+        let baa = Boxaa::new();
+        assert!(baa.size_range().is_none());
     }
 }


### PR DESCRIPTION
## Summary
Address Copilot review comments from PR #97:
- Use `compare_relation_f64` helper in `make_wh_ratio_indicator` for consistency
- Align `Boxaa::size_range` return order with `Boxa::size_range` → `(min_w, min_h, max_w, max_h)`
- Document zip truncation behavior in `select_with_indicator`
- Add edge case tests: zero-height box in ratio indicator, empty Boxaa in size_range

## Test plan
- [x] 19 unit tests (16 original + 2 new edge case + 1 existing)
- [x] cargo clippy clean
- [x] cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)