### PR TITLE
test(core): rasteropip mirrored border テスト実装

### DIFF
--- a/crates/leptonica-core/tests/rasteropip_reg.rs
+++ b/crates/leptonica-core/tests/rasteropip_reg.rs
@@ -86,36 +86,39 @@ fn rasteropip_reg_copy_consistency() {
 /// C equivalent: pixRemoveBorder + pixAddMirroredBorder
 #[test]
 fn rasteropip_reg_mirrored_border() {
+    const BORDER: u32 = 40;
+
     let mut rp = RegParams::new("rasteropip_mirror");
 
     let pixs = leptonica_test::load_test_image("test8.jpg").expect("load test8.jpg");
     let w = pixs.width();
     let h = pixs.height();
 
-    // Remove 40-pixel border on all sides
-    let pixt = pixs.remove_border(40).expect("remove_border(40)");
+    // Remove BORDER-pixel border on all sides
+    let pixt = pixs.remove_border(BORDER).expect("remove_border(BORDER)");
     let tw = pixt.width();
     let th = pixt.height();
-    rp.compare_values((w - 80) as f64, tw as f64, 0.0);
-    rp.compare_values((h - 80) as f64, th as f64, 0.0);
+    rp.compare_values(w.saturating_sub(2 * BORDER) as f64, tw as f64, 0.0);
+    rp.compare_values(h.saturating_sub(2 * BORDER) as f64, th as f64, 0.0);
 
-    // Add mirrored border of 40 pixels on all sides
+    // Add mirrored border of BORDER pixels on all sides
     let pixd = pixt
-        .add_mirrored_border(40, 40, 40, 40)
-        .expect("add_mirrored_border(40,40,40,40)");
+        .add_mirrored_border(BORDER, BORDER, BORDER, BORDER)
+        .expect("add_mirrored_border");
 
     // Dimensions must match original
     rp.compare_values(w as f64, pixd.width() as f64, 0.0);
     rp.compare_values(h as f64, pixd.height() as f64, 0.0);
 
     // Interior region of pixd must exactly match pixt
-    let interior_ok =
-        (0..th).all(|y| (0..tw).all(|x| pixt.get_pixel(x, y) == pixd.get_pixel(x + 40, y + 40)));
+    let interior_ok = (0..th)
+        .all(|y| (0..tw).all(|x| pixt.get_pixel(x, y) == pixd.get_pixel(x + BORDER, y + BORDER)));
     rp.compare_values(1.0, if interior_ok { 1.0 } else { 0.0 }, 0.0);
 
-    // Spot-check left mirror border: pixd[39-j, y+40] == pixd[40+j, y+40] for j=0..5
-    let border_ok = (0..5u32)
-        .all(|j| (0..5u32).all(|y| pixd.get_pixel(39 - j, y + 40) == pixt.get_pixel(j, y)));
+    // Spot-check left mirror border: pixd[BORDER-1-j, y+BORDER] == pixt[j, y] for j in 0..4
+    let border_ok = (0..4u32).all(|j| {
+        (0..4u32).all(|y| pixd.get_pixel(BORDER - 1 - j, y + BORDER) == pixt.get_pixel(j, y))
+    });
     rp.compare_values(1.0, if border_ok { 1.0 } else { 0.0 }, 0.0);
 
     assert!(rp.cleanup());


### PR DESCRIPTION
## Why

`rasteropip_reg_mirrored_border` は `pixRemoveBorder`/`pixAddMirroredBorder` が未実装として `#[ignore]` になっていたが、
`Pix::remove_border` および `Pix::add_mirrored_border` はすでに実装済みであるためテスト本体を実装できる。

## What

- `rasteropip_reg.rs` に `rasteropip_reg_mirrored_border` のテスト本体を実装
- `remove_border(40)` + `add_mirrored_border(40,40,40,40)` のパイプラインを検証
- 出力寸法が元画像と同一であることを確認
- 内部領域が de-bordered 画像と完全一致することを確認
- 左ミラーボーダーのスポットチェックで反転が正確であることを確認
- プロダクションコードへの変更なし

## Impact

leptonica-core の `rasteropip_reg_mirrored_border` #[ignore] を 1 件解除

🤖 Generated with [Claude Code](https://claude.com/claude-code)