### PR TITLE
docs(plans): Phase 4 IMPLEMENTED ステータス更新

### DIFF
--- a/docs/plans/102_io-full-porting.md
+++ b/docs/plans/102_io-full-porting.md
@@ -208,6 +208,8 @@ pub struct ImageHeader {
 
 ## Phase 4: PNM拡張 - ASCII書き込み + PAM（1 PR）
 
+**Status: IMPLEMENTED** (PR #122)
+
 **C参照**: `reference/leptonica/src/pnmio.c` L400-700
 
 ### 実装内容


### PR DESCRIPTION
## 概要
計画書 102_io-full-porting.md の Phase 4 を IMPLEMENTED (PR #122) に更新。

## 変更点
- Phase 4: PNM拡張 に `**Status: IMPLEMENTED** (PR #122)` を追加