### PR TITLE
test(core): core モジュール回帰テストに golden manifest チェックを追加

### DIFF
--- a/docs/plans/014_regression-test-enhance.md
+++ b/docs/plans/014_regression-test-enhance.md
@@ -1,6 +1,6 @@
 # Phase 3: 回帰テスト修正計画
 
-Status: IN_PROGRESS (PR 7/8: recog 完了)
+Status: IN_PROGRESS (PR 8/8: core 完了)
 
 ## Context
 

--- a/docs/plans/022_core-golden-enhance.md
+++ b/docs/plans/022_core-golden-enhance.md
@@ -1,0 +1,29 @@
+# 022: core モジュール回帰テスト golden manifest 強化
+
+Status: IN_PROGRESS
+
+Phase 3 PR 8/8: `tests/core/` 配下の回帰テストに `write_pix_and_check()` を追加し、
+golden manifest によるピクセルレベル回帰検出を有効化する。
+
+## Context
+
+Phase 3（回帰テスト強化）の最終PR。core モジュールには7つの RegParams 使用ファイルがあり、
+うち boxa3_reg は既に golden 済み（3エントリ）。残り6ファイルのうち4ファイルが
+決定的な Pix 出力を持ち golden 化の対象となる。
+
+親計画: `docs/plans/014_regression-test-enhance.md`
+
+## 対象ファイル (4ファイル, ~12 golden)
+
+- `conversion_reg.rs` — ~9 golden (depth conversion results from PNG/TIFF sources)
+- `hash_reg.rs` — 1 golden (hash-line rendered)
+- `logicops_reg.rs` — 1 golden (inverted image)
+- `fpix1_reg.rs` — 1 golden (FPix→Pix conversion)
+
+## 除外ファイル
+
+- `boxa3_reg.rs` — 既に golden 済み（3エントリ）
+- `equal_reg.rs` — compare_pix で既にピクセル比較済み
+- `insert_reg.rs` — Pix 出力なし（Numa/Boxa/Pixa 要素操作のみ）
+- JPEG ソースのテスト — デコーダ差異リスク
+- RegParams 未使用ファイル（13ファイル） — Phase 3 スコープ外

--- a/docs/plans/022_core-golden-enhance.md
+++ b/docs/plans/022_core-golden-enhance.md
@@ -1,6 +1,6 @@
 # 022: core モジュール回帰テスト golden manifest 強化
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 
 Phase 3 PR 8/8: `tests/core/` 配下の回帰テストに `write_pix_and_check()` を追加し、
 golden manifest によるピクセルレベル回帰検出を有効化する。

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -15,6 +15,7 @@
 use crate::common::RegParams;
 use leptonica::PixelDepth;
 use leptonica::core::pix::RemoveColormapTarget;
+use leptonica::io::ImageFormat;
 
 /// Test 1bpp → various depth conversions (C checks 0-3).
 ///
@@ -51,6 +52,9 @@ fn conversion_reg_from_1bpp() {
     rp.compare_values(pix1.width() as f64, pix2.width() as f64, 0.0);
     rp.compare_values(pix1.height() as f64, pix2.height() as f64, 0.0);
 
+    rp.write_pix_and_check(&pix8, ImageFormat::Png)
+        .expect("write pix8 conversion_from_1bpp");
+
     assert!(rp.cleanup(), "conversion from 1bpp test failed");
 }
 
@@ -80,6 +84,11 @@ fn conversion_reg_from_2bpp() {
     rp.compare_values(pix2.width() as f64, pix8.width() as f64, 0.0);
     rp.compare_values(pix2.height() as f64, pix8.height() as f64, 0.0);
 
+    rp.write_pix_and_check(&pix8, ImageFormat::Png)
+        .expect("write pix8 conversion_from_2bpp");
+    rp.write_pix_and_check(&pix32, ImageFormat::Png)
+        .expect("write pix32 conversion_from_2bpp");
+
     assert!(rp.cleanup(), "conversion from 2bpp test failed");
 }
 
