### PR TITLE
chore(cargo): exclude unnecessary files from crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,15 @@ edition = "2024"
 license = "BSD-2-Clause"
 repository = "https://github.com/tagawa/leptonica-rs"
 description = "Rust port of Leptonica image processing library"
+exclude = [
+    "reference/**",
+    "tests/data/**",
+    "tests/golden/**",
+    "tests/regout/**",
+    "docs/**",
+    "CLAUDE.md",
+    ".markdownlintignore",
+]
 
 [dependencies]
 thiserror = "2.0.18"


### PR DESCRIPTION
## 概要

crates.io へのパッケージアップロードが 10MB 上限を超えて失敗していた問題を修正。
`Cargo.toml` に `exclude` セクションを追加し、利用者に不要なファイルを除外する。

## 変更点

- `reference/**` - Cリファレンス実装（git submodule）を除外
- `tests/data/**` - テスト用画像データを除外
- `tests/golden/**` / `tests/regout/**` - 回帰テストのgolden/出力ファイルを除外
- `docs/**` / `CLAUDE.md` / `.markdownlintignore` - 開発ドキュメントを除外

## 効果

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| ファイル数 | 1,444 | 338 |
| パッケージサイズ（圧縮後） | 17.8 MiB | 893.8 KiB |

## テスト

- [x] `cargo package --no-verify --allow-dirty` でサイズ確認済み（893.8 KiB）