### PR TITLE
refactor: fix clippy warnings across multiple crates

### DIFF
--- a/crates/leptonica-core/src/box_/mod.rs
+++ b/crates/leptonica-core/src/box_/mod.rs
@@ -1094,8 +1094,8 @@ mod tests {
         assert_eq!(result.len(), 1);
         let b = result.get(0).unwrap();
         // After 180° rotation the bounding box should be the same
-        assert!((b.x - 0).abs() <= 1);
-        assert!((b.y - 0).abs() <= 1);
+        assert!(b.x.abs() <= 1);
+        assert!(b.y.abs() <= 1);
         assert!((b.w - 10).abs() <= 1);
         assert!((b.h - 10).abs() <= 1);
     }

--- a/crates/leptonica-io/src/jpeg.rs
+++ b/crates/leptonica-io/src/jpeg.rs
@@ -243,7 +243,7 @@ mod tests {
         let mut pix_mut = pix.try_into_mut().unwrap();
         for y in 0..10u32 {
             for x in 0..10u32 {
-                pix_mut.set_pixel_unchecked(x, y, (x * 25) as u32);
+                pix_mut.set_pixel_unchecked(x, y, x * 25);
             }
         }
         let pix: Pix = pix_mut.into();
@@ -306,7 +306,7 @@ mod tests {
         let mut pix_mut = pix.try_into_mut().unwrap();
         for y in 0..100u32 {
             for x in 0..100u32 {
-                pix_mut.set_pixel_unchecked(x, y, ((x + y) % 256) as u32);
+                pix_mut.set_pixel_unchecked(x, y, (x + y) % 256);
             }
         }
         let pix: Pix = pix_mut.into();

--- a/crates/leptonica-morph/src/morphapp.rs
+++ b/crates/leptonica-morph/src/morphapp.rs
@@ -303,7 +303,8 @@ mod tests {
     fn test_union_of_morph_ops_single_sel_equals_direct() {
         let pix = create_1bpp_test();
         let sel = Sel::create_brick(3, 3).unwrap();
-        let union = union_of_morph_ops(&pix, &[sel.clone()], MorphOpType::Dilate).unwrap();
+        let union =
+            union_of_morph_ops(&pix, std::slice::from_ref(&sel), MorphOpType::Dilate).unwrap();
         let direct = dilate(&pix, &sel).unwrap();
         assert!(union.equals(&direct));
     }
@@ -340,7 +341,9 @@ mod tests {
     fn test_intersection_of_morph_ops_single_sel_equals_direct() {
         let pix = create_1bpp_test();
         let sel = Sel::create_brick(3, 3).unwrap();
-        let result = intersection_of_morph_ops(&pix, &[sel.clone()], MorphOpType::Erode).unwrap();
+        let result =
+            intersection_of_morph_ops(&pix, std::slice::from_ref(&sel), MorphOpType::Erode)
+                .unwrap();
         let direct = erode(&pix, &sel).unwrap();
         assert!(result.equals(&direct));
     }

--- a/crates/leptonica-morph/src/sel.rs
+++ b/crates/leptonica-morph/src/sel.rs
@@ -1927,14 +1927,11 @@ mod tests {
     fn test_sela_add_basic_has_expected_names() {
         let sels = sela_add_basic();
         let names: Vec<_> = sels.iter().filter_map(|s| s.name()).collect();
-        assert!(names.iter().any(|n| *n == "sel_2h"), "missing sel_2h");
-        assert!(names.iter().any(|n| *n == "sel_51v"), "missing sel_51v");
-        assert!(
-            names.iter().any(|n| *n == "sel_4"),
-            "missing sel_4 (2D square)"
-        );
-        assert!(names.iter().any(|n| *n == "sel_2dp"), "missing sel_2dp");
-        assert!(names.iter().any(|n| *n == "sel_5dm"), "missing sel_5dm");
+        assert!(names.contains(&"sel_2h"), "missing sel_2h");
+        assert!(names.contains(&"sel_51v"), "missing sel_51v");
+        assert!(names.contains(&"sel_4"), "missing sel_4 (2D square)");
+        assert!(names.contains(&"sel_2dp"), "missing sel_2dp");
+        assert!(names.contains(&"sel_5dm"), "missing sel_5dm");
     }
 
     #[test]
@@ -2114,8 +2111,6 @@ mod tests {
 
     #[test]
     fn test_sela_write_and_read_roundtrip() {
-        use std::io::BufReader;
-
         let mut sela = Sela::new();
         let mut sel1 = Sel::new(3, 3).unwrap();
         sel1.set_name("sel_a");


### PR DESCRIPTION
## 概要

`cargo clippy -- -D warnings` で報告されたWarning 12件を修正する。

## 変更点

| ファイル | 警告種別 | 修正内容 |
|---|---|---|
| `leptonica-morph/src/morphapp.rs` | `cloned_ref_to_slice_refs` | `&[sel.clone()]` → `std::slice::from_ref(&sel)` |
| `leptonica-morph/src/sel.rs` | `manual_contains` | `iter().any(\|n\| *n == "...")` → `contains(&"...")` |
| `leptonica-morph/src/sel.rs` | `unused_imports` | 未使用の `use std::io::BufReader` 削除 |
| `leptonica-core/src/box_/mod.rs` | `identity_op` | `b.x - 0` → `b.x`、`b.y - 0` → `b.y` |
| `leptonica-io/src/jpeg.rs` | `unnecessary_cast` | `(x * 25) as u32` → `x * 25`（u32→u32キャスト除去） |

## テスト

- [x] `cargo clippy --workspace -- -D warnings` 警告ゼロ確認
- [x] `cargo fmt --all -- --check` 通過