### PR TITLE
fix(recog): use if let instead of match for single pattern in dewarpa test

### DIFF
--- a/crates/leptonica-recog/src/dewarp/dewarpa.rs
+++ b/crates/leptonica-recog/src/dewarp/dewarpa.rs
@@ -833,11 +833,9 @@ mod tests {
         // but for a different reason (no disparity data), not "no model".
         let result = da.apply_disparity(0, &pix, 0, 0);
         // We expect an error about missing disparity, not missing model
-        match result {
-            Err(crate::error::RecogError::InvalidParameter(msg)) => {
-                assert!(!msg.contains("has no Dewarp model"), "unexpected: {msg}");
-            }
-            _ => {} // Any other outcome is acceptable for the RED phase
+        // Any other outcome is acceptable for the RED phase
+        if let Err(crate::error::RecogError::InvalidParameter(msg)) = result {
+            assert!(!msg.contains("has no Dewarp model"), "unexpected: {msg}");
         }
     }
 }


### PR DESCRIPTION
## 概要

`dewarpa.rs` のテストコード内で Clippy の `single_match` 警告が発生していたため修正。

## 変更点

- `crates/leptonica-recog/src/dewarp/dewarpa.rs`: 単一パターンの `match` を `if let` に置き換え

## テスト

- [x] `cargo clippy --package leptonica-recog -- -D warnings` 通過確認済み