### PR TITLE
test(region): 距離関数・グレーフィル・迷路・スペックル回帰テスト4個を追加（PR 7-1）

### DIFF
--- a/crates/leptonica-region/tests/distance_reg.rs
+++ b/crates/leptonica-region/tests/distance_reg.rs
@@ -21,7 +21,6 @@ use leptonica_test::RegParams;
 /// Computes the distance from each foreground pixel to the nearest background
 /// pixel for 4-way and 8-way connectivity at 8bpp and 16bpp output depth.
 #[test]
-#[ignore = "not yet implemented: distance regression tests"]
 fn distance_reg_all_combos() {
     let mut rp = RegParams::new("dist_combos");
 
@@ -58,7 +57,6 @@ fn distance_reg_all_combos() {
 /// then applies seedfill_gray to label each connected component with
 /// the maximum distance value in that component.
 #[test]
-#[ignore = "not yet implemented: distance regression tests"]
 fn distance_reg_seedfill_labeling() {
     let mut rp = RegParams::new("dist_seedfill");
 

--- a/crates/leptonica-region/tests/grayfill_reg.rs
+++ b/crates/leptonica-region/tests/grayfill_reg.rs
@@ -39,7 +39,6 @@ fn make_mask_200() -> Pix {
 /// Seeds the image from a small central region and propagates using the
 /// inverse gray fill rule (seed <= mask).
 #[test]
-#[ignore = "not yet implemented: grayfill regression tests"]
 fn grayfill_reg_inv() {
     let mut rp = RegParams::new("gfill_inv");
 
@@ -76,7 +75,6 @@ fn grayfill_reg_inv() {
 ///
 /// Seeds from a high-value central region and fills up to mask values.
 #[test]
-#[ignore = "not yet implemented: grayfill regression tests"]
 fn grayfill_reg_standard() {
     let mut rp = RegParams::new("gfill_std");
 
@@ -114,7 +112,6 @@ fn grayfill_reg_standard() {
 ///
 /// Finds local minima in the mask, then uses them as seeds for basin filling.
 #[test]
-#[ignore = "not yet implemented: grayfill regression tests"]
 fn grayfill_reg_basin() {
     let mut rp = RegParams::new("gfill_basin");
 
@@ -123,7 +120,8 @@ fn grayfill_reg_basin() {
     let h = mask.height();
 
     // C: pixLocalExtrema(pixm, 0, 0, &pixmin, NULL);
-    let (pixmin, _pixmax) = local_extrema(&mask, 0, 0).expect("local_extrema");
+    // Rust requires min_max_size to be odd and >= 1; 0 in C means "no size filter"
+    let (pixmin, _pixmax) = local_extrema(&mask, 1, 0).expect("local_extrema");
     assert_eq!(pixmin.depth(), PixelDepth::Bit1);
 
     // C: pixs3 = pixSeedfillGrayBasin(pixmin, pixm, 30, 4);

--- a/crates/leptonica-region/tests/maze_reg.rs
+++ b/crates/leptonica-region/tests/maze_reg.rs
@@ -23,7 +23,6 @@ use leptonica_test::RegParams;
 ///
 /// Generates a binary maze and finds the shortest path between two points.
 #[test]
-#[ignore = "not yet implemented: maze regression tests"]
 fn maze_reg_binary() {
     let mut rp = RegParams::new("maze_bin");
 
@@ -53,7 +52,6 @@ fn maze_reg_binary() {
 ///
 /// Finds minimum-cost paths through a grayscale image using Dijkstra's algorithm.
 #[test]
-#[ignore = "not yet implemented: maze regression tests"]
 fn maze_reg_gray() {
     let mut rp = RegParams::new("maze_gray");
 
@@ -88,7 +86,6 @@ fn maze_reg_gray() {
 ///
 /// Verifies that the generated maze has at least one passage (connected component).
 #[test]
-#[ignore = "not yet implemented: maze regression tests"]
 fn maze_reg_connectivity() {
     let mut rp = RegParams::new("maze_conn");
 

--- a/crates/leptonica-region/tests/speckle_reg.rs
+++ b/crates/leptonica-region/tests/speckle_reg.rs
@@ -27,7 +27,6 @@ use leptonica_test::RegParams;
 ///
 /// Clears all foreground pixels connected to the border.
 #[test]
-#[ignore = "not yet implemented: speckle regression tests"]
 fn speckle_reg_clear_border() {
     let mut rp = RegParams::new("speckle_border");
 
@@ -54,7 +53,6 @@ fn speckle_reg_clear_border() {
 ///
 /// Counts and finds connected components in feyn.tif (already 1bpp).
 #[test]
-#[ignore = "not yet implemented: speckle regression tests"]
 fn speckle_reg_count_components() {
     let mut rp = RegParams::new("speckle_count");
 
@@ -81,7 +79,6 @@ fn speckle_reg_count_components() {
 /// Removes connected components smaller than a given size threshold to
 /// simulate speckle noise removal.
 #[test]
-#[ignore = "not yet implemented: speckle regression tests"]
 fn speckle_reg_select_by_size() {
     let mut rp = RegParams::new("speckle_size");
 


### PR DESCRIPTION
## 概要

leptonica-region クレートの回帰テスト4ファイル（12テスト）を追加する。
C版 `distance_reg.c`, `grayfill_reg.c`, `maze_reg.c`, `speckle_reg.c` に対応。

## 変更点

- `distance_reg.rs`: `distance_function` 全8組み合わせ（connectivity × depth × boundary）+ `seedfill_gray` ラベリング（2テスト）
- `grayfill_reg.rs`: `seedfill_gray_inv`、`seedfill_gray`、`local_extrema` + `seedfill_gray_basin`（3テスト + 1永続ignore）
- `maze_reg.rs`: `generate_binary_maze` + `search_binary_maze`、`search_gray_maze`、連結性チェック（3テスト）
- `speckle_reg.rs`: `clear_border`、`pix_count_components` + `find_connected_components`、`pix_select_by_size`（3テスト + 1永続ignore）

### 実装上の注意

- `speckle_reg` は C版がmorph/filter関数（pixHMT, pixDilate）を使用するため、leptonica-regionのAPIのみでテストを構成（feyn.tif 1bppを直接使用）
- `local_extrema` の `min_max_size=0`（C版）は Rust では `1` に変換（Rust実装は奇数かつ≥1を要求）
- leptonica-region に leptonica-color の dev-dependency 追加なし

## テスト

- [x] `cargo test --package leptonica-region` 全通過
- [x] `cargo clippy --package leptonica-region -- -D warnings` 通過
- [x] `cargo fmt --all -- --check` 通過

## TDD履歴

1. RED: `test(region): add RED regression tests for distance/fill/maze/speckle` (b37f608)
2. GREEN: `test(region): enable distance/fill/maze/speckle regression tests [GREEN]` (2468445)