@@ -98,11 +107,17 @@ fn conversion_reg_from_4bpp() {
     rp.compare_values(pix4.width() as f64, pix8.width() as f64, 0.0);
     rp.compare_values(pix4.height() as f64, pix8.height() as f64, 0.0);
 
+    rp.write_pix_and_check(&pix8, ImageFormat::Png)
+        .expect("write pix8 conversion_from_4bpp");
+
     // Convert 4 bpp grayscale image
     let pix4g = crate::common::load_test_image("weasel4.16g.png").expect("load weasel4.16g.png");
     let pix8g = pix4g.convert_4_to_8(false).expect("convert_4_to_8 no cmap");
     assert_eq!(pix8g.depth(), PixelDepth::Bit8);
     rp.compare_values(8.0, pix8g.depth().bits() as f64, 0.0);
+
+    rp.write_pix_and_check(&pix8g, ImageFormat::Png)
+        .expect("write pix8g conversion_from_4bpp");
 
     assert!(rp.cleanup(), "conversion from 4bpp test failed");
 }
@@ -128,6 +143,11 @@ fn conversion_reg_from_8bpp() {
         .expect("remove to grayscale");
     assert_eq!(gray.depth(), PixelDepth::Bit8);
     rp.compare_values(8.0, gray.depth().bits() as f64, 0.0);
+
+    rp.write_pix_and_check(&converted, ImageFormat::Png)
+        .expect("write converted conversion_from_8bpp");
+    rp.write_pix_and_check(&gray, ImageFormat::Png)
+        .expect("write gray conversion_from_8bpp");
 
     assert!(rp.cleanup(), "conversion from 8bpp test failed");
 }
@@ -181,6 +201,11 @@ fn conversion_reg_from_16bpp() {
     // Dimensions preserved
     rp.compare_values(pix16.width() as f64, pix8_ls.width() as f64, 0.0);
     rp.compare_values(pix16.height() as f64, pix8_ls.height() as f64, 0.0);
+
+    rp.write_pix_and_check(&pix8_ls, ImageFormat::Png)
+        .expect("write pix8_ls conversion_from_16bpp");
+    rp.write_pix_and_check(&pix8_ms, ImageFormat::Png)
+        .expect("write pix8_ms conversion_from_16bpp");
 
     assert!(rp.cleanup(), "conversion from 16bpp test failed");
 }

--- a/tests/core/fpix1_reg.rs
+++ b/tests/core/fpix1_reg.rs
@@ -8,6 +8,7 @@
 //! C Leptonica: `reference/leptonica/prog/fpix1_reg.c`
 
 use crate::common::RegParams;
+use leptonica::io::ImageFormat;
 use leptonica::{FPix, NegativeHandling, Pix, PixelDepth};
 
 // ==========================================================================
