### PR TITLE
docs: update comparison docs for IO full porting completion (v3)

### DIFF
--- a/docs/analysis/feature-comparison-c-vs-rust.md
+++ b/docs/analysis/feature-comparison-c-vs-rust.md
@@ -1,14 +1,14 @@
 # C版 vs Rust版 機能比較
 
-調査日: 2026-02-05
+調査日: 2026-02-21（IO全移植計画完了を反映）
 
 ## 概要
 
 | 項目 | C版 (reference/leptonica) | Rust版 (leptonica-rs) |
 | ---- | ------------------------- | --------------------- |
 | ソースファイル数 | **182個** (.c) | **56個** (.rs) |
-| コード行数 | **約240,000行** | **約20,200行** |
-| 実装率（行数ベース） | 100% | **約8.4%** |
+| コード行数 | **約240,000行** | **約69,100行** |
+| 実装率（行数ベース） | 100% | **約28.8%** |
 
 ## 機能カテゴリ別比較
 
@@ -29,17 +29,19 @@
 
 | フォーマット | C版 | Rust版 | 備考 |
 | ------------ | --- | ------ | ---- |
-| BMP | ✅ bmpio.c | ✅ bmp.rs | 完全実装 |
-| PNG | ✅ pngio.c | ✅ png.rs | feature gate |
-| JPEG | ✅ jpegio.c | ✅ jpeg.rs | feature gate |
-| PNM (PBM/PGM/PPM) | ✅ pnmio.c | ✅ pnm.rs | feature gate |
-| TIFF | ✅ tiffio.c | ✅ tiff.rs | feature gate、マルチページ対応 |
-| GIF | ✅ gifio.c | ✅ gif.rs | feature gate |
-| WebP | ✅ webpio.c, webpanimio.c | ✅ webp.rs | feature gate |
-| JP2K (JPEG2000) | ✅ jp2kio.c | ✅ jp2k.rs | 読み込み対応 |
-| PDF | ✅ pdfio1-2.c, pdfapp.c | ✅ pdf.rs | 書き込み対応 |
-| PostScript | ✅ psio1-2.c | ✅ ps/ | EPS/PS出力 |
+| BMP | ✅ bmpio.c | ✅ bmp.rs | デフォルト有効 |
+| PNG | ✅ pngio.c | ✅ png.rs | feature gate (`png-format`、デフォルト有効)、ヘッダー読み取り対応 |
+| JPEG | ✅ jpegio.c | ✅ jpeg.rs | feature gate (`jpeg`、デフォルト有効)、読み書き+ヘッダー対応 |
+| PNM (PBM/PGM/PPM/PAM) | ✅ pnmio.c | ✅ pnm.rs | デフォルト有効、ASCII/Binary/PAM全対応 |
+| TIFF | ✅ tiffio.c | ✅ tiff.rs | feature gate (`tiff-format`)、マルチページ、圧縮検出、追記対応 |
+| GIF | ✅ gifio.c | ✅ gif.rs | feature gate (`gif-format`) |
+| WebP | ✅ webpio.c, webpanimio.c | ✅ webp.rs | feature gate (`webp-format`)、ヘッダー読み取り対応 |
+| JP2K (JPEG2000) | ✅ jp2kio.c | ✅ jp2k.rs | feature gate (`jp2k-format`)、読み込み+ヘッダー対応 |
+| SPIX | ✅ spixio.c | ✅ spix.rs | Leptonica独自シリアライズ形式 |
+| PDF | ✅ pdfio1-2.c, pdfapp.c | ✅ pdf.rs | feature gate (`pdf-format`)、Flate/DCT圧縮、マルチページ対応 |
+| PostScript | ✅ psio1-2.c | ✅ ps/ | feature gate (`ps-format`)、Level 1/2/3、マルチページ対応 |
 | フォーマット検出 | ✅ readfile.c | ✅ format.rs | 完全実装 |
+| ヘッダー読み取り | ✅ readfile.c | ✅ header.rs | 全フォーマット対応 |
 
 ### 3. 幾何変換
 
@@ -153,7 +155,7 @@
 | クレート | 行数 | 完成度 | 主要機能 |
 | -------- | ---- | ------ | -------- |
 | leptonica-core | 2,519 | ★★★★★ | Pix, Box, Pta, Colormap |
-| leptonica-io | 2,795 | ★★★★★ | BMP/PNG/JPEG/PNM/TIFF読み書き |
+| leptonica-io | ~7,930 | ★★★★★ | 全フォーマット読み書き、ヘッダー、SPIX、PDF/PS拡張 |
 | leptonica-transform | 1,509 | ★★★★★ | 回転（直交）、スケーリング |
 | leptonica-morph | 827 | ★★★★★ | 二値形態学操作 |
 | leptonica-filter | 917 | ★★★★★ | 畳み込み、エッジ検出 |
@@ -184,7 +186,7 @@
 2. ~~**文字認識** - OCR関連~~ ✅ 完了（テンプレートマッチング、DID）
 3. ~~**JBIG2分類** - 圧縮用クラスタリング~~ ✅ 完了
 4. **バーコード** - 特殊用途
-5. **PDF/PS出力** - 特殊用途
+5. ~~**PDF/PS出力** - 特殊用途~~ ✅ 完了（Flate/DCT圧縮、マルチページ対応）
 
 ## C版機能カテゴリ（182ファイル）
 

--- a/docs/analysis/test-comparison-c-vs-rust.md
+++ b/docs/analysis/test-comparison-c-vs-rust.md
@@ -1,14 +1,14 @@
 # C版 vs Rust版 テストケース比較
 
-調査日: 2026-02-05（更新）
+調査日: 2026-02-21（IO全移植計画完了を反映）
 
 ## 概要
 
 | 項目             | C版 (reference/leptonica) | Rust版 (leptonica-rs) |
 | ---------------- | ------------------------- | --------------------- |
-| テスト総数       | **305個** (.c)            | **33ファイル**        |
-| 回帰テスト       | **160個** (*_reg.c)       | なし                  |
-| 個別テスト関数   | 多数                      | **217個**             |
+| テスト総数       | **305個** (.c)            | **42+ファイル**       |
+| 回帰テスト       | **160個** (*_reg.c)       | **9個** (IO回帰テスト)|
+| 個別テスト関数   | 多数                      | **2,592個**           |
 | テストランナー   | alltests_reg.c            | `cargo test`          |
 
 ## C版テストの特徴
