### PR TITLE
test(morph): 形態学拡張回帰テスト6個を追加（PR 8-1）

### DIFF
--- a/crates/leptonica-morph/tests/binmorph6_reg.rs
+++ b/crates/leptonica-morph/tests/binmorph6_reg.rs
@@ -21,7 +21,6 @@ use leptonica_test::RegParams;
 ///    pix5 = pixCloseSafe(NULL, pix1, sel);
 ///    pix6 = pixSubtract(NULL, pix3, pix1);
 #[test]
-#[ignore = "not yet implemented: binmorph6 regression tests"]
 fn binmorph6_reg_custom_sel() {
     let mut rp = RegParams::new("bmorph6_sel");
 
@@ -68,7 +67,6 @@ fn binmorph6_reg_custom_sel() {
 ///
 /// Creates a custom structuring element from a pattern string.
 #[test]
-#[ignore = "not yet implemented: binmorph6 regression tests"]
 fn binmorph6_reg_sel_from_string() {
     let mut rp = RegParams::new("bmorph6_strsel");
 
@@ -80,8 +78,8 @@ fn binmorph6_reg_sel_from_string() {
 
     // Verify center element
     assert_eq!(cross.get_element(1, 1), Some(SelElement::Hit));
-    // Verify corner elements
-    assert_eq!(cross.get_element(0, 0), Some(SelElement::DontCare));
+    // Verify corner elements ('o' = Miss in from_string)
+    assert_eq!(cross.get_element(0, 0), Some(SelElement::Miss));
 
     assert!(rp.cleanup(), "binmorph6 sel_from_string test failed");
 }

--- a/crates/leptonica-morph/tests/ccthin1_reg.rs
+++ b/crates/leptonica-morph/tests/ccthin1_reg.rs
@@ -20,13 +20,12 @@ use leptonica_test::RegParams;
 ///
 /// C: sela4 = sela4ccThin(NULL); pix1 = selaDisplayInPix(sela4, 35, 3, 15, 3);
 #[test]
-#[ignore = "not yet implemented: ccthin1 regression tests"]
 fn ccthin1_reg_4cc_sels() {
     let mut rp = RegParams::new("cthin1_4cc");
 
     let sels = sels_4cc_thin();
-    // There should be exactly 7 4-cc thinning sels
-    rp.compare_values(7.0, sels.len() as f64, 0.0);
+    // There are 9 4-cc thinning sels (SEL_4_1 through SEL_4_9)
+    rp.compare_values(9.0, sels.len() as f64, 0.0);
 
     // Each sel should have at least one hit element
     for sel in &sels {
@@ -40,13 +39,12 @@ fn ccthin1_reg_4cc_sels() {
 ///
 /// C: sela8 = sela8ccThin(NULL); pix1 = selaDisplayInPix(sela8, 35, 3, 15, 3);
 #[test]
-#[ignore = "not yet implemented: ccthin1 regression tests"]
 fn ccthin1_reg_8cc_sels() {
     let mut rp = RegParams::new("cthin1_8cc");
 
     let sels = sels_8cc_thin();
-    // There should be exactly 7 8-cc thinning sels
-    rp.compare_values(7.0, sels.len() as f64, 0.0);
+    // There are 9 8-cc thinning sels (SEL_8_1 through SEL_8_9)
+    rp.compare_values(9.0, sels.len() as f64, 0.0);
 
     for sel in &sels {
         rp.compare_values(1.0, if sel.hit_count() > 0 { 1.0 } else { 0.0 }, 0.0);
@@ -59,13 +57,12 @@ fn ccthin1_reg_8cc_sels() {
 ///
 /// C: sela48 = sela4and8ccThin(NULL);
 #[test]
-#[ignore = "not yet implemented: ccthin1 regression tests"]
 fn ccthin1_reg_4and8cc_sels() {
     let mut rp = RegParams::new("cthin1_48cc");
 
     let sels = sels_4and8cc_thin();
-    // There should be exactly 6 4-and-8-cc preserving sels
-    rp.compare_values(6.0, sels.len() as f64, 0.0);
+    // There are 2 4-and-8-cc preserving sels (SEL_48_1, SEL_48_2)
+    rp.compare_values(2.0, sels.len() as f64, 0.0);
 
     for sel in &sels {
         rp.compare_values(1.0, if sel.hit_count() > 0 { 1.0 } else { 0.0 }, 0.0);
@@ -78,7 +75,6 @@ fn ccthin1_reg_4and8cc_sels() {
 ///
 /// C: various sel rotation tests from sela4ccThin and selRotateOrth
 #[test]
-#[ignore = "not yet implemented: ccthin1 regression tests"]
 fn ccthin1_reg_make_thin_sels() {
     let mut rp = RegParams::new("cthin1_make");
 

--- a/crates/leptonica-morph/tests/ccthin2_reg.rs
+++ b/crates/leptonica-morph/tests/ccthin2_reg.rs
@@ -21,7 +21,6 @@ use leptonica_test::RegParams;
 ///
 /// C: pix1 = pixThinConnected(pixs, L_THIN_FG, 4, 0);
 #[test]
-#[ignore = "not yet implemented: ccthin2 regression tests"]
 fn ccthin2_reg_thin_4cc() {
     let mut rp = RegParams::new("cthin2_4cc");
 
@@ -56,7 +55,6 @@ fn ccthin2_reg_thin_4cc() {
 ///
 /// C: pix1 = pixThinConnected(pixs, L_THIN_FG, 8, 0);
 #[test]
-#[ignore = "not yet implemented: ccthin2 regression tests"]
 fn ccthin2_reg_thin_8cc() {
     let mut rp = RegParams::new("cthin2_8cc");
 
@@ -77,7 +75,6 @@ fn ccthin2_reg_thin_8cc() {
 /// C: pix1 = pixThinConnectedBySet(pixs, L_THIN_FG, sela, 0);
 /// Tests Set4cc1, Set4cc2, Set8cc1, Set48.
 #[test]
-#[ignore = "not yet implemented: ccthin2 regression tests"]
 fn ccthin2_reg_thin_by_set() {
     let mut rp = RegParams::new("cthin2_set");
 
@@ -118,7 +115,6 @@ fn ccthin2_reg_thin_by_set() {
 ///
 /// C: pix1 = pixThinConnectedBySet(pixs, L_THIN_BG, sela, 5);
 #[test]
-#[ignore = "not yet implemented: ccthin2 regression tests"]
 fn ccthin2_reg_thin_bg() {
     let mut rp = RegParams::new("cthin2_bg");
 

--- a/crates/leptonica-morph/tests/fhmtauto_reg.rs
+++ b/crates/leptonica-morph/tests/fhmtauto_reg.rs
@@ -21,7 +21,6 @@ use leptonica_test::RegParams;
 /// C: pixref = pixHMT(NULL, pixs, sel);
 ///    pix2 = pixFHMTGen_1(NULL, pix1, selname);  -- auto-gen version (not available)
 #[test]
-#[ignore = "not yet implemented: fhmtauto regression tests"]
 fn fhmtauto_reg_hit_miss() {
     let mut rp = RegParams::new("fhmtauto_hmt");
 
@@ -57,7 +56,6 @@ fn fhmtauto_reg_hit_miss() {
 ///
 /// Verifies that HMT with a 1x1 HIT sel returns the original image.
 #[test]
-#[ignore = "not yet implemented: fhmtauto regression tests"]
 fn fhmtauto_reg_identity_sel() {
     let mut rp = RegParams::new("fhmtauto_id");
 

--- a/crates/leptonica-morph/tests/fmorphauto_reg.rs
+++ b/crates/leptonica-morph/tests/fmorphauto_reg.rs
@@ -20,7 +20,6 @@ use leptonica_test::RegParams;
 /// C: pixt1 = pixDilate(NULL, pixs, sel);
 ///    pixt2 = pixFMorphopGen_1(NULL, pixs1, L_MORPH_DILATE, selname);  -- not available
 #[test]
-#[ignore = "not yet implemented: fmorphauto regression tests"]
 fn fmorphauto_reg_dilate_erode() {
     let mut rp = RegParams::new("fmorphauto_ops");
 
@@ -74,7 +73,6 @@ fn fmorphauto_reg_dilate_erode() {
 ///
 /// C: open = erode(dilate(pix)); result should be subset of original
 #[test]
-#[ignore = "not yet implemented: fmorphauto regression tests"]
 fn fmorphauto_reg_open_subset() {
     let mut rp = RegParams::new("fmorphauto_open");
 
@@ -83,9 +81,10 @@ fn fmorphauto_reg_open_subset() {
     let h = pix.height();
     let orig_count = pix.count_pixels();
 
+    // Opening = erode then dilate (anti-extensive: result <= original)
     let sel = Sel::create_brick(3, 3).expect("create 3x3 sel");
-    let dilated = dilate(&pix, &sel).expect("dilate");
-    let opened = erode(&dilated, &sel).expect("erode (open second step)");
+    let eroded = erode(&pix, &sel).expect("erode (open first step)");
+    let opened = dilate(&eroded, &sel).expect("dilate (open second step)");
 
     rp.compare_values(w as f64, opened.width() as f64, 0.0);
     rp.compare_values(h as f64, opened.height() as f64, 0.0);

--- a/crates/leptonica-morph/tests/graymorph2_reg.rs
+++ b/crates/leptonica-morph/tests/graymorph2_reg.rs
@@ -21,7 +21,6 @@ use leptonica_test::RegParams;
 /// C: pix1 = pixDilateGray3(pixs, 3, 1);  pix2 = pixDilateGray(pixs, 3, 1);
 /// C: regTestComparePix(rp, pix1, pix2);
 #[test]
-#[ignore = "not yet implemented: graymorph2 regression tests"]
 fn graymorph2_reg_dilate() {
     let mut rp = RegParams::new("gmorph2_dilate");
 
@@ -52,7 +51,6 @@ fn graymorph2_reg_dilate() {
 ///
 /// C: pix1 = pixErodeGray3(pixs, 3, 1);  pix2 = pixErodeGray(pixs, 3, 1);
 #[test]
-#[ignore = "not yet implemented: graymorph2 regression tests"]
 fn graymorph2_reg_erode() {
     let mut rp = RegParams::new("gmorph2_erode");
 


### PR DESCRIPTION
## 概要

leptonica-morph クレートに6テストファイル（17テスト）を追加する。
C版 binmorph6, ccthin1, ccthin2, graymorph2, fhmtauto, fmorphauto の回帰テストに対応。

## 変更点

### Active テスト
- `binmorph6_reg`: カスタムSel（create_brick/from_string）+ dilate/open/close_safe/subtract（2テスト）
- `ccthin1_reg`: sels_4cc_thin/sels_8cc_thin/sels_4and8cc_thin/make_thin_sels + rotate_orth（4テスト）
- `ccthin2_reg`: thin_connected（4/8-way 前景/背景）+ thin_connected_by_set（4テスト）
- `graymorph2_reg`: dilate_gray/erode_gray 単調性テスト 3x1/1x3/3x3（2テスト）
- `fhmtauto_reg`: hit_miss_transform（thin sels + identity）（2テスト）
- `fmorphauto_reg`: dilate/erode extensive/anti-extensive + opening subset（2テスト）

### 永続 ignore（各1個）
- fhmtauto/fmorphauto: auto-gen関数（pixFHMTGen_1, pixFMorphopGen_1）未対応

### 実装上の修正
- `Sel::from_string` では `'o'` = `Miss`（DontCare ではない）
- `sels_4cc_thin/sels_8cc_thin`: 9個返す（7ではない）
- `sels_4and8cc_thin`: 2個返す（6ではない）
- Opening（open）= erode → dilate（dilate → erode = closing の誤解を修正）

## テスト

- [x] `cargo test --package leptonica-morph` 全通過
- [x] `cargo clippy --package leptonica-morph -- -D warnings` 通過
- [x] `cargo fmt --all -- --check` 通過

## C版対応

- `reference/leptonica/prog/binmorph6_reg.c`
- `reference/leptonica/prog/ccthin1_reg.c`
- `reference/leptonica/prog/ccthin2_reg.c`
- `reference/leptonica/prog/graymorph2_reg.c`
- `reference/leptonica/prog/fhmtauto_reg.c`
- `reference/leptonica/prog/fmorphauto_reg.c`