### PR TITLE
docs(plans): mark Phase 5 as IMPLEMENTED

### DIFF
--- a/docs/plans/025_phase5-coverage-expansion.md
+++ b/docs/plans/025_phase5-coverage-expansion.md
@@ -1,6 +1,6 @@
 # Phase 5: テストカバレッジ拡充 — Ratio < 0.1 テストの C版同等化
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 
 ## Context
 


### PR DESCRIPTION
## 概要

Phase 5 計画書のステータスを IMPLEMENTED に更新。

## 変更点

- `docs/plans/025_phase5-coverage-expansion.md`: Status を IN_PROGRESS → IMPLEMENTED に変更

## 完了した PR

| PR | ブランチ | 内容 | manifest +entries |
|----|----------|------|-------------------|
| #284 | test/phase5-coverage-expansion | 7テスト既存API活用拡充 | +59 |
| #285 | feat/filter-max-dynamic-range | max_dynamic_range + distance/writetext | +40 |
| #286 | test/phase5-psioseg-expansion | psioseg composite pipeline | +4 |

合計: 478→541 manifest entries