### PR TITLE
docs: add CI, docs, crates.io, and license badges to READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,10 @@
 # leptonica-rs
 
+[![CI](https://github.com/tagawa/leptonica-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/tagawa/leptonica-rs/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/leptonica.svg)](https://crates.io/crates/leptonica)
+[![docs.rs](https://docs.rs/leptonica/badge.svg)](https://docs.rs/leptonica)
+[![License: BSD-2-Clause](https://img.shields.io/badge/license-BSD--2--Clause-blue.svg)](LICENSE)
+
 [Leptonica](http://www.leptonica.org/) 画像処理ライブラリのRust移植。
 
 [English](README.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # leptonica-rs
 
+[![CI](https://github.com/tagawa/leptonica-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/tagawa/leptonica-rs/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/leptonica.svg)](https://crates.io/crates/leptonica)
+[![docs.rs](https://docs.rs/leptonica/badge.svg)](https://docs.rs/leptonica)
+[![License: BSD-2-Clause](https://img.shields.io/badge/license-BSD--2--Clause-blue.svg)](LICENSE)
+
 A Rust reimplementation of the [Leptonica](http://www.leptonica.org/) image processing library.
 
 [日本語](README.ja.md)


### PR DESCRIPTION
## 概要

README（英語版・日本語版）にステータスバッジを追加する。

## 変更点

- `README.md` / `README.ja.md` のタイトル直下にバッジ行を追加
  - **CI**: GitHub Actions `ci.yml` ワークフローのステータス
  - **docs.rs**: ドキュメント生成ステータス
  - **crates.io**: パッケージバージョン
  - **License**: BSD-2-Clause

## テスト

- [ ] 動作確認済み（バッジURLの正確性確認）