@@ -66,9 +66,10 @@ writetext, xformbox
 
 ### 構造（Rust版）
 
-- 各クレートの`src/*.rs`内に`#[cfg(test)]`モジュール
-- 単体テストのみ、統合テストなし
-- テストデータなし（in-memory生成のみ）
+- 各クレートの`src/*.rs`内に`#[cfg(test)]`モジュール（単体テスト）
+- `crates/leptonica-io/tests/`に統合テスト（9ファイル、C版`*_reg.c`に対応）
+- テストデータ: `tests/data/images/`（実画像使用）
+- テスト出力: `tests/regout/`（`.gitignore`対象、REGTEST_MODE=generateで生成）
 
 ### テスト分布
 
@@ -90,6 +91,21 @@ writetext, xformbox
 | leptonica-io        | format.rs          | 7        |
 | leptonica-io        | png.rs             | 2        |
 | leptonica-io        | pnm.rs             | 2        |
+| leptonica-io        | jpeg.rs            | 5+       |
+| leptonica-io        | tiff.rs            | 6+       |
+| leptonica-io        | spix.rs            | 5+       |
+| leptonica-io        | header.rs          | 10+      |
+| leptonica-io        | ps/mod.rs          | 19       |
+| leptonica-io        | pdf.rs             | 10+      |
+| leptonica-io (統合) | jpegio_reg.rs      | 2        |
+| leptonica-io (統合) | spixio_reg.rs      | 2        |
+| leptonica-io (統合) | pnmio_reg.rs       | 7        |
+| leptonica-io (統合) | mtiff_reg.rs       | 10       |
+| leptonica-io (統合) | iomisc_reg.rs      | 13       |
+| leptonica-io (統合) | ioformats_reg.rs   | 1        |
+| leptonica-io (統合) | pngio_reg.rs       | 1        |
+| leptonica-io (統合) | gifio_reg.rs       | 2        |
+| leptonica-io (統合) | webpio_reg.rs      | 3        |
 | leptonica-morph     | binary.rs          | 7        |
 | leptonica-morph     | sel.rs             | 6        |
 | leptonica-recog     | baseline.rs        | 7        |
@@ -107,20 +123,21 @@ writetext, xformbox
 | leptonica-region    | watershed.rs       | 6        |
 | leptonica-transform | rotate.rs          | 15       |
 | leptonica-transform | scale.rs           | 8        |
-| **合計**            | **33ファイル**     | **217個**|
+| **合計**            | **42+ファイル**    | **2,592個**|
 
 ### クレート別集計
 
 | クレート            | テスト数 | カバー範囲                            |
 | ------------------- | -------- | ------------------------------------- |
-| leptonica-color     | 33       | 色空間変換、分析、量子化、二値化      |
-| leptonica-core      | 32       | Pix、Box、Colormap、Pta基本操作       |
-| leptonica-filter    | 15       | 畳み込み、エッジ検出、カーネル        |
-| leptonica-io        | 13       | BMP/PNG/PNM読み書き、フォーマット判定 |
-| leptonica-morph     | 13       | 二値モルフォロジー、構造化要素        |
-| leptonica-recog     | 60       | ページ分割、傾き検出、文字認識、JBIG2 |
-| leptonica-region    | 28       | 連結成分、ラベリング、シードフィル    |
-| leptonica-transform | 23       | 回転、スケーリング                    |
+| leptonica-core      | 1,372    | Pix、Box、Colormap、Pta、Numa、Pixa等 |
+| leptonica-filter    | 250      | 畳み込み、エッジ検出、バイラテラル、ランク |
+| leptonica-transform | 183      | 回転、スケーリング、アフィン、射影    |
+| leptonica-morph     | 182      | 二値/グレースケール/カラー形態学、DWA |
+| leptonica-color     | 164      | 色空間変換、分析、量子化、二値化      |
+| leptonica-recog     | 156      | ページ分割、傾き検出、文字認識、JBIG2 |
+| leptonica-io        | 150      | 全フォーマット読み書き、ヘッダー、回帰テスト |
+| leptonica-region    | 131      | 連結成分、ラベリング、シードフィル    |
+| leptonica-test      | 4        | テストインフラ                        |
 
 ### テストがないクレート
 
@@ -130,31 +147,32 @@ writetext, xformbox
 
 | 観点             | C版                    | Rust版                        |
 | ---------------- | ---------------------- | ----------------------------- |
-| **回帰テスト**   | ゴールデンファイル比較 | なし                          |
-| **視覚テスト**   | 画像出力・目視確認     | なし                          |
-| **I/Oテスト**    | 全フォーマット網羅     | BMP/PNG/PNMのみ               |
-| **統合テスト**   | alltests_reg.c         | なし                          |
-| **テストデータ** | 豊富（画像、PDF等）    | in-memory生成のみ             |
-| **カバレッジ**   | 160分野                | 約15分野（8クレート）         |
+| **回帰テスト**   | ゴールデンファイル比較 | ✅ RegParams + goldenファイル  |
+| **視覚テスト**   | 画像出力・目視確認     | REGTEST_MODE=displayで対応    |
+| **I/Oテスト**    | 全フォーマット網羅     | ✅ 全フォーマット対応          |
+| **統合テスト**   | alltests_reg.c         | 9ファイル（IO回帰テスト）     |
+| **テストデータ** | 豊富（画像、PDF等）    | tests/data/images/に実画像    |
+| **カバレッジ**   | 160分野                | 9クレート、2,592テスト関数    |
 
 ## 推奨アクション
 
 ### 優先度高
 
-1. **統合テスト追加**: `tests/`ディレクトリに回帰テスト
-2. **ゴールデンファイル**: C版の出力を参照データとして利用
-3. **テストデータ**: `reference/leptonica/prog/`の画像を活用
+1. ~~**統合テスト追加**: `tests/`ディレクトリに回帰テスト~~ ✅ IO回帰テスト完了
+2. ~~**ゴールデンファイル**: C版の出力を参照データとして利用~~ ✅ RegParams実装済み
+3. ~~**テストデータ**: `reference/leptonica/prog/`の画像を活用~~ ✅ tests/data/images/使用中
+4. **非IO回帰テスト**: morph/transform/filter/color等の回帰テスト追加
 
 ### 優先度中
 
