### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leptonica"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "gif",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptonica"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 license = "BSD-2-Clause"
 repository = "https://github.com/tagawa0525/leptonica-rs"


### PR DESCRIPTION
## 概要

バージョンを 0.1.1 → 0.2.0 にバンプ。

## 変更点

- `Cargo.toml`: version = "0.2.0"
- `Cargo.lock`: 自動更新

## v0.2.0 のハイライト（v0.1.1 以降の変更）

- C版回帰テストカバレッジ 100% 達成（140/159 → 159/159）
- morph 拡張 API 追加（selective_conn_comp_fill, fast_tophat, h_dome 等）
- 移植進捗ドキュメントの全面更新

## テスト

- [x] `cargo check` 通過