### PR TITLE
docs(plans): Phase 5 IMPLEMENTED ステータス更新

### DIFF
--- a/docs/plans/102_io-full-porting.md
+++ b/docs/plans/102_io-full-porting.md
@@ -248,6 +248,8 @@ ENDHDR
 
 ## Phase 5: TIFF拡張（1 PR）
 
+**Status: IMPLEMENTED** (PR #124)
+
 **C参照**: `reference/leptonica/src/tiffio.c`
 
 ### 実装内容


### PR DESCRIPTION
## 概要
Phase 5 (TIFF拡張) のステータスをIMPLEMENTEDに更新

## 変更点
- 102_io-full-porting.md の Phase 5 セクションに IMPLEMENTED (PR #124) を追記