### PR TITLE
feat(io): PDF DCT(JPEG)圧縮 + write_pdf_from_files

### DIFF
--- a/crates/leptonica-io/src/pdf.rs
+++ b/crates/leptonica-io/src/pdf.rs
@@ -469,6 +469,13 @@ fn encode_jpeg_for_pdf(
         PdfColorSpace::DeviceRgb => jpeg_encoder::ColorType::Rgb,
     };
 
+    if width > u16::MAX as u32 || height > u16::MAX as u32 {
+        return Err(IoError::EncodeError(format!(
+            "image dimensions {}x{} exceed JPEG maximum of 65535",
+            width, height
+        )));
+    }
+
     let mut jpeg_buf = Vec::new();
     let encoder = jpeg_encoder::Encoder::new(&mut jpeg_buf, quality);
     encoder


### PR DESCRIPTION
## 概要
Phase 6: PDF出力にJPEG圧縮オプションを追加し、ファイル群からのPDF生成機能を実装。

## 変更点
- `PdfCompression::Jpeg`: DCTDecode filterでJPEG圧縮データをPDFに埋め込む
- 1bpp/2bpp/4bpp画像はJPEG指定でもFlateにフォールバック
- `write_pdf_from_files`: ファイルパス群から画像を読み込みマルチページPDF生成
- `encode_jpeg_for_pdf` ヘルパー関数（`jpeg` feature有効時のみ）
- テスト5件追加

## テスト
- [x] `cargo test --workspace` 全パス
- [x] `cargo clippy --workspace --all-features -- -D warnings` パス
- [x] `cargo fmt --all -- --check` パス