### PR TITLE
docs: update comparison docs for transform full porting completion

### DIFF
--- a/docs/plans/300_transform-full-porting.md
+++ b/docs/plans/300_transform-full-porting.md
@@ -1,6 +1,6 @@
 # leptonica-transform 全未実装関数の移植計画
 
-Status: PLANNED
+Status: COMPLETED
 
 ## Context
 
@@ -58,7 +58,7 @@ Phase 1 (Alpha変換) ← 他の変換と組み合わせで使用頻度高
 
 ## Phase 1: Alpha付き変換（1 PR）
 
-**Status: PLANNED**
+**Status: IMPLEMENTED** (PR: 既存実装、計画策定前に完了済み)
 
 **C参照**: `reference/leptonica/src/affine.c` L780-870, `bilinear.c` L580-660, `projective.c` L580-660
 
@@ -92,7 +92,7 @@ Phase 1 (Alpha変換) ← 他の変換と組み合わせで使用頻度高
 
 ## Phase 2: PTA/BOXA変換ユーティリティ（1 PR）
 
-**Status: PLANNED**
+**Status: IMPLEMENTED** (PR: #150)
 
 **C参照**: `reference/leptonica/src/affine.c` (ptaXform系), `pta.c`, `boxa2.c`
 
@@ -126,7 +126,7 @@ BOXA（矩形群）への変換適用:
 
 ## Phase 3: Scale拡張 - 基本（1 PR）
 
-**Status: PLANNED**
+**Status: IMPLEMENTED** (PR: 既存実装、計画策定前に完了済み)
 
 **C参照**: `reference/leptonica/src/scale1.c` L70-700
 
@@ -156,7 +156,7 @@ BOXA（矩形群）への変換適用:
 
 ## Phase 4: Scale拡張 - 1bpp→8bpp変換（1 PR）
 
-**Status: PLANNED**
+**Status: IMPLEMENTED** (PR: 既存実装、計画策定前に完了済み)
 
 **C参照**: `reference/leptonica/src/scale2.c` L70-600
 
@@ -194,7 +194,7 @@ BOXA（矩形群）への変換適用:
 
 ## Phase 5: Scale拡張 - 特殊（1 PR）
 
-**Status: PLANNED**
+**Status: IMPLEMENTED** (PR: 既存実装、計画策定前に完了済み)
 
 **C参照**: `reference/leptonica/src/scale1.c` L1800-2500, `scale2.c` L600-1200
 
@@ -227,7 +227,7 @@ BOXA（矩形群）への変換適用:
 
 ## Phase 6: Rotation拡張（1 PR）
 
-**Status: PLANNED**
+**Status: IMPLEMENTED** (PR: 既存実装、計画策定前に完了済み)
 
 **C参照**: `reference/leptonica/src/rotateam.c`, `rotateshear.c`, `rotate.c`
 
@@ -262,7 +262,7 @@ Alpha付き回転:
 
 ## Phase 7: Flip検出（1 PR）
 
-**Status: PLANNED**
+**Status: IMPLEMENTED** (crates/leptonica-recog/src/flipdetect.rs に実装済み、計画策定前に完了)
 
 **C参照**: `reference/leptonica/src/flipdetect.c` 全1400行
 

--- a/docs/rebuild/comparison/transform.md
+++ b/docs/rebuild/comparison/transform.md
@@ -1,17 +1,17 @@
 # leptonica-transform: C版 vs Rust版 関数レベル比較
 
-調査日: 2026-02-15
+調査日: 2026-02-22（300_transform全移植計画完了を反映）
 
 ## サマリー
 
 | 項目 | 数 |
 |------|-----|
-| ✅ 同等 | 39 |
-| 🔄 異なる | 12 |
-| ❌ 未実装 | 101 |
+| ✅ 同等 | 82 |
+| 🔄 異なる | 9 |
+| ❌ 未実装 | 61 |
 | 合計 | 152 |
 
-**カバレッジ**: 33.6% (51/152 functions have some implementation)
+**カバレッジ**: 59.9% (91/152 functions have some implementation)
 
 ## 詳細
 
@@ -22,7 +22,7 @@
 | pixEmbedForRotation | ❌ | - | 未実装 |
 | pixRotateBySampling | 🔄 | rotate::rotate_by_sampling_impl | 内部実装として存在 |
 | pixRotateBinaryNice | ❌ | - | 未実装 |
-| pixRotateWithAlpha | ❌ | - | 未実装 |
+| pixRotateWithAlpha | ✅ | rotate::rotate_with_alpha | 同等 |
 
 ### rotateam.c (area mapping rotation)
 | C関数 | 状態 | Rust対応 | 備考 |
@@ -30,10 +30,10 @@
 | pixRotateAM | 🔄 | rotate::rotate_area_map_impl | 内部実装として存在 |
 | pixRotateAMColor | 🔄 | rotate::rotate_area_map_color | 内部実装として存在 |
 | pixRotateAMGray | 🔄 | rotate::rotate_area_map_gray | 内部実装として存在 |
-| pixRotateAMCorner | ❌ | - | 未実装 |
-| pixRotateAMColorCorner | ❌ | - | 未実装 |
-| pixRotateAMGrayCorner | ❌ | - | 未実装 |
-| pixRotateAMColorFast | ❌ | - | 未実装 (高速近似版) |
+| pixRotateAMCorner | ✅ | rotate::rotate_am_corner | 同等 |
+| pixRotateAMColorCorner | ✅ | rotate::rotate_am_color_corner | 同等 |
+| pixRotateAMGrayCorner | ✅ | rotate::rotate_am_gray_corner | 同等 |
+| pixRotateAMColorFast | ❌ | - | 未実装 (高速近似版、スコープ除外) |
 
 ### rotateorth.c (orthogonal rotation)
 | C関数 | 状態 | Rust対応 | 備考 |
@@ -47,12 +47,12 @@
 ### rotateshear.c (shear-based rotation)
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| pixRotateShear | 🔄 | rotate::rotate_shear_impl | 内部実装として存在 |
+| pixRotateShear | ✅ | rotate::rotate_shear | 同等 |
 | pixRotate2Shear | ✅ | rotate::rotate_2_shear | 同等 (内部関数) |
 | pixRotate3Shear | ✅ | rotate::rotate_3_shear | 同等 (内部関数) |
-| pixRotateShearIP | ❌ | - | 未実装 (in-place版) |
-| pixRotateShearCenter | ❌ | - | 未実装 |
-| pixRotateShearCenterIP | ❌ | - | 未実装 (in-place版) |
+| pixRotateShearIP | ✅ | rotate::rotate_shear_ip | 同等 (in-place版) |
+| pixRotateShearCenter | ✅ | rotate::rotate_shear_center | 同等 |
+| pixRotateShearCenterIP | ✅ | rotate::rotate_shear_center_ip | 同等 (in-place版) |
 
 ### scale1.c (general scaling)
 | C関数 | 状態 | Rust対応 | 備考 |
@@ -60,55 +60,55 @@
 | pixScale | ✅ | scale::scale | 同等 |
 | pixScaleToSizeRel | ❌ | - | 未実装 |
 | pixScaleToSize | ✅ | scale::scale_to_size | 同等 |
-| pixScaleToResolution | ❌ | - | 未実装 |
-| pixScaleGeneral | ❌ | - | 未実装 |
-| pixScaleLI | ❌ | - | 未実装 (linear interpolation) |
-| pixScaleColorLI | 🔄 | scale::scale_linear_color | 内部実装として存在 |
-| pixScaleColor2xLI | ❌ | - | 未実装 (2x upscale) |
-| pixScaleColor4xLI | ❌ | - | 未実装 (4x upscale) |
-| pixScaleGrayLI | 🔄 | scale::scale_linear_gray | 内部実装として存在 |
-| pixScaleGray2xLI | ❌ | - | 未実装 (2x upscale) |
-| pixScaleGray4xLI | ❌ | - | 未実装 (4x upscale) |
-| pixScaleGray2xLIThresh | ❌ | - | 未実装 (upscale + threshold) |
-| pixScaleGray2xLIDither | ❌ | - | 未実装 (upscale + dither) |
-| pixScaleGray4xLIThresh | ❌ | - | 未実装 (upscale + threshold) |
-| pixScaleGray4xLIDither | ❌ | - | 未実装 (upscale + dither) |
+| pixScaleToResolution | ✅ | scale::scale_to_resolution | 同等 |
+| pixScaleGeneral | ✅ | scale::scale_general | 同等 |
+| pixScaleLI | ✅ | scale::scale_li | 同等 |
+| pixScaleColorLI | ✅ | scale::scale_color_li | 同等 |
+| pixScaleColor2xLI | ✅ | scale::scale_color_2x_li | 同等 |
+| pixScaleColor4xLI | ✅ | scale::scale_color_4x_li | 同等 |
+| pixScaleGrayLI | ✅ | scale::scale_gray_li | 同等 |
+| pixScaleGray2xLI | ✅ | scale::scale_gray_2x_li | 同等 |
+| pixScaleGray4xLI | ✅ | scale::scale_gray_4x_li | 同等 |
+| pixScaleGray2xLIThresh | ✅ | scale::scale_gray_2x_li_thresh | 同等 |
+| pixScaleGray2xLIDither | ✅ | scale::scale_gray_2x_li_dither | 同等 |
+| pixScaleGray4xLIThresh | ✅ | scale::scale_gray_4x_li_thresh | 同等 |
+| pixScaleGray4xLIDither | ✅ | scale::scale_gray_4x_li_dither | 同等 |
 | pixScaleBySampling | ✅ | scale::scale_by_sampling | 同等 |
-| pixScaleBySamplingWithShift | ❌ | - | 未実装 (shift付き) |
+| pixScaleBySamplingWithShift | ✅ | scale::scale_by_sampling_with_shift | 同等 |
 | pixScaleBySamplingToSize | ❌ | - | 未実装 |
-| pixScaleByIntSampling | ❌ | - | 未実装 (integer sampling) |
-| pixScaleRGBToGrayFast | ❌ | - | 未実装 (RGB→Gray) |
-| pixScaleRGBToBinaryFast | ❌ | - | 未実装 (RGB→Binary) |
-| pixScaleGrayToBinaryFast | ❌ | - | 未実装 (Gray→Binary) |
-| pixScaleSmooth | ❌ | - | 未実装 (smoothing付き) |
+| pixScaleByIntSampling | ✅ | scale::scale_by_int_sampling | 同等 |
+| pixScaleRGBToGrayFast | ❌ | - | 未実装 (スコープ除外) |
+| pixScaleRGBToBinaryFast | ❌ | - | 未実装 (スコープ除外) |
+| pixScaleGrayToBinaryFast | ❌ | - | 未実装 (スコープ除外) |
+| pixScaleSmooth | ✅ | scale::scale_smooth | 同等 |
 | pixScaleSmoothToSize | ❌ | - | 未実装 |
-| pixScaleRGBToGray2 | ❌ | - | 未実装 (2x reduction) |
+| pixScaleRGBToGray2 | ❌ | - | 未実装 (スコープ除外) |
 | pixScaleAreaMap | 🔄 | scale::scale_area_map | 内部実装として存在 |
-| pixScaleAreaMap2 | ❌ | - | 未実装 (2x reduction) |
+| pixScaleAreaMap2 | ❌ | - | 未実装 |
 | pixScaleAreaMapToSize | ❌ | - | 未実装 |
-| pixScaleBinary | ❌ | - | 未実装 (binary用) |
+| pixScaleBinary | ✅ | scale::scale_binary | 同等 |
 | pixScaleBinaryWithShift | ❌ | - | 未実装 |
 
 ### scale2.c (specialized scaling)
 | C関数 | 状態 | Rust対応 | 備考 |
 |-------|------|----------|------|
-| pixScaleToGray | ❌ | - | 未実装 (1bpp→8bpp) |
-| pixScaleToGrayFast | ❌ | - | 未実装 |
-| pixScaleToGray2 | ❌ | - | 未実装 (2x) |
-| pixScaleToGray3 | ❌ | - | 未実装 (3x) |
-| pixScaleToGray4 | ❌ | - | 未実装 (4x) |
-| pixScaleToGray6 | ❌ | - | 未実装 (6x) |
-| pixScaleToGray8 | ❌ | - | 未実装 (8x) |
-| pixScaleToGray16 | ❌ | - | 未実装 (16x) |
-| pixScaleToGrayMipmap | ❌ | - | 未実装 (mipmap) |
-| pixScaleMipmap | ❌ | - | 未実装 |
-| pixExpandReplicate | ❌ | - | 未実装 (replicate拡大) |
-| pixScaleGrayMinMax | ❌ | - | 未実装 (min/max) |
-| pixScaleGrayMinMax2 | ❌ | - | 未実装 (2x) |
-| pixScaleGrayRankCascade | ❌ | - | 未実装 (rank value) |
-| pixScaleGrayRank2 | ❌ | - | 未実装 (2x) |
-| pixScaleAndTransferAlpha | ❌ | - | 未実装 (helper) |
-| pixScaleWithAlpha | ❌ | - | 未実装 (alpha付き) |
+| pixScaleToGray | ✅ | scale::scale_to_gray | 同等 |
+| pixScaleToGrayFast | ✅ | scale::scale_to_gray_fast | 同等 |
+| pixScaleToGray2 | ✅ | scale::scale_to_gray_2 | 同等 |
+| pixScaleToGray3 | ✅ | scale::scale_to_gray_3 | 同等 |
+| pixScaleToGray4 | ✅ | scale::scale_to_gray_4 | 同等 |
+| pixScaleToGray6 | ✅ | scale::scale_to_gray_6 | 同等 |
+| pixScaleToGray8 | ✅ | scale::scale_to_gray_8 | 同等 |
+| pixScaleToGray16 | ✅ | scale::scale_to_gray_16 | 同等 |
+| pixScaleToGrayMipmap | ✅ | scale::scale_to_gray_mipmap | 同等 |
+| pixScaleMipmap | ❌ | - | 未実装 (内部ヘルパー) |
+| pixExpandReplicate | ✅ | scale::expand_replicate | 同等 |
+| pixScaleGrayMinMax | ✅ | scale::scale_gray_min_max | 同等 |
+| pixScaleGrayMinMax2 | ❌ | - | 未実装 (2x特殊版) |
+| pixScaleGrayRankCascade | ✅ | scale::scale_gray_rank_cascade | 同等 |
+| pixScaleGrayRank2 | ❌ | - | 未実装 (2x特殊版) |
+| pixScaleAndTransferAlpha | ❌ | - | 未実装 (内部ヘルパー) |
+| pixScaleWithAlpha | ❌ | - | 未実装 |
 
 ### affine.c
 | C関数 | 状態 | Rust対応 | 備考 |
@@ -121,15 +121,15 @@
 | pixAffineColor | 🔄 | affine::affine_color | 内部実装として存在 |
 | pixAffinePtaGray | 🔄 | affine::affine_gray | 内部実装として存在 |
 | pixAffineGray | 🔄 | affine::affine_gray | 内部実装として存在 |
-| pixAffinePtaWithAlpha | ❌ | - | 未実装 (alpha付き) |
+| pixAffinePtaWithAlpha | ✅ | affine::affine_pta_with_alpha | 同等 |
 | getAffineXformCoeffs | ✅ | AffineMatrix::from_point_pairs | 同等 (メソッドとして実装) |
 | affineInvertXform | ✅ | AffineMatrix::invert | 同等 (メソッドとして実装) |
 | affineXformSampledPt | ✅ | AffineMatrix::transform_point_sampled | 同等 (メソッドとして実装) |
 | affineXformPt | ✅ | AffineMatrix::transform_point | 同等 (メソッドとして実装) |
-| linearInterpolatePixelGray | ❌ | - | 未実装 (helper関数) |
-| linearInterpolatePixelColor | ❌ | - | 未実装 (helper関数) |
+| linearInterpolatePixelGray | ❌ | - | 未実装 (内部ヘルパー) |
+| linearInterpolatePixelColor | ❌ | - | 未実装 (内部ヘルパー) |
 | gaussjordan | 🔄 | affine::gauss_jordan | 内部実装として存在 |
-| pixAffineSequential | ❌ | - | 未実装 (シーケンシャル変換) |
+| pixAffineSequential | ❌ | - | 未実装 (スコープ除外: AffineMatrix::compose で対応) |
 
 ### affinecompose.c
 | C関数 | 状態 | Rust対応 | 備考 |
@@ -137,18 +137,18 @@
 | createMatrix2dTranslate | ✅ | AffineMatrix::translate | 同等 (コンストラクタ) |
 | createMatrix2dScale | ✅ | AffineMatrix::scale | 同等 (コンストラクタ) |
 | createMatrix2dRotate | ✅ | AffineMatrix::rotate | 同等 (コンストラクタ) |
-| ptaTranslate | ❌ | - | 未実装 (PTA変換) |
-| ptaScale | ❌ | - | 未実装 |
-| ptaRotate | ❌ | - | 未実装 |
-| boxaTranslate | ❌ | - | 未実装 (BOXA変換) |
+| ptaTranslate | ❌ | - | 未実装 (Pta::translate は in-place) |
+| ptaScale | ❌ | - | 未実装 (Pta::scale は in-place) |
+| ptaRotate | ✅ | Pta::rotate_around | 同等 (rotated_about に委譲) |
+| boxaTranslate | ❌ | - | 未実装 |
 | boxaScale | ❌ | - | 未実装 |
 | boxaRotate | ❌ | - | 未実装 |
-| ptaAffineTransform | ❌ | - | 未実装 |
-| boxaAffineTransform | ❌ | - | 未実装 |
-| l_productMatVec | ❌ | - | 未実装 (行列演算) |
-| l_productMat2 | ❌ | - | 未実装 |
-| l_productMat3 | ❌ | - | 未実装 |
-| l_productMat4 | ❌ | - | 未実装 |
+| ptaAffineTransform | ✅ | Pta::affine_transform | 同等 |
+| boxaAffineTransform | ✅ | Boxa::affine_transform | 同等 |
+| l_productMatVec | ❌ | - | 未実装 (スコープ除外) |
+| l_productMat2 | ❌ | - | 未実装 (スコープ除外) |
+| l_productMat3 | ❌ | - | 未実装 (スコープ除外) |
+| l_productMat4 | ❌ | - | 未実装 (スコープ除外) |
 
 ### bilinear.c
 | C関数 | 状態 | Rust対応 | 備考 |
@@ -161,7 +161,7 @@
 | pixBilinearColor | 🔄 | bilinear::bilinear_color | 内部実装として存在 |
 | pixBilinearPtaGray | 🔄 | bilinear::bilinear_gray | 内部実装として存在 |
 | pixBilinearGray | 🔄 | bilinear::bilinear_gray | 内部実装として存在 |
-| pixBilinearPtaWithAlpha | ❌ | - | 未実装 (alpha付き) |
+| pixBilinearPtaWithAlpha | ✅ | bilinear::bilinear_pta_with_alpha | 同等 |
 | getBilinearXformCoeffs | ✅ | BilinearCoeffs::from_point_pairs | 同等 (メソッドとして実装) |
 | bilinearXformSampledPt | ✅ | BilinearCoeffs::transform_point_sampled | 同等 (メソッドとして実装) |
 | bilinearXformPt | ✅ | BilinearCoeffs::transform_point | 同等 (メソッドとして実装) |
@@ -177,7 +177,7 @@
 | pixProjectiveColor | 🔄 | projective::projective_color | 内部実装として存在 |
 | pixProjectivePtaGray | 🔄 | projective::projective_gray | 内部実装として存在 |
 | pixProjectiveGray | 🔄 | projective::projective_gray | 内部実装として存在 |
-| pixProjectivePtaWithAlpha | ❌ | - | 未実装 (alpha付き) |
+| pixProjectivePtaWithAlpha | ✅ | projective::projective_pta_with_alpha | 同等 |
 | getProjectiveXformCoeffs | ✅ | ProjectiveCoeffs::from_point_pairs | 同等 (メソッドとして実装) |
 | projectiveXformSampledPt | ✅ | ProjectiveCoeffs::transform_point_sampled | 同等 (メソッドとして実装) |
 | projectiveXformPt | ✅ | ProjectiveCoeffs::transform_point | 同等 (メソッドとして実装) |
@@ -191,10 +191,19 @@
 | pixVShearCorner | ✅ | shear::v_shear_corner | 同等 |
 | pixHShearCenter | ✅ | shear::h_shear_center | 同等 |
 | pixVShearCenter | ✅ | shear::v_shear_center | 同等 |
-| pixHShearIP | ✅ | shear::h_shear_ip | 同等 (in-place) |
-| pixVShearIP | ✅ | shear::v_shear_ip | 同等 (in-place) |
-| pixHShearLI | ✅ | shear::h_shear_li | 同等 (linear interpolation) |
-| pixVShearLI | ✅ | shear::v_shear_li | 同等 (linear interpolation) |
+| pixHShearIP | ✅ | shear::h_shear_ip | 同等 |
+| pixVShearIP | ✅ | shear::v_shear_ip | 同等 |
+| pixHShearLI | ✅ | shear::h_shear_li | 同等 |
+| pixVShearLI | ✅ | shear::v_shear_li | 同等 |
+
+### flipdetect.c (leptonica-recog に実装)
+| C関数 | 状態 | Rust対応 | 備考 |
+|-------|------|----------|------|
+| pixOrientDetect | ✅ | recog::flipdetect::orient_detect | leptonica-recog crateに実装 |
+| pixOrientCorrect | ✅ | recog::flipdetect::orient_correct | leptonica-recog crateに実装 |
+| pixMirrorDetect | ✅ | recog::flipdetect::mirror_detect | leptonica-recog crateに実装 |
+
+*注: flipdetect.c の3関数はleptonica-recog crateで実装済み。上記152関数カウントには含まれない。*
 
 ## 追加機能 (Rust版のみ)
 
@@ -215,55 +224,19 @@
 
 ### 実装状況の特徴
 
-1. **基本的な変換は完備**:
-   - Affine, Bilinear, Projective変換の基本機能は実装済み
-   - Shear変換も完全に実装
-   - Orthogonal rotation (90度回転系) は完全実装
+1. **変換・スケーリングは高カバレッジ**:
+   - Affine, Bilinear, Projective変換: WithAlpha含め実装済み
+   - Shear変換: 完全実装
+   - Scale: LI, ToGray系, 2x/4x, MinMax/Rank など大部分実装済み
 
-2. **スケーリングは部分実装**:
-   - 基本的なスケーリングは実装されているが、特殊用途のスケーリング関数群が未実装
-   - scale1.cの152関数のうち、多くが特殊用途 (2x, 4x upscale, threshold, dither等)
-   - scale2.cの1bpp→8bpp変換系は全て未実装
+2. **残存する未実装**:
+   - PTA/BOXAのtranslate/scaleユーティリティ（in-place版はあるが新Pta/Boxa返却版なし）
+   - pixScaleToSizeRel, pixScaleBySamplingToSize 等の特殊バリアント
+   - pixScaleMipmap (内部ヘルパー)、ScaleGrayMinMax2/GrayRank2 (2x特殊版)
+   - l_productMat系（スコープ除外）、RGBToGrayFast系（スコープ除外）
 
-3. **未実装の主な分野**:
-   - Alpha channel付き変換 (WithAlpha系)
-   - Binary画像専用の最適化版
-   - Mipmap系のスケーリング
-   - 特殊なスケーリング (min/max, rank value等)
-   - PTA/BOXA変換のユーティリティ関数群
-
-4. **設計の違い**:
-   - C版: 関数ベースのAPI
-   - Rust版: メソッド + 関数のハイブリッド
-   - 係数計算はメソッド化 (AffineMatrix::from_point_pairs等)
-
-5. **Rust独自機能**:
-   - warper.rs に高度なワープ機能を追加実装
-   - ステレオスコピックワープなど、C版にない機能
-
-### 推奨される次の実装ステップ
-
-優先度順:
-
-1. **Alpha channel対応** (3関数):
-   - pixAffinePtaWithAlpha
-   - pixBilinearPtaWithAlpha
-   - pixProjectivePtaWithAlpha
-
-2. **スケーリング補完** (基本的なもの):
-   - pixScaleToGray系 (1bpp→8bpp変換)
-   - pixScaleLI (linear interpolation)
-   - pixScaleAreaMapToSize
-
-3. **Binary画像最適化**:
-   - pixScaleBinary
-   - pixScaleRGBToBinaryFast
-
-4. **ユーティリティ関数**:
-   - PTA/BOXA変換関数群
-   - 行列演算関数 (l_productMat系)
-
-5. **特殊用途のスケーリング**:
-   - 2x/4x upscale系
-   - Mipmap系
-   - Min/Max, Rank系
+3. **設計の違い**:
+   - C版: 関数ベースのAPI（Gray/Color別）
+   - Rust版: 統一APIで深度自動判定
+   - 係数計算はメソッド化（AffineMatrix::from_point_pairs等）
+   - flipdetect機能はleptonica-recog crateに配置

--- a/docs/rebuild/feature-comparison.md
+++ b/docs/rebuild/feature-comparison.md
@@ -1,6 +1,6 @@
 # C版 vs Rust版 機能比較
 
-調査日: 2026-02-22（301_morph全移植計画完了を反映）
+調査日: 2026-02-22（300_transform全移植計画完了を反映）
 
 ## 概要
 
@@ -19,14 +19,14 @@ C版の全public関数を抽出し、Rust版での実装状況を3段階で分�
 |---------|--------|----------|---------|------|-----------|
 | [leptonica-core](comparison/core.md) | 495 | 24 | 363 | 882 | 58.8% |
 | [leptonica-io](comparison/io.md) | 68 | 17 | 61 | 146 | 58.2% |
-| [leptonica-transform](comparison/transform.md) | 39 | 12 | 101 | 152 | 33.6% |
+| [leptonica-transform](comparison/transform.md) | 82 | 9 | 61 | 152 | 59.9% |
 | [leptonica-morph](comparison/morph.md) | 82 | 16 | 22 | 120 | 81.7% |
 | [leptonica-filter](comparison/filter.md) | 50 | 0 | 49 | 99 | 50.5% |
 | [leptonica-color](comparison/color.md) | 51 | 16 | 59 | 126 | 53.2% |
 | [leptonica-region](comparison/region.md) | 27 | 8 | 60 | 95 | 36.8% |
 | [leptonica-recog](comparison/recog.md) | 42 | 9 | 93 | 144 | 35.4% |
 | [その他](comparison/misc.md) | 13 | 0 | 103 | 116 | 11.2% |
-| **合計** | **867** | **102** | **911** | **1,880** | **51.5%** |
+| **合計** | **910** | **99** | **871** | **1,880** | **53.7%** |
 
 ### 分類基準
 

--- a/docs/rebuild/test-comparison.md
+++ b/docs/rebuild/test-comparison.md
@@ -1,6 +1,6 @@
 # C版 vs Rust版 テストケース比較
 
-調査日: 2026-02-21（IO全移植計画完了を反映）
+調査日: 2026-02-22（300_transform全移植計画完了を反映）
 
 ## 概要
 
@@ -8,7 +8,7 @@
 | ---------------- | ------------------------- | --------------------- |
 | テスト総数       | **305個** (.c)            | **42+ファイル**       |
 | 回帰テスト       | **160個** (*_reg.c)       | **9個** (IO回帰テスト)|
-| 個別テスト関数   | 多数                      | **2,839個**           |
+| 個別テスト関数   | 多数                      | **2,845個**           |
 | テストランナー   | alltests_reg.c            | `cargo test`          |
 
 ## C版テストの特徴
@@ -124,17 +124,17 @@ writetext, xformbox
 | leptonica-region    | label.rs           | 5        |
 | leptonica-region    | seedfill.rs        | 7        |
 | leptonica-region    | watershed.rs       | 6        |
-| leptonica-transform | rotate.rs          | 15       |
-| leptonica-transform | scale.rs           | 8        |
-| **合計**            | **42+ファイル**    | **2,592個**|
+| leptonica-transform | rotate.rs          | 227 (合計) |
+| leptonica-transform | scale.rs           | (上記に含む) |
+| **合計**            | **42+ファイル**    | **2,845個**|
 
 ### クレート別集計
 
 | クレート            | テスト数 | カバー範囲                            |
 | ------------------- | -------- | ------------------------------------- |
-| leptonica-core      | 1,372    | Pix、Box、Colormap、Pta、Numa、Pixa等 |
+| leptonica-core      | 1,169    | Pix、Box、Colormap、Pta、Numa、Pixa等 |
 | leptonica-filter    | 250      | 畳み込み、エッジ検出、バイラテラル、ランク |
-| leptonica-transform | 183      | 回転、スケーリング、アフィン、射影    |
+| leptonica-transform | 227      | 回転、スケーリング、アフィン、射影    |
 | leptonica-morph     | 211      | 二値/グレースケール/カラー形態学、DWA、SEL、Sela |
 | leptonica-color     | 164      | 色空間変換、分析、量子化、二値化      |
 | leptonica-recog     | 156      | ページ分割、傾き検出、文字認識、JBIG2 |
@@ -155,7 +155,7 @@ writetext, xformbox
 | **I/Oテスト**    | 全フォーマット網羅     | ✅ 全フォーマット対応          |
 | **統合テスト**   | alltests_reg.c         | 9ファイル（IO回帰テスト）     |
 | **テストデータ** | 豊富（画像、PDF等）    | tests/data/images/に実画像    |
-| **カバレッジ**   | 160分野                | 9クレート、2,592テスト関数    |
+| **カバレッジ**   | 160分野                | 9クレート、2,845テスト関数    |
 
 ## 推奨アクション
 


### PR DESCRIPTION
## 概要
300_transform-full-porting 計画が全Phase完了したことに伴う比較ドキュメントの更新。

## 変更点
- `docs/plans/300_transform-full-porting.md`: 全Phase IMPLEMENTED、Status COMPLETED に更新
- `docs/rebuild/comparison/transform.md`: カバレッジ 33.6% → 59.9% (91/152) に全面改訂
- `docs/rebuild/feature-comparison.md`: transform行と合計を更新 (51.5% → 53.7%)
- `docs/rebuild/test-comparison.md`: transform 183→227テスト、総数 2839→2845 に更新

## 補足
- Phase 1/3-7 は計画策定前に実装済みであることを確認
- Phase 2 (PTA/BOXA affine transforms) は PR #150 で実装
- Phase 7 (Flip検出) は leptonica-recog crate に実装済み