@@ -222,6 +223,9 @@ fn fpix1_reg_pix_conversion() {
 
     let pix2 = fpix2.to_pix(8, NegativeHandling::ClipToZero).unwrap();
     rp.compare_values(8.0, pix2.depth().bits() as f64, 0.0);
+
+    rp.write_pix_and_check(&pix2, ImageFormat::Png)
+        .expect("write pix2 fpix1_pix");
 
     // Negative handling: ClipToZero
     let mut fpix3 = FPix::new(2, 1).unwrap();

--- a/tests/core/hash_reg.rs
+++ b/tests/core/hash_reg.rs
@@ -9,6 +9,7 @@
 use crate::common::RegParams;
 use leptonica::core::pix::HashOrientation;
 use leptonica::core::pixel;
+use leptonica::io::ImageFormat;
 use leptonica::{Box, Pix, PixelDepth, PixelOp};
 
 #[test]
@@ -39,6 +40,9 @@ fn hash_reg() {
     rp.compare_values(rendered.width() as f64, 40.0, 0.0);
     let on = rendered.count_pixels();
     rp.compare_values(1.0, if on > 0 { 1.0 } else { 0.0 }, 0.0);
+
+    rp.write_pix_and_check(&rendered, ImageFormat::Tiff)
+        .expect("write rendered hash");
 
     assert!(rp.cleanup(), "hash regression test failed");
 }

--- a/tests/core/logicops_reg.rs
+++ b/tests/core/logicops_reg.rs
@@ -14,6 +14,7 @@
 
 use crate::common::RegParams;
 use leptonica::Pix;
+use leptonica::io::ImageFormat;
 
 /// Test pixInvert: double-invert identity (C checks 0-2).
 ///
@@ -32,6 +33,9 @@ fn logicops_reg_invert() {
     // Double invert should yield original
     let pix3 = pix2.invert();
     rp.compare_pix(&pix1, &pix3);
+
+    rp.write_pix_and_check(&pix2, ImageFormat::Tiff)
+        .expect("write inverted logicops_invert");
 
     assert!(rp.cleanup(), "logicops invert test failed");
 }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -130,6 +130,15 @@ colorseg.05.png	1544d222ba54aa32
 colorspace.23.png	a7622784a55dc974
 compfilter_write_synthetic.01.png	776f015732796ef4
 compfilter_write_synthetic.02.png	32bbb5fff34c2454
+conversion_from_16bpp.04.png	ff9aba5ee2aaace0
+conversion_from_16bpp.05.png	ff9aba5ee2aaace0
+conversion_from_1bpp.07.png	ff9aba5ee2aaace0
+conversion_from_2bpp.05.png	536739402d73641e
+conversion_from_2bpp.06.png	af7f58945e330afe
+conversion_from_4bpp.03.png	368eed4016fed93a
+conversion_from_4bpp.05.png	8f7b016c981b0817
+conversion_from_8bpp.04.png	34396ef54eddf107
+conversion_from_8bpp.05.png	8ef9102efc7e88f0
 convolve_blockconv_32bpp.01.jpg	d88bf13111d25d4e
 convolve_blockconv_8bpp.01.jpg	109a1bd29a030a27
 convolve_blockconv_gray.01.jpg	152b8dec435a055f
@@ -202,6 +211,7 @@ findpat1_brick.03.tif	03c19098398419ff
 findpat1_hmt.03.tif	a253d69b6fc1c3be
 findpat2_asterisk.03.tif	691ed904fa578a7b
 flipdetect_correct.03.tif	36b18174021bfd7d
+fpix1_pix.06.png	f2e933a99b05252b
 gfill_basin.03.png	2adac671711d1a33
 gfill_hybrid.02.png	b2730774e0ef631d
 gfill_inv.03.png	c50cb009e8c84c55
@@ -233,6 +243,7 @@ gquant_multi.03.png	08810b088ba999b8
 hardlight_color.03.png	281943cdfdbdf537
 hardlight_gray.03.png	3152a69afc6e4c40
 hardlight_orig.03.png	440823de285d4407
+hash.04.tif	5e6de61a46a887d8
 ioformats.08.png	ccbd13ca1df413ea
 ioformats.11.png	368eed4016fed93a
 ioformats.13.png	ae835cf4d3a91625
@@ -269,6 +280,7 @@ lineremoval_arith.07.png	8d99f24d54367565
 lineremoval_morph.03.png	75e5ba2f861cdc3e
 lineremoval_morph.06.png	fc8919170aa50eab
 lineremoval_pipe.03.png	c8d9ac4cf5a3e493
+logicops_invert.03.tif	2fd7502f5f315b39
 multitype_affine.13.png	7dffbf06e42b314a
 multitype_bilinear.13.png	fb8ae32dc802adb5
 multitype_projective.13.png	76c65b6d01e6adea


### PR DESCRIPTION
## Summary

Phase 3 PR 8/8: `tests/core/` 配下の回帰テストに `write_pix_and_check()` を追加し、golden manifest によるピクセルレベル回帰検出を有効化。

- `conversion_reg.rs`: 9 golden (1bpp→8, 2bpp→8/32, 4bpp→8×2, 8bpp→converted/gray, 16bpp→8ls/8ms)
- `hash_reg.rs`: 1 golden (rendered hash-line, 1bpp)
- `logicops_reg.rs`: 1 golden (inverted image, 1bpp)
- `fpix1_reg.rs`: 1 golden (FPix→Pix conversion, 8bpp)

合計12エントリ追加（371→383）。JPEG ソーステスト (karen8.jpg, marge.jpg) はデコーダ差異リスクのため除外。

## Test plan

- [x] `cargo test --test core` 全450テスト通過
- [x] `REGTEST_MODE=generate cargo test --test core` で manifest 生成
- [x] `cargo clippy --all-features --all-targets -- -D warnings` クリーン
- [x] `cargo fmt --all -- --check` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)