### PR TITLE
Phase 2: Tiled block convolution の実装

### DIFF
--- a/crates/leptonica-filter/src/block_conv.rs
+++ b/crates/leptonica-filter/src/block_conv.rs
@@ -460,9 +460,11 @@ fn blockconv_tiled_gray(pix: &Pix, wc: u32, hc: u32, nx: u32, ny: u32) -> Filter
             let out_w = if jx == nx - 1 { w - out_x } else { wt };
             let out_h = if iy == ny - 1 { h - out_y } else { ht };
 
-            // Input region: extend by wc+1 overlap, clipped to image bounds.
-            // The extra pixel beyond wc ensures blockconv_gray's integral
-            // image has the correct xmin/ymin offsets for interior pixels.
+            // Input region: extend the tile with asymmetric overlap, clipped
+            // to image bounds.  Left/top extend by wc+1 (the extra pixel
+            // beyond wc ensures blockconv_gray's integral-image xmin/ymin
+            // offsets are correct for all interior pixels).  Right/bottom
+            // extend by wc so the convolution window is fully covered.
             let clip_x = out_x.saturating_sub(wc + 1);
             let clip_y = out_y.saturating_sub(hc + 1);
             let clip_right = (out_x + out_w + wc).min(w - 1);
@@ -779,7 +781,7 @@ mod tests {
         assert_eq!(bordered.height(), 26);
 
         let result = blockconv_gray_tile(&bordered, None, 2, 2).unwrap();
-        // Output: (26 - 2*2 - 2) × (26 - 2*2 - 2) = 18×18
+        // Output: (26 - 2*(2 + 2)) × (26 - 2*(2 + 2)) = 18×18
         assert_eq!(result.width(), 18);
         assert_eq!(result.height(), 18);
 


### PR DESCRIPTION
## 概要

filter crateにtiled block convolution関数（`blockconv_gray_tile`, `blockconv_tiled`）を実装。
大規模画像でのメモリ効率改善のため、画像をnx×nyタイルに分割して個別に畳み込みを行う。

C版 `pixBlockconvGrayTile()` / `pixBlockconvTiled()` に対応（`convolve.c`）。

## 変更点

- `blockconv_gray_tile()`: パディング済み8bppタイルに対する積分画像ベースのO(1)ブロック畳み込み
- `blockconv_tiled()`: nx×nyタイル分割、各タイルを`blockconv_gray`で処理し結果をマージ
  - 8bpp: 直接処理
  - 32bpp: R/G/Bチャンネル分離→個別処理→再合成
  - nx≤1 && ny≤1 → `blockconv()`に委譲
  - タイルが小さすぎる場合はnx/nyを自動縮小
- `blockconv_tiled_gray()`: 内部ヘルパー。クリップしたタイルに`blockconv_gray`を適用し、同一の境界補正アルゴリズムで非タイル版とピクセル一致する結果を保証

## テスト

- [x] `test_blockconv_gray_tile_basic`: uniform padded tile処理
- [x] `test_blockconv_gray_tile_noop_zero_kernel`: wc=0/hc=0のno-op
- [x] `test_blockconv_tiled_matches_non_tiled`: 非タイル版との±1ピクセル一致
- [x] `test_blockconv_tiled_single_tile_delegates`: nx=1,ny=1でblockconv委譲
- [x] `test_blockconv_tiled_color`: 32bpp RGB処理
- [x] 全22 block_convテスト通過、clippy/fmt通過