-1. **JPEG/TIFF I/O**: テスト追加が必要（現在BMP/PNG/PNMのみ）
-2. **モルフォロジー**: グレースケールモルフォロジーのテスト追加
-3. **幾何変換**: affine, bilinear, projective変換のテスト追加
+1. ~~**JPEG/TIFF I/O**: テスト追加が必要~~ ✅ jpegio_reg, mtiff_reg実装済み
+2. **モルフォロジー**: グレースケールモルフォロジーの回帰テスト追加
+3. **幾何変換**: affine, bilinear, projective変換の回帰テスト追加
 
 ### 優先度低
 
 1. **ベンチマーク**: C版との性能比較
-2. **視覚テスト**: 画像出力による確認機構
+2. ~~**視覚テスト**: 画像出力による確認機構~~ ✅ REGTEST_MODE=display実装済み
 
 ## 参考
 

--- a/docs/rebuild/comparison/io.md
+++ b/docs/rebuild/comparison/io.md
@@ -1,14 +1,14 @@
 # leptonica-io: C版 vs Rust版 関数レベル比較
 
-調査日: 2026-02-15
+調査日: 2026-02-21（IO全移植計画 Phase 1-7 完了を反映）
 
 ## サマリー
 
 | 項目 | 数 |
 |------|-----|
-| ✅ 同等 | 32 |
-| 🔄 異なる | 15 |
-| ❌ 未実装 | 99 |
+| ✅ 同等 | 68 |
+| 🔄 異なる | 17 |
+| ❌ 未実装 | 61 |
 | 合計 | 146 |
 
 ## 詳細
@@ -25,12 +25,12 @@
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
 | pixReadStreamPng | ✅ 同等 | `png::read_png` | Uses png crate |
-| readHeaderPng | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| freadHeaderPng | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| readHeaderMemPng | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| fgetPngResolution | ❌ 未実装 | - | 解像度取得のみは未サポート |
+| readHeaderPng | ✅ 同等 | `png::read_header_png` | IHDR + pHYsチャンク解析 |
+| freadHeaderPng | ✅ 同等 | `png::read_header_png` | Unified with stream |
+| readHeaderMemPng | ✅ 同等 | `png::read_header_png` | Unified with stream |
+| fgetPngResolution | ✅ 同等 | `png::read_header_png` | ImageHeader.x/y_resolution |
 | isPngInterlaced | ❌ 未実装 | - | Interlace判定は未サポート |
-| fgetPngColormapInfo | ❌ 未実装 | - | Colormap情報取得は未サポート |
+| fgetPngColormapInfo | ❌ 未実装 | - | Colormap詳細情報取得は未サポート |
 | pixWritePng | ✅ 同等 | `png::write_png` | Top level wrapper |
 | pixWriteStreamPng | ✅ 同等 | `png::write_png` | Uses png crate |
 | pixSetZlibCompression | ❌ 未実装 | - | 圧縮レベル設定は未サポート |
@@ -43,31 +43,31 @@
 |-------|------|----------|------|
 | pixReadJpeg | ✅ 同等 | `jpeg::read_jpeg` | Top level wrapper |
 | pixReadStreamJpeg | ✅ 同等 | `jpeg::read_jpeg` | Uses jpeg-decoder crate |
-| readHeaderJpeg | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| freadHeaderJpeg | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| fgetJpegResolution | ❌ 未実装 | - | 解像度取得のみは未サポート |
+| readHeaderJpeg | ✅ 同等 | `jpeg::read_header_jpeg` | jpeg-decoderでinfo取得 |
+| freadHeaderJpeg | ✅ 同等 | `jpeg::read_header_jpeg` | Unified with stream |
+| fgetJpegResolution | ✅ 同等 | `jpeg::read_header_jpeg` | ImageHeader.x/y_resolution |
 | fgetJpegComment | ❌ 未実装 | - | コメント取得は未サポート |
 | pixWriteJpeg | 🔄 異なる | `jpeg::write_jpeg` | jpeg-encoder使用、C版はlibjpeg |
 | pixWriteStreamJpeg | 🔄 異なる | `jpeg::write_jpeg` | jpeg-encoder使用 |
 | pixReadMemJpeg | ✅ 同等 | `jpeg::read_jpeg` | Unified with stream |
-| readHeaderMemJpeg | ❌ 未実装 | - | Memory版header読み取り未サポート |
-| readResolutionMemJpeg | ❌ 未実装 | - | Memory版解像度取得未サポート |
+| readHeaderMemJpeg | ✅ 同等 | `jpeg::read_header_jpeg` | Unified with stream |
+| readResolutionMemJpeg | ✅ 同等 | `jpeg::read_header_jpeg` | ImageHeader.x/y_resolution |
 | pixWriteMemJpeg | 🔄 異なる | `jpeg::write_jpeg_mem` | jpeg-encoder使用 |
 | pixSetChromaSampling | ❌ 未実装 | - | Chroma sampling設定未サポート |
 
-### pnmio.c (PNM/PBM/PGM/PPM I/O)
+### pnmio.c (PNM/PBM/PGM/PPM/PAM I/O)
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| pixReadStreamPnm | ✅ 同等 | `pnm::read_pnm` | PBM/PGM/PPM対応 |
-| readHeaderPnm | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| freadHeaderPnm | ❌ 未実装 | - | Header読み取りのみは未サポート |
+| pixReadStreamPnm | ✅ 同等 | `pnm::read_pnm` | PBM/PGM/PPM/PAM対応 |
+| readHeaderPnm | ✅ 同等 | `pnm::read_header_pnm` | PNMヘッダー解析 |
+| freadHeaderPnm | ✅ 同等 | `pnm::read_header_pnm` | Unified with stream |
 | pixWriteStreamPnm | ✅ 同等 | `pnm::write_pnm` | Binary format出力 |
-| pixWriteStreamAsciiPnm | ❌ 未実装 | - | ASCII format出力は未サポート |
-| pixWriteStreamPam | ❌ 未実装 | - | PAM format (P7) は未サポート |
+| pixWriteStreamAsciiPnm | ✅ 同等 | `pnm::write_pnm_ascii` | P1/P2/P3 ASCII形式 |
+| pixWriteStreamPam | ✅ 同等 | `pnm::write_pam` | P7 PAM形式 |
 | pixReadMemPnm | ✅ 同等 | `pnm::read_pnm` | Unified with stream |
