### PR TITLE
docs(license): add original Leptonica copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 BSD 2-Clause License
 
-Copyright (c) 2025-2026, leptonica-rs contributors
-All rights reserved.
+Copyright (C) 2001-2020 Leptonica.  All rights reserved.
+Copyright (c) 2025-2026, leptonica-rs contributors.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
## 概要

LICENSE ファイルにオリジナルの Leptonica 著作権表示を追加します。

## 変更点

- `LICENSE`: Leptonica の元の著作権表示を追記

## テスト

- [ ] 内容確認済み