### PR TITLE
feat(core): Phase 2 Pta/Boxa affine transform functions

### DIFF
--- a/crates/leptonica-core/src/box_/mod.rs
+++ b/crates/leptonica-core/src/box_/mod.rs
@@ -743,11 +743,6 @@ impl Boxa {
             .collect()
     }
 
-    /// Returns a new Boxa with all boxes rotated about center (xc, yc) by angle (radians, clockwise).
-    ///
-    /// Each box is represented by its 4 corners; after rotation the axis-aligned
-    /// bounding box of those corners becomes the new box.
-    ///
     /// Apply a 3x3 affine transformation matrix to all boxes.
     ///
     /// Each box is converted to 4 corner points, transformed by the matrix,

--- a/crates/leptonica-core/src/pta/transform.rs
+++ b/crates/leptonica-core/src/pta/transform.rs
@@ -226,20 +226,12 @@ impl Pta {
 
     /// Rotate all points about center (xc, yc) by angle (radians, clockwise positive).
     ///
-    /// Unlike [`rotate`](Pta::rotate) which rotates in-place around the origin,
-    /// this method returns a new Pta and allows specifying a rotation center.
+    /// This is a convenience wrapper around [`Pta::rotated_about`], which
+    /// provides the canonical implementation corresponding to the C function.
     ///
     /// C equivalent: `ptaRotate()` in `affinecompose.c`
     pub fn rotate_around(&self, xc: f32, yc: f32, angle: f32) -> Pta {
-        let sina = angle.sin();
-        let cosa = angle.cos();
-        self.iter()
-            .map(|(x, y)| {
-                let xp = xc + (x - xc) * cosa - (y - yc) * sina;
-                let yp = yc + (x - xc) * sina + (y - yc) * cosa;
-                (xp, yp)
-            })
-            .collect()
+        self.rotated_about(xc, yc, angle)
     }
 
     /// Apply a 3x3 affine transformation matrix to all points.


### PR DESCRIPTION
## 概要
300_transform-full-porting 計画の Phase 2: PTA/BOXA変換ユーティリティを実装。

## 変更点
- `Pta::rotate_around`: 任意の中心点を指定した回転（C版 `ptaRotate` に対応）
- `Pta::affine_transform`: 3x3アフィン変換行列の適用（C版 `ptaAffineTransform` に対応）
- `Boxa::affine_transform`: 各Boxの4コーナーを変換しAABBを計算（C版 `boxaAffineTransform` に対応）
- 6テスト追加（回転・アフィン・単位行列・スケール+平行移動・空Pta）

## テスト
- [x] `cargo test -p leptonica-core` 全パス
- [x] `cargo test --workspace` 全パス
- [x] `cargo clippy -p leptonica-core -- -D warnings` 警告なし
- [x] `cargo fmt -p leptonica-core -- --check` OK