-| readHeaderMemPnm | ❌ 未実装 | - | Memory版header読み取り未サポート |
+| readHeaderMemPnm | ✅ 同等 | `pnm::read_header_pnm` | Unified with stream |
 | pixWriteMemPnm | ✅ 同等 | `pnm::write_pnm` | Unified with stream |
-| pixWriteMemPam | ❌ 未実装 | - | PAM format memory出力未サポート |
+| pixWriteMemPam | ✅ 同等 | `pnm::write_pam` | Unified with stream |
 
 ### tiffio.c (TIFF I/O)
 | C関数 | 状態 | Rust対応 | 備考 |
@@ -77,7 +77,7 @@
 | pixWriteTiff | ✅ 同等 | `tiff::write_tiff` | Top level wrapper |
 | pixWriteTiffCustom | ❌ 未実装 | - | カスタムタグ対応未実装 |
 | pixWriteStreamTiff | ✅ 同等 | `tiff::write_tiff` | Uses tiff crate |
-| pixWriteStreamTiffWA | ❌ 未実装 | - | Write-append mode未サポート |
+| pixWriteStreamTiffWA | 🔄 異なる | `tiff::write_tiff_append` | read-all-rewrite方式 |
 | pixReadFromMultipageTiff | ✅ 同等 | `tiff::read_tiff_page` | 指定ページ読み取り |
 | pixaReadMultipageTiff | ✅ 同等 | `tiff::read_tiff_multipage` | 全ページ読み取り |
 | pixaWriteMultipageTiff | ✅ 同等 | `tiff::write_tiff_multipage` | 複数ページ書き込み |
@@ -86,10 +86,10 @@
 | fprintTiffInfo | ❌ 未実装 | - | TIFF情報表示は未サポート |
 | tiffGetCount | ✅ 同等 | `tiff::tiff_page_count` | ページ数取得 |
 | getTiffResolution | ✅ 同等 | `tiff::tiff_resolution` | 解像度取得 |
-| readHeaderTiff | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| freadHeaderTiff | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| readHeaderMemTiff | ❌ 未実装 | - | Memory版header読み取り未サポート |
-| findTiffCompression | ❌ 未実装 | - | 圧縮形式検出は未サポート |
+| readHeaderTiff | ✅ 同等 | `tiff::read_header_tiff` | TIFFディレクトリ情報 |
+| freadHeaderTiff | ✅ 同等 | `tiff::read_header_tiff` | Unified with stream |
+| readHeaderMemTiff | ✅ 同等 | `tiff::read_header_tiff` | Unified with stream |
+| findTiffCompression | ✅ 同等 | `tiff::tiff_compression` | 圧縮形式検出 |
 | extractG4DataFromFile | ❌ 未実装 | - | G4データ抽出は未サポート |
 | pixReadMemTiff | ✅ 同等 | `tiff::read_tiff` | Unified with stream |
 | pixReadMemFromMultipageTiff | ✅ 同等 | `tiff::read_tiff_page` | Memory版ページ読み取り |
@@ -111,8 +111,8 @@
 |-------|------|----------|------|
 | pixReadStreamWebP | ✅ 同等 | `webp::read_webp` | Uses webp crate |
 | pixReadMemWebP | ✅ 同等 | `webp::read_webp` | Unified with stream |
-| readHeaderWebP | ❌ 未実装 | - | Header読み取りのみは未サポート |
-| readHeaderMemWebP | ❌ 未実装 | - | Memory版header読み取り未サポート |
+| readHeaderWebP | ✅ 同等 | `webp::read_header_webp` | VP8/VP8L/VP8Xチャンク解析 |
+| readHeaderMemWebP | ✅ 同等 | `webp::read_header_webp` | Unified with stream |
 | pixWriteWebP | ✅ 同等 | `webp::write_webp` | Top level wrapper |
 | pixWriteStreamWebP | ✅ 同等 | `webp::write_webp` | Uses webp crate |
 | pixWriteMemWebP | ✅ 同等 | `webp::write_webp` | Unified with stream |
@@ -137,7 +137,7 @@
 ### pdfio1.c (PDF I/O - High Level)
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| convertFilesToPdf | ❌ 未実装 | - | ファイル群→PDF変換未実装 |
+| convertFilesToPdf | 🔄 異なる | `pdf::write_pdf_from_files` | パス群→PDF、異なるAPI |
 | saConvertFilesToPdf | ❌ 未実装 | - | SARRAY版ファイル群→PDF未実装 |
 | saConvertFilesToPdfData | ❌ 未実装 | - | SARRAY版→PDFメモリ未実装 |
 | selectDefaultPdfEncoding | ❌ 未実装 | - | デフォルトエンコード選択未実装 |
@@ -201,7 +201,7 @@
 | pixWriteSegmentedPageToPS | ❌ 未実装 | - | Pixセグメント化ページ→PS未実装 |
 | pixWriteMixedToPS | ❌ 未実装 | - | 混合コンテンツ→PS未実装 |
 | convertToPSEmbed | ❌ 未実装 | - | 埋め込みPS変換未実装 |
-| pixaWriteCompressedToPS | ❌ 未実装 | - | Pixa圧縮→PS未実装 |
+| pixaWriteCompressedToPS | 🔄 異なる | `ps::write_ps_multi` | マルチページPS、異なるAPI |
 | pixWriteCompressedToPS | ❌ 未実装 | - | Pix圧縮→PS未実装 |
 
 ### psio2.c (PostScript I/O - Low Level)
@@ -231,31 +231,31 @@
 | pixReadWithHint | ❌ 未実装 | - | ヒント付き読み取り未実装 |
 | pixReadIndexed | ❌ 未実装 | - | インデックス指定読み取り未実装 |
 | pixReadStream | ✅ 同等 | `read_image_format` | Stream読み取り |
-| pixReadHeader | ❌ 未実装 | - | Header読み取り未実装 |
+| pixReadHeader | ✅ 同等 | `read_image_header` | ユニバーサルヘッダー読み取り |
 | findFileFormat | 🔄 異なる | `detect_format` | ファイルフォーマット検出 |
 | findFileFormatStream | 🔄 異なる | `detect_format_from_bytes` | Stream版フォーマット検出 |
 | findFileFormatBuffer | 🔄 異なる | `detect_format_from_bytes` | Buffer版フォーマット検出 |
 | fileFormatIsTiff | ❌ 未実装 | - | TIFF判定未実装 |
 | pixReadMem | ✅ 同等 | `read_image_mem` | Memory読み取り |
