### PR TITLE
docs(plans): mark IO full porting plan as COMPLETED

### DIFF
--- a/docs/plans/102_io-full-porting.md
+++ b/docs/plans/102_io-full-porting.md
@@ -1,6 +1,6 @@
 # leptonica-io 全未実装関数の移植計画
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 
 ## Context
 
@@ -303,6 +303,8 @@ ENDHDR
 ---
 
 ## Phase 7: PS拡張（1 PR）
+
+**Status: IMPLEMENTED** (PR #128)
 
 **C参照**: `reference/leptonica/src/psio1.c`, `psio2.c`
 


### PR DESCRIPTION
## 概要
計画書102のPhase 7 (PS拡張) をIMPLEMENTEDに、全体ステータスをIMPLEMENTEDに更新。

## 変更点
- Phase 7: PS拡張を `IMPLEMENTED` (PR #128) に更新
- 全体ステータスを `IN_PROGRESS` → `IMPLEMENTED` に変更
- 全7フェーズ完了: PR #118, #119, #120, #122, #124, #126, #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)