### PR TITLE
docs: README回帰テストカバレッジ更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Progress against the original 182 source files and 1,880 public functions.
 | -------------------- | -------------------------- |
 | Lines of code        | ~120,000 / ~240,000       |
 | Function coverage    | 1,128 / 1,880 (60.0%)    |
-| Regression test coverage | 59 / 159 (37.1%)      |
+| Regression test coverage | 140 / 159 (88.1%)     |
 
 Details: [Feature comparison](docs/porting/feature-comparison.md) / [Test comparison](docs/porting/test-comparison.md)
 


### PR DESCRIPTION
## 概要
README.mdの回帰テストカバレッジを最新値に更新。

## 変更点
- Regression test coverage: 59/159 (37.1%) → 140/159 (88.1%)

## テスト
- [ ] ドキュメントのみの変更のため、コードへの影響なし