-| pixReadHeaderMem | ❌ 未実装 | - | Memory版header読み取り未実装 |
+| pixReadHeaderMem | ✅ 同等 | `read_image_header_mem` | Memory版header読み取り |
 | writeImageFileInfo | ❌ 未実装 | - | 画像ファイル情報書き込み未実装 |
 | ioFormatTest | ❌ 未実装 | - | I/Oフォーマットテスト未実装 |
 
 ### writefile.c (汎用書き込み)
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| l_jpegSetQuality | ❌ 未実装 | - | JPEG品質設定未実装 |
+| l_jpegSetQuality | ❌ 未実装 | - | グローバル品質設定（RustはJpegOptionsで対応） |
 | setLeptDebugOK | ❌ 未実装 | - | デバッグ設定未実装 |
 | pixaWriteFiles | ❌ 未実装 | - | Pixa複数ファイル書き込み未実装 |
 | pixWriteDebug | ❌ 未実装 | - | デバッグ書き込み未実装 |
 | pixWrite | ✅ 同等 | `write_image` | ファイルパスへ書き込み |
-| pixWriteAutoFormat | ❌ 未実装 | - | 自動フォーマット書き込み未実装 |
+| pixWriteAutoFormat | ✅ 同等 | `write_image_auto` | 拡張子推定による書き込み |
 | pixWriteStream | ✅ 同等 | `write_image_format` | Stream書き込み |
-| pixWriteImpliedFormat | ❌ 未実装 | - | 拡張子から判定書き込み未実装 |
-| pixChooseOutputFormat | ❌ 未実装 | - | 出力フォーマット選択未実装 |
-| getImpliedFileFormat | ❌ 未実装 | - | 拡張子からフォーマット取得未実装 |
-| getFormatFromExtension | ❌ 未実装 | - | 拡張子判定未実装 |
-| pixGetAutoFormat | ❌ 未実装 | - | 自動フォーマット取得未実装 |
+| pixWriteImpliedFormat | ✅ 同等 | `write_image_auto` | 拡張子から判定書き込み |
+| pixChooseOutputFormat | ✅ 同等 | `choose_output_format` | 深度/colormapに基づく自動選択 |
+| getImpliedFileFormat | ✅ 同等 | `ImageFormat::from_path` | パスからフォーマット取得 |
+| getFormatFromExtension | ✅ 同等 | `ImageFormat::from_extension` | 拡張子判定 |
+| pixGetAutoFormat | ✅ 同等 | `choose_output_format` | 自動フォーマット取得 |
 | getFormatExtension | ❌ 未実装 | - | フォーマット→拡張子変換未実装 |
 | pixWriteMem | ✅ 同等 | `write_image_mem` | Memory書き込み |
 | l_fileDisplay | ❌ 未実装 | - | ファイル表示未実装 |
@@ -269,15 +269,15 @@
 ### spixio.c (SPIX serialization)
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| pixReadStreamSpix | ❌ 未実装 | - | SPIX読み取り未実装 |
-| readHeaderSpix | ❌ 未実装 | - | SPIXヘッダー読み取り未実装 |
-| freadHeaderSpix | ❌ 未実装 | - | SPIXヘッダーファイル読み取り未実装 |
-| sreadHeaderSpix | ❌ 未実装 | - | SPIXヘッダー文字列読み取り未実装 |
-| pixWriteStreamSpix | ❌ 未実装 | - | SPIX書き込み未実装 |
-| pixReadMemSpix | ❌ 未実装 | - | SPIXメモリ読み取り未実装 |
-| pixWriteMemSpix | ❌ 未実装 | - | SPIXメモリ書き込み未実装 |
-| pixSerializeToMemory | ❌ 未実装 | - | Pixシリアライズ未実装 |
-| pixDeserializeFromMemory | ❌ 未実装 | - | Pixデシリアライズ未実装 |
+| pixReadStreamSpix | ✅ 同等 | `spix::read_spix` | SPIX読み取り |
+| readHeaderSpix | ✅ 同等 | `spix::read_header_spix` | 先頭24バイト解析 |
+| freadHeaderSpix | ✅ 同等 | `spix::read_header_spix` | Unified with stream |
+| sreadHeaderSpix | ✅ 同等 | `spix::read_header_spix` | Unified with stream |
+| pixWriteStreamSpix | ✅ 同等 | `spix::write_spix` | SPIX書き込み |
+| pixReadMemSpix | ✅ 同等 | `spix::read_spix` | Unified with stream |
+| pixWriteMemSpix | ✅ 同等 | `spix::write_spix` | Unified with stream |
+| pixSerializeToMemory | ✅ 同等 | `spix::write_spix` | Pixシリアライズ |
+| pixDeserializeFromMemory | ✅ 同等 | `spix::read_spix` | Pixデシリアライズ |
 
 ## 設計上の相違点
 
@@ -325,62 +325,35 @@
 - jpeg-decoder / jpeg-encoder
 - png crate
 - tiff crate
-- gif crate (image-rsベース)
-- webp crate
-- jpeg2000 crate
+- gif crate
+- image-webp crate
+- hayro-jpeg2000 crate
+- pdf-writer (PDF出力)
+- miniz_oxide (Flate圧縮)
 
 ### 5. 未実装の主要機能カテゴリ
 
