### PR TITLE
量子化・二値化・ペイント回帰テスト5個を追加（PR 6-3）

### DIFF
--- a/crates/leptonica-color/tests/dither_reg.rs
+++ b/crates/leptonica-color/tests/dither_reg.rs
@@ -20,7 +20,6 @@ use leptonica_test::RegParams;
 ///
 /// Converts 8bpp grayscale to 1bpp using Floyd-Steinberg dithering.
 #[test]
-#[ignore = "not yet implemented: dither regression tests"]
 fn dither_reg_to_binary() {
     let mut rp = RegParams::new("dither_bin");
 
@@ -48,7 +47,6 @@ fn dither_reg_to_binary() {
 ///
 /// Converts 8bpp grayscale to 1bpp using ordered (Bayer) dithering.
 #[test]
-#[ignore = "not yet implemented: dither regression tests"]
 fn dither_reg_ordered() {
     let mut rp = RegParams::new("dither_ord");
 

--- a/crates/leptonica-color/tests/grayquant_reg.rs
+++ b/crates/leptonica-color/tests/grayquant_reg.rs
@@ -24,7 +24,6 @@ use leptonica_test::RegParams;
 ///
 /// Converts 8bpp grayscale to 1bpp at a given threshold.
 #[test]
-#[ignore = "not yet implemented: grayquant regression tests"]
 fn grayquant_reg_threshold_binary() {
     let mut rp = RegParams::new("gquant_bin");
 
@@ -45,7 +44,6 @@ fn grayquant_reg_threshold_binary() {
 ///
 /// Thresholds 8bpp gray to 2bpp and 4bpp with various levels.
 #[test]
-#[ignore = "not yet implemented: grayquant regression tests"]
 fn grayquant_reg_threshold_multi() {
     let mut rp = RegParams::new("gquant_multi");
 
@@ -88,7 +86,6 @@ fn grayquant_reg_threshold_multi() {
 /// Tests median_cut_quant, octree_quant_256, fixed_octcube_quant_256,
 /// and octree_quant_by_population.
 #[test]
-#[ignore = "not yet implemented: grayquant regression tests"]
 fn grayquant_reg_color_quant() {
     let mut rp = RegParams::new("gquant_cquant");
 

--- a/crates/leptonica-color/tests/paint_reg.rs
+++ b/crates/leptonica-color/tests/paint_reg.rs
@@ -23,7 +23,6 @@ use leptonica_test::RegParams;
 ///
 /// Colorizes dark and light gray pixels in a 32bpp image.
 #[test]
-#[ignore = "not yet implemented: paint regression tests"]
 fn paint_reg_color_gray() {
     let mut rp = RegParams::new("paint_cgray");
 
@@ -71,7 +70,6 @@ fn paint_reg_color_gray() {
 ///
 /// Creates a binary mask from thresholding, then paints a color through it.
 #[test]
-#[ignore = "not yet implemented: paint regression tests"]
 fn paint_reg_through_mask() {
     let mut rp = RegParams::new("paint_mask");
 
@@ -104,7 +102,6 @@ fn paint_reg_through_mask() {
 ///
 /// Renders colored lines and box outlines on a 32bpp image.
 #[test]
-#[ignore = "not yet implemented: paint regression tests"]
 fn paint_reg_render_color() {
     let mut rp = RegParams::new("paint_render");
 
@@ -146,7 +143,6 @@ fn paint_reg_render_color() {
 ///
 /// Renders blended lines and box outlines on a 32bpp image.
 #[test]
-#[ignore = "not yet implemented: paint regression tests"]
 fn paint_reg_render_blend() {
     let mut rp = RegParams::new("paint_blend");
 

--- a/crates/leptonica-color/tests/paintmask_reg.rs
+++ b/crates/leptonica-color/tests/paintmask_reg.rs
@@ -22,7 +22,6 @@ use leptonica_test::RegParams;
 /// Creates a mask from rabi.png, clips and inverts it, then paints through
 /// the mask onto a 32bpp image.
 #[test]
-#[ignore = "not yet implemented: paintmask regression tests"]
 fn paintmask_reg_32bpp() {
     let mut rp = RegParams::new("pmask_32");
 
@@ -59,7 +58,6 @@ fn paintmask_reg_32bpp() {
 ///
 /// Quantizes a 32bpp image and clips a region.
 #[test]
-#[ignore = "not yet implemented: paintmask regression tests"]
 fn paintmask_reg_quant_clip() {
     let mut rp = RegParams::new("pmask_qclip");
 

--- a/crates/leptonica-color/tests/threshnorm_reg.rs
+++ b/crates/leptonica-color/tests/threshnorm_reg.rs
@@ -22,7 +22,6 @@ use leptonica_test::RegParams;
 /// targetthresh, targetthresh+20, targetthresh+40. We test the same
 /// threshold sweep on raw 8bpp gray.
 #[test]
-#[ignore = "not yet implemented: threshnorm regression tests"]
 fn threshnorm_reg_threshold_sweep() {
     let mut rp = RegParams::new("threshnorm_sweep");
 


### PR DESCRIPTION
## 概要

leptonica-color の量子化・二値化・ペイント系回帰テスト5個を追加する（PR 6-3）。

## 変更点

- `dither_reg.rs`: dither_to_binary, ordered_dither (2x2/4x4/8x8)
- `grayquant_reg.rs`: threshold_to_binary/2bpp/4bpp, median_cut_quant, octree_quant_256, fixed_octcube_quant_256, octree_quant_by_population
- `threshnorm_reg.rs`: threshold_to_binary を複数閾値でスイープ
- `paint_reg.rs`: pix_color_gray, paint_through_mask, render_line/box_color, render_line/box_blend
- `paintmask_reg.rs`: paint_through_mask with clipped mask, median_cut_quant + clip_rectangle

計13テストがアクティブ、5テストは未実装API（pixClipMasked, pixThresholdSpreadNorm, pixColorGrayCmap等）のため ignore 継続。

## テスト

- [x] 動作確認済み（13 active tests pass, 5 ignored）
- [x] cargo clippy --workspace 通過
- [x] cargo fmt 適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)