-1. **Header-only読み取り**: 画像本体を読まずにメタデータのみ取得する関数群
-2. **PostScript高レベル機能**: 複数ファイル→PS、セグメント化PS等
-3. **PDF高レベル機能**: 複数ファイル→PDF、PDF連結、セグメント化PDF等
-4. **SPIX serialization**: Leptonica独自のシリアライゼーション形式
-5. **アニメーションWebP**: WebPアニメーション対応
-6. **Display機能**: pixDisplay等のGUI表示機能
-7. **品質・圧縮設定**: グローバル変数による品質/圧縮レベル設定
-
-## 推奨される次のステップ
-
-### 優先度: 高
-
-1. **Header読み取り機能**: メタデータのみ取得する軽量API
-   - 各フォーマット用の`read_header_*`関数
-   - `ImageHeader { width, height, depth, format, ... }`型の導入
-
-2. **JPEG品質設定**: `JpegOptions`構造体でのオプション指定
-   - C版の`pixSetChromaSampling`相当
-
-3. **PNG圧縮レベル設定**: `PngOptions`構造体でのオプション指定
-   - C版の`pixSetZlibCompression`相当
-
-### 優先度: 中
-
-4. **PDF高レベル機能**:
-   - 複数画像→単一PDF (`pixaConvertToPdf`相当)
-   - PDF連結 (`concatenatePdf`相当)
-
-5. **PostScript基本機能**:
-   - 複数画像→PSファイル
-   - 圧縮PS出力
-
-6. **TIFF拡張機能**:
-   - カスタムタグ対応 (`pixWriteTiffCustom`相当)
-
-### 優先度: 低
-
-7. **アニメーションWebP**: 静止画中心なら不要
-8. **SPIX serialization**: Leptonica特有、他形式で代替可能
-9. **Display機能**: I/Oライブラリの範囲外
+1. **PDF高レベル変換機能**: 複数ファイル→PDF（セグメント化、連結等）
+2. **PostScript高レベル機能**: セグメント化PS、生フォーマット埋め込み
+3. **アニメーションWebP**: WebPアニメーション対応
+4. **Display機能**: pixDisplay等のGUI表示機能
+5. **品質・圧縮設定**: グローバル変数による品質/圧縮レベル設定（RustではOptions構造体で対応済み）
 
 ## まとめ
 
-Rust版leptonica-ioは、基本的な画像I/O機能（BMP, PNG, JPEG, TIFF, GIF, WebP, JP2K）の読み書きは実装済みで、C版の約22%の関数が同等または類似の機能を提供している。
+Rust版leptonica-ioは、IO全移植計画（Phase 1-7）の完了により、C版146関数のうち85関数（58.2%）が同等または類似の機能を提供している（32.2% → 58.2%に改善）。
 
-未実装の68%は主に以下のカテゴリ:
-- Header-only読み取り（メタデータのみ）
-- PDF/PS高レベル変換機能
-- 品質・圧縮レベルのグローバル設定
-- GUI表示機能
-- Leptonica独自フォーマット（SPIX）
+主な追加機能:
+- JPEG書き込み（Phase 1）
+- SPIX形式の読み書き（Phase 2）
+- 全フォーマットのヘッダー読み取り + フォーマットユーティリティ（Phase 3）
+- PNM ASCII書き込み + PAM形式（Phase 4）
+- TIFF圧縮検出 + 追記モード（Phase 5）
+- PDF DCT（JPEG）圧縮（Phase 6）
+- PS マルチページ + Level 2 DCT圧縮（Phase 7）
 
-Rust版は外部crateを活用したモダンなI/O抽象化（Read/Write trait）を採用し、C版より型安全でメモリ安全なAPIを提供している。
+残りの未実装42%は主に:
+- PDF/PS高レベル変換・セグメント化機能
+- GUI表示機能（pixDisplay等）
+- アニメーションWebP
+- JP2K書き込み（pure Rustエンコーダなし）

--- a/docs/rebuild/feature-comparison.md
+++ b/docs/rebuild/feature-comparison.md
@@ -1,6 +1,6 @@
 # C版 vs Rust版 機能比較
 
-調査日: 2026-02-21（Phase 13-17.3 実装を反映）
+調査日: 2026-02-21（Phase 13-17.3 実装 + IO全移植計画 Phase 1-7 完了を反映）
 
 ## 概要
 
@@ -18,7 +18,7 @@ C版の全public関数を抽出し、Rust版での実装状況を3段階で分�
 | クレート | ✅ 同等 | 🔄 異なる | ❌ 未実装 | 合計 | カバレッジ |
 |---------|--------|----------|---------|------|-----------|
 | [leptonica-core](comparison/core.md) | 495 | 24 | 363 | 882 | 58.8% |
-| [leptonica-io](comparison/io.md) | 32 | 15 | 99 | 146 | 32.2% |
+| [leptonica-io](comparison/io.md) | 68 | 17 | 61 | 146 | 58.2% |
 | [leptonica-transform](comparison/transform.md) | 39 | 12 | 101 | 152 | 33.6% |
 | [leptonica-morph](comparison/morph.md) | 34 | 12 | 74 | 120 | 38.3% |
 | [leptonica-filter](comparison/filter.md) | 50 | 0 | 49 | 99 | 50.5% |
@@ -26,7 +26,7 @@ C版の全public関数を抽出し、Rust版での実装状況を3段階で分�
 | [leptonica-region](comparison/region.md) | 27 | 8 | 60 | 95 | 36.8% |
 | [leptonica-recog](comparison/recog.md) | 42 | 9 | 93 | 144 | 35.4% |
 | [その他](comparison/misc.md) | 13 | 0 | 103 | 116 | 11.2% |
-| **合計** | **783** | **96** | **1,001** | **1,880** | **46.8%** |
+| **合計** | **819** | **98** | **963** | **1,880** | **48.8%** |
 
 ### 分類基準
 
@@ -70,17 +70,19 @@ C版の全public関数を抽出し、Rust版での実装状況を3段階で分�
 
 | フォーマット | C版 | Rust版 | 備考 |
 | ------------ | --- | ------ | ---- |
-| BMP | ✅ bmpio.c | ✅ bmp.rs | 完全実装 |
-| PNG | ✅ pngio.c | ✅ png.rs | feature gate |
-| JPEG | ✅ jpegio.c | ✅ jpeg.rs | feature gate |
-| PNM (PBM/PGM/PPM) | ✅ pnmio.c | ✅ pnm.rs | feature gate |
-| TIFF | ✅ tiffio.c | ✅ tiff.rs | feature gate、マルチページ対応 |
-| GIF | ✅ gifio.c | ✅ gif.rs | feature gate |
-| WebP | ✅ webpio.c, webpanimio.c | ✅ webp.rs | feature gate |
-| JP2K (JPEG2000) | ✅ jp2kio.c | ✅ jp2k.rs | 読み込み対応 |
-| PDF | ✅ pdfio1-2.c, pdfapp.c | ✅ pdf.rs | 書き込み対応 |
-| PostScript | ✅ psio1-2.c | ✅ ps/ | EPS/PS出力 |
+| BMP | ✅ bmpio.c | ✅ bmp.rs | デフォルト有効 |
+| PNG | ✅ pngio.c | ✅ png.rs | feature gate (`png-format`、デフォルト有効) |
+| JPEG | ✅ jpegio.c | ✅ jpeg.rs | feature gate (`jpeg`、デフォルト有効)、読み書き対応 |
+| PNM (PBM/PGM/PPM/PAM) | ✅ pnmio.c | ✅ pnm.rs | デフォルト有効、ASCII/Binary/PAM対応 |
+| TIFF | ✅ tiffio.c | ✅ tiff.rs | feature gate (`tiff-format`)、マルチページ対応 |
+| GIF | ✅ gifio.c | ✅ gif.rs | feature gate (`gif-format`) |
+| WebP | ✅ webpio.c, webpanimio.c | ✅ webp.rs | feature gate (`webp-format`) |
+| JP2K (JPEG2000) | ✅ jp2kio.c | ✅ jp2k.rs | feature gate (`jp2k-format`)、読み込み対応 |
+| SPIX | ✅ spixio.c | ✅ spix.rs | Leptonica独自シリアライズ形式 |
+| PDF | ✅ pdfio1-2.c, pdfapp.c | ✅ pdf.rs | feature gate (`pdf-format`)、Flate/DCT圧縮 |
+| PostScript | ✅ psio1-2.c | ✅ ps/ | feature gate (`ps-format`)、Level 1/2/3、マルチページ |
 | フォーマット検出 | ✅ readfile.c | ✅ format.rs | 完全実装 |
+| ヘッダー読み取り | ✅ readfile.c | ✅ header.rs | 全フォーマット対応 |
 
 ### 3. 幾何変換
 
@@ -178,7 +180,7 @@ C版の全public関数を抽出し、Rust版での実装状況を3段階で分�
 | クレート | 行数 | 関数カバレッジ | 主要機能 |
 | -------- | ---- | ------------- | -------- |
 | leptonica-core | ~46,300 | 519/882 (58.8%) | Pix, Box, Pta, Colormap, 演算, 比較, ブレンド, 描画, 統計, ヒストグラム |
-| leptonica-io | 2,795 | 47/146 (32.2%) | BMP/PNG/JPEG/PNM/TIFF/GIF/WebP/JP2K/PDF/PS |
+| leptonica-io | ~7,930 | 85/146 (58.2%) | BMP/PNG/JPEG/PNM/TIFF/GIF/WebP/JP2K/PDF/PS/SPIX + ヘッダー読み取り |
 | leptonica-transform | 1,509 | 51/152 (33.6%) | 回転, スケーリング, アフィン, 射影, シアー |
 | leptonica-morph | 827 | 46/120 (38.3%) | 二値/グレースケール/カラー形態学, DWA, 細線化 |
 | leptonica-filter | 917 | 50/99 (50.5%) | 畳み込み, エッジ検出, バイラテラル, ランク |
@@ -186,7 +188,7 @@ C版の全public関数を抽出し、Rust版での実装状況を3段階で分�
 | leptonica-region | 2,385 | 35/95 (36.8%) | 連結成分, シードフィル, 分水嶺, 四分木, 迷路 |
 | leptonica-recog | 6,580 | 51/144 (35.4%) | スキュー補正, デワーピング, 文字認識, バーコード |
 | その他 | - | 13/116 (11.2%) | ワーパー, エンコーディング |
-| **合計** | **~64,000** | **879/1,880 (46.8%)** | |
+| **合計** | **~69,100** | **917/1,880 (48.8%)** | |
 
 ## 未実装の主要領域
 

--- a/docs/rebuild/test-comparison.md
+++ b/docs/rebuild/test-comparison.md
@@ -1,14 +1,14 @@
 # C版 vs Rust版 テストケース比較
 
-調査日: 2026-02-05（更新）
+調査日: 2026-02-21（IO全移植計画完了を反映）
 
 ## 概要
 
 | 項目             | C版 (reference/leptonica) | Rust版 (leptonica-rs) |
 | ---------------- | ------------------------- | --------------------- |
-| テスト総数       | **305個** (.c)            | **33ファイル**        |
-| 回帰テスト       | **160個** (*_reg.c)       | なし                  |
-| 個別テスト関数   | 多数                      | **217個**             |
+| テスト総数       | **305個** (.c)            | **42+ファイル**       |
+| 回帰テスト       | **160個** (*_reg.c)       | **9個** (IO回帰テスト)|
+| 個別テスト関数   | 多数                      | **2,592個**           |
 | テストランナー   | alltests_reg.c            | `cargo test`          |
 
 ## C版テストの特徴
@@ -66,9 +66,10 @@ writetext, xformbox
 
 ### 構造（Rust版）
 
-- 各クレートの`src/*.rs`内に`#[cfg(test)]`モジュール
-- 単体テストのみ、統合テストなし
-- テストデータなし（in-memory生成のみ）
+- 各クレートの`src/*.rs`内に`#[cfg(test)]`モジュール（単体テスト）
+- `crates/leptonica-io/tests/`に統合テスト（9ファイル、C版`*_reg.c`に対応）
+- テストデータ: `tests/data/images/`（実画像使用）
+- テスト出力: `tests/regout/`（`.gitignore`対象、REGTEST_MODE=generateで生成）
 
 ### テスト分布
 
@@ -90,6 +91,21 @@ writetext, xformbox
 | leptonica-io        | format.rs          | 7        |
 | leptonica-io        | png.rs             | 2        |
 | leptonica-io        | pnm.rs             | 2        |
+| leptonica-io        | jpeg.rs            | 5+       |
+| leptonica-io        | tiff.rs            | 6+       |
+| leptonica-io        | spix.rs            | 5+       |
+| leptonica-io        | header.rs          | 10+      |
+| leptonica-io        | ps/mod.rs          | 19       |
+| leptonica-io        | pdf.rs             | 10+      |
+| leptonica-io (統合) | jpegio_reg.rs      | 2        |
+| leptonica-io (統合) | spixio_reg.rs      | 2        |
+| leptonica-io (統合) | pnmio_reg.rs       | 7        |
+| leptonica-io (統合) | mtiff_reg.rs       | 10       |
+| leptonica-io (統合) | iomisc_reg.rs      | 13       |
+| leptonica-io (統合) | ioformats_reg.rs   | 1        |
+| leptonica-io (統合) | pngio_reg.rs       | 1        |
+| leptonica-io (統合) | gifio_reg.rs       | 2        |
+| leptonica-io (統合) | webpio_reg.rs      | 3        |
 | leptonica-morph     | binary.rs          | 7        |
 | leptonica-morph     | sel.rs             | 6        |
 | leptonica-recog     | baseline.rs        | 7        |
@@ -107,20 +123,21 @@ writetext, xformbox
 | leptonica-region    | watershed.rs       | 6        |
 | leptonica-transform | rotate.rs          | 15       |
 | leptonica-transform | scale.rs           | 8        |
-| **合計**            | **33ファイル**     | **217個**|
+| **合計**            | **42+ファイル**    | **2,592個**|
 
 ### クレート別集計
 
 | クレート            | テスト数 | カバー範囲                            |
 | ------------------- | -------- | ------------------------------------- |
-| leptonica-color     | 33       | 色空間変換、分析、量子化、二値化      |
-| leptonica-core      | 32       | Pix、Box、Colormap、Pta基本操作       |
-| leptonica-filter    | 15       | 畳み込み、エッジ検出、カーネル        |
-| leptonica-io        | 13       | BMP/PNG/PNM読み書き、フォーマット判定 |
-| leptonica-morph     | 13       | 二値モルフォロジー、構造化要素        |
-| leptonica-recog     | 60       | ページ分割、傾き検出、文字認識、JBIG2 |
-| leptonica-region    | 28       | 連結成分、ラベリング、シードフィル    |
-| leptonica-transform | 23       | 回転、スケーリング                    |
+| leptonica-core      | 1,372    | Pix、Box、Colormap、Pta、Numa、Pixa等 |
+| leptonica-filter    | 250      | 畳み込み、エッジ検出、バイラテラル、ランク |
+| leptonica-transform | 183      | 回転、スケーリング、アフィン、射影    |
+| leptonica-morph     | 182      | 二値/グレースケール/カラー形態学、DWA |
+| leptonica-color     | 164      | 色空間変換、分析、量子化、二値化      |
+| leptonica-recog     | 156      | ページ分割、傾き検出、文字認識、JBIG2 |
+| leptonica-io        | 150      | 全フォーマット読み書き、ヘッダー、回帰テスト |
+| leptonica-region    | 131      | 連結成分、ラベリング、シードフィル    |
+| leptonica-test      | 4        | テストインフラ                        |
 
 ### テストがないクレート
 
@@ -130,31 +147,32 @@ writetext, xformbox
 
 | 観点             | C版                    | Rust版                        |
 | ---------------- | ---------------------- | ----------------------------- |
-| **回帰テスト**   | ゴールデンファイル比較 | なし                          |
-| **視覚テスト**   | 画像出力・目視確認     | なし                          |
-| **I/Oテスト**    | 全フォーマット網羅     | BMP/PNG/PNMのみ               |
-| **統合テスト**   | alltests_reg.c         | なし                          |
-| **テストデータ** | 豊富（画像、PDF等）    | in-memory生成のみ             |
-| **カバレッジ**   | 160分野                | 約15分野（8クレート）         |
+| **回帰テスト**   | ゴールデンファイル比較 | ✅ RegParams + goldenファイル  |
+| **視覚テスト**   | 画像出力・目視確認     | REGTEST_MODE=displayで対応    |
+| **I/Oテスト**    | 全フォーマット網羅     | ✅ 全フォーマット対応          |
+| **統合テスト**   | alltests_reg.c         | 9ファイル（IO回帰テスト）     |
+| **テストデータ** | 豊富（画像、PDF等）    | tests/data/images/に実画像    |
+| **カバレッジ**   | 160分野                | 9クレート、2,592テスト関数    |
 
 ## 推奨アクション
 
 ### 優先度高
 
-1. **統合テスト追加**: `tests/`ディレクトリに回帰テスト
-2. **ゴールデンファイル**: C版の出力を参照データとして利用
-3. **テストデータ**: `reference/leptonica/prog/`の画像を活用
+1. ~~**統合テスト追加**: `tests/`ディレクトリに回帰テスト~~ ✅ IO回帰テスト完了
+2. ~~**ゴールデンファイル**: C版の出力を参照データとして利用~~ ✅ RegParams実装済み
+3. ~~**テストデータ**: `reference/leptonica/prog/`の画像を活用~~ ✅ tests/data/images/使用中
+4. **非IO回帰テスト**: morph/transform/filter/color等の回帰テスト追加
 
 ### 優先度中
 
-1. **JPEG/TIFF I/O**: テスト追加が必要（現在BMP/PNG/PNMのみ）
-2. **モルフォロジー**: グレースケールモルフォロジーのテスト追加
-3. **幾何変換**: affine, bilinear, projective変換のテスト追加
+1. ~~**JPEG/TIFF I/O**: テスト追加が必要~~ ✅ jpegio_reg, mtiff_reg実装済み
+2. **モルフォロジー**: グレースケールモルフォロジーの回帰テスト追加
+3. **幾何変換**: affine, bilinear, projective変換の回帰テスト追加
 
 ### 優先度低
 
 1. **ベンチマーク**: C版との性能比較
-2. **視覚テスト**: 画像出力による確認機構
+2. ~~**視覚テスト**: 画像出力による確認機構~~ ✅ REGTEST_MODE=display実装済み
 
 ## 参考
 


### PR DESCRIPTION
## 概要
IO全移植計画 (102) の全7フェーズ完了に伴い、比較ドキュメント5ファイルを更新。
PR #130 (6件) + PR #131 (3件) の全レビュー指摘を反映した最終版。

## 変更点
- `docs/rebuild/comparison/io.md`: 関数レベル比較を全面更新 (32.2%→58.2%)
- `docs/rebuild/feature-comparison.md`: IOカバレッジ更新、全フォーマットにfeature gate名明記
- `docs/rebuild/test-comparison.md`: テスト数 217→2,592、IO回帰テスト追加
- `docs/analysis/`: 上記と同等の更新を反映

## 過去レビュー対応（全9件反映済み）
1. `tests/golden/` 参照を削除（未作成のため）
2. 全フォーマットにfeature gate名を統一的に明記 (`png-format`, `jpeg`, `tiff-format`等)
3. ソースファイル数を56個に統一
4. crate名を正確に修正 (image-webp, hayro-jpeg2000)
5. コード行数・実装率を rebuild/ と一致 (~69,100行, ~28.8%)

## テスト
- ドキュメントのみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)