### PR TITLE
chore: C版leptonica git submoduleを除去

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/reference/
 /tests/golden/
 /tests/regout/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "reference/leptonica"]
-	path = reference/leptonica
-	url = git@github.com:DanBloomberg/leptonica.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ src/
 
 ## テスト
 
-- 回帰テスト: C版 `reference/leptonica/prog/*_reg.c` に対応
+- 回帰テスト: C版 `prog/*_reg.c` に対応
 - テストデータ: `tests/data/images/`
 - ハッシュ manifest: `tests/golden_manifest.tsv`（git 管理、CI で出力変化を検出）
 - ローカル golden: `tests/golden/`（.gitignore、デバッグ用）
@@ -155,4 +155,4 @@ pub struct PixMut { inner: PixData }     // 可変・直接所有
 
 `docs/porting/`: prompt.md, overall-plan.md, feature-comparison.md, test-comparison.md
 
-C版ソース: `reference/leptonica/`（`git submodule update --init`）
+C版ソース: https://github.com/DanBloomberg/leptonica（必要に応じて `reference/leptonica/` に手動clone）

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,6 +55,18 @@ cargo test --all-features
 cargo clippy --all-features --all-targets
 ```
 
+### C版リファレンスソース（オプション）
+
+移植資料やヘルパースクリプトの一部は `reference/leptonica/` にC版ソースがあることを前提とする。
+必要な場合は手動でcloneする:
+
+```bash
+mkdir -p reference
+git clone https://github.com/DanBloomberg/leptonica.git reference/leptonica
+```
+
+`reference/` ディレクトリは `.gitignore` に含まれており、gitで追跡されない。
+
 ## ドキュメント
 
 - `CLAUDE.md` -- 開発規約・プロセスルール

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,7 +13,7 @@
 
 [Leptonica](http://www.leptonica.org/) は Dan Bloomberg 氏が開発・保守するC言語のオープンソース画像処理ライブラリである。約240,000行のコードに2,700以上の関数を収録し、ドキュメント画像処理から自然画像処理まで幅広い領域をカバーする。[Tesseract OCR](https://github.com/tesseract-ocr/tesseract/) や [OpenCV](https://github.com/opencv/opencv) をはじめとする多くのプロジェクトの基盤として20年以上にわたり利用されてきた。
 
-本プロジェクトは、Leptonicaの設計思想とアルゴリズムをRustで再実装するものである。C版のソースコードとドキュメントを一次資料として参照し、その機能を忠実に移植することを目指す。C版のソースはgit submoduleとして `reference/leptonica/` に配置し、常に原典を参照できるようにしている。
+本プロジェクトは、Leptonicaの設計思想とアルゴリズムをRustで再実装するものである。[C版のソースコード](https://github.com/DanBloomberg/leptonica)とドキュメントを一次資料として参照し、その機能を忠実に移植することを目指す。
 
 ## 移植状況
 
@@ -54,15 +54,6 @@ cargo test
 cargo test --all-features
 cargo clippy --all-features --all-targets
 ```
-
-### C版リファレンスの取得
-
-```bash
-git submodule update --init
-```
-
-> **注意**: `.gitmodules` ではSSH URL（`git@github.com:...`）を使用しています。
-> SSHキーが設定されていない環境では、HTTPS形式に変更してください。
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A pure Rust reimplementation of the [Leptonica](http://www.leptonica.org/) image
 
 [Leptonica](http://www.leptonica.org/) is an open-source C library for image processing and analysis, created and maintained by Dan Bloomberg. With approximately 240,000 lines of code and over 2,700 functions, it covers a broad range of operations from document image processing to natural image analysis. Leptonica has served as a foundational library for projects such as [Tesseract OCR](https://github.com/tesseract-ocr/tesseract/) and [OpenCV](https://github.com/opencv/opencv) for over 20 years.
 
-This project reimplements Leptonica's design and algorithms in Rust. The original C source code and documentation serve as the primary reference, included as a git submodule under `reference/leptonica/`.
+This project reimplements Leptonica's design and algorithms in Rust. The original [C source code](https://github.com/DanBloomberg/leptonica) and documentation serve as the primary reference.
 
 ## Porting Status
 
@@ -54,15 +54,6 @@ cargo test
 cargo test --all-features
 cargo clippy --all-features --all-targets
 ```
-
-### Fetching the C Reference
-
-```bash
-git submodule update --init
-```
-
-> **Note**: `.gitmodules` uses SSH URLs (`git@github.com:...`).
-> If SSH keys are not configured, change the URL to HTTPS format.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ cargo test --all-features
 cargo clippy --all-features --all-targets
 ```
 
+### C Reference Source (Optional)
+
+Some porting documents and helper scripts reference the original C source at `reference/leptonica/`.
+To use them, clone the C source manually:
+
+```bash
+mkdir -p reference
+git clone https://github.com/DanBloomberg/leptonica.git reference/leptonica
+```
+
+The `reference/` directory is listed in `.gitignore` and will not be tracked by git.
+
 ## Documentation
 
 - `CLAUDE.md` -- Development conventions and process rules

--- a/docs/plans/027_remove-c-submodule.md
+++ b/docs/plans/027_remove-c-submodule.md
@@ -1,0 +1,112 @@
+# C版leptonica git submoduleの除去
+
+## Context
+
+C版leptonicaは `reference/leptonica/` にgit submoduleとして配置されていたが、移植作業がほぼ完了し（関数カバレッジ82%、回帰テスト100%）、日常的な参照が不要になった。submoduleを除去してリポジトリ構成を簡素化する。
+
+ローカルで必要な場合は手動で `git clone` できるよう `.gitignore` にパスを追加する。
+
+## 変更対象ファイル
+
+### 1. Git submodule除去（コマンド）
+
+```bash
+git rm reference/leptonica          # gitの追跡から除去
+rm .gitmodules                      # 他のsubmoduleなし → ファイル削除
+git add .gitmodules
+# .git/config のsubmoduleエントリは git rm で自動除去される
+# .git/modules/reference/leptonica はローカルキャッシュ → rm -rf で手動削除
+```
+
+### 2. `.gitignore` — `reference/` を追加
+
+```text
+/reference/
+```
+
+ローカルにC版ソースを手動cloneしても追跡されないようにする。
+
+### 3. `README.md` (L16, L58-65)
+
+- L16: submoduleとして含まれている旨の記述を削除、代わりにC版公式リポジトリへのリンクに変更
+- L58-65: 「Fetching the C Reference」セクションを削除
+
+### 4. `README.ja.md` (L16, L58-65)
+
+- L16: 同上（日本語版）
+- L58-65: 「C版リファレンスの取得」セクションを削除
+
+### 5. `CLAUDE.md` (L95, L101)
+
+- `reference/leptonica/prog/*_reg.c` への言及を削除または代替表現に変更
+- `git submodule update --init` の記述を削除
+- `examples/compare_golden.rs` + `scripts/golden_map.tsv` の記述は残す（Cソースに依存しない）
+
+### 6. `scripts/audit-regression-tests.py` (L23, L31, L102-108)
+
+C版ソースをスキャンするスクリプト。submoduleがなくなると動作しない。
+→ エラーメッセージを「submoduleをチェックアウトしてください」から「C版ソースを手動cloneしてください」に変更。
+
+### 7. テスト・ソースファイルのコメント（163箇所）
+
+テストファイル161件、ソースファイル1件に `reference/leptonica/` パスがコメントとしてハードコードされている。
+
+パターン例:
+
+```rust
+//! C version: `reference/leptonica/prog/convolve_reg.c`
+//! C Leptonica: `reference/leptonica/prog/boxa1_reg.c`
+//! C reference: reference/leptonica/prog/watershed_reg.c
+//! C版: reference/leptonica/src/adaptmap.c
+// C reference: reference/leptonica/src/scale2.c
+```
+
+**対応**: `reference/leptonica/` プレフィックスを一括削除。結果:
+
+```rust
+//! C version: `prog/convolve_reg.c`
+//! C Leptonica: `prog/boxa1_reg.c`
+// C reference: src/scale2.c
+```
+
+leptonicaプロジェクト内の相対パスとして十分明確であり、submoduleのローカルパスに依存しなくなる。`sed` で一括置換:
+
+```bash
+find tests/ src/ -name '*.rs' -exec sed -i 's|reference/leptonica/||g' {} +
+```
+
+### 8. `scripts/verify_*.c` (3ファイル)
+
+C版leptonicaのヘッダに依存するCソース。submodule除去後も、手動clone環境で使う想定。
+→ 変更不要（ファイル冒頭コメントの "reference/leptonica/prog/" は実行ディレクトリの案内として正確）
+
+### 9. `examples/compare_golden.rs` (L9-19コメント)
+
+ビルド手順のコメントに `cd reference/leptonica` がある。
+→ 変更不要（手動clone先のパス指定として引き続き有効）
+
+### 10. `docs/plans/`, `docs/porting/` — 変更不要
+
+完了済み計画・移植資料は歴史的記録。パスの参照は当時の事実として正確なので改変しない。
+
+## コミット構成
+
+1コミットで実施: `chore: remove C leptonica git submodule`
+
+## 検証
+
+```bash
+# submoduleが除去されていること
+git submodule status  # 出力なし
+cat .gitmodules       # ファイルなし
+
+# ビルド・テストが影響を受けないこと
+cargo check --all-features
+cargo test --all-features
+cargo clippy --all-features --all-targets -- -D warnings
+cargo fmt --all -- --check
+
+# .gitignore が reference/ を無視すること
+mkdir -p reference/test && git status  # reference/ が表示されない
+rm -rf reference/test
+```

--- a/docs/porting/overall-plan.md
+++ b/docs/porting/overall-plan.md
@@ -34,7 +34,7 @@ leptonica-rs/
 │   ├── leptonica-recog/          # 文字認識・バーコード・デワープ・スキュー
 │   └── leptonica-test/           # 回帰テストインフラ（RegParams, compare_* 等）
 ├── leptonica/                    # ファサードcrate（全crateのre-export）
-└── reference/leptonica/          # C版 leptonica（git submodule）
+└── reference/leptonica/          # C版 leptonica（手動clone）
 ```
 
 ### 依存関係（実際の構成）

--- a/docs/porting/prompt.md
+++ b/docs/porting/prompt.md
@@ -43,7 +43,7 @@
 leptonica-rs/
 ├── Cargo.toml                    # workspace root
 ├── CLAUDE.md                     # 規約（後述）
-├── reference/leptonica/          # C版ソース（git submodule、read-only参照）
+├── reference/leptonica/          # C版ソース（手動clone、read-only参照）
 ├── crates/
 │   ├── leptonica-core/           # Pix, Box, Numa, FPix等の基本データ構造
 │   ├── leptonica-io/             # 画像I/O（PNG, JPEG, TIFF, GIF, WebP, BMP, PNM, JP2K, PDF, PS）

--- a/scripts/audit-regression-tests.py
+++ b/scripts/audit-regression-tests.py
@@ -104,6 +104,7 @@ def get_alltests_names() -> list[str]:
             f"Missing required file: {ALLTESTS_REG}\n"
             "The C leptonica source is not available.\n"
             "Please clone it manually:\n"
+            "    mkdir -p reference\n"
             "    git clone https://github.com/DanBloomberg/leptonica.git reference/leptonica"
         )
     content = ALLTESTS_REG.read_text(encoding="utf-8")

--- a/scripts/audit-regression-tests.py
+++ b/scripts/audit-regression-tests.py
@@ -102,9 +102,9 @@ def get_alltests_names() -> list[str]:
     if not ALLTESTS_REG.exists():
         raise FileNotFoundError(
             f"Missing required file: {ALLTESTS_REG}\n"
-            "The leptonica reference submodule may not be checked out.\n"
-            "Please run:\n"
-            "    git submodule update --init --recursive"
+            "The C leptonica source is not available.\n"
+            "Please clone it manually:\n"
+            "    git clone https://github.com/DanBloomberg/leptonica.git reference/leptonica"
         )
     content = ALLTESTS_REG.read_text(encoding="utf-8")
     names = re.findall(r'"([a-z0-9_]+)_reg"', content)

--- a/src/filter/rank.rs
+++ b/src/filter/rank.rs
@@ -549,7 +549,7 @@ pub fn max_filter(pix: &Pix, width: u32, height: u32) -> FilterResult<Pix> {
 
 // ---------------------------------------------------------------------------
 // Grayscale downscaling by rank / min-max selection
-// C reference: reference/leptonica/src/scale2.c
+// C reference: src/scale2.c
 // ---------------------------------------------------------------------------
 
 /// Operation type for [`scale_gray_min_max`].

--- a/tests/color/alphaops_reg.rs
+++ b/tests/color/alphaops_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/alphaops_reg.c`
+//! C Leptonica: `prog/alphaops_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/color/binarize_reg.rs
+++ b/tests/color/binarize_reg.rs
@@ -1,6 +1,6 @@
 //! Binarization regression test
 //!
-//! C version: reference/leptonica/prog/binarize_reg.c
+//! C version: prog/binarize_reg.c
 //! Tests Otsu, adaptive threshold, Sauvola and other binarization methods.
 //!
 //! Expanded in Phase 5 to add tiled Sauvola, sauvola_on_contrast_norm,

--- a/tests/color/blackwhite_reg.rs
+++ b/tests/color/blackwhite_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/blackwhite_reg.c`
+//! C Leptonica: `prog/blackwhite_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/color/blend1_reg.rs
+++ b/tests/color/blend1_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/blend1_reg.c`
+//! C Leptonica: `prog/blend1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/color/blend2_reg.rs
+++ b/tests/color/blend2_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/blend2_reg.c`
+//! C Leptonica: `prog/blend2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/color/blend3_reg.rs
+++ b/tests/color/blend3_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/blend3_reg.c`
+//! C Leptonica: `prog/blend3_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/color/blend4_reg.rs
+++ b/tests/color/blend4_reg.rs
@@ -12,7 +12,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/blend4_reg.c`
+//! C Leptonica: `prog/blend4_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/color/blend5_reg.rs
+++ b/tests/color/blend5_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/blend5_reg.c`
+//! C Leptonica: `prog/blend5_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/color/cmapquant_reg.rs
+++ b/tests/color/cmapquant_reg.rs
@@ -1,6 +1,6 @@
 //! Colormap quantization regression test
 //!
-//! C version: reference/leptonica/prog/cmapquant_reg.c
+//! C version: prog/cmapquant_reg.c
 
 use crate::common::{RegParams, load_test_image};
 use leptonica::color::{

--- a/tests/color/colorcontent_reg.rs
+++ b/tests/color/colorcontent_reg.rs
@@ -1,6 +1,6 @@
 //! Color content analysis regression test
 //!
-//! C version: reference/leptonica/prog/colorcontent_reg.c
+//! C version: prog/colorcontent_reg.c
 //! Tests color_content, count_colors, is_grayscale, grayscale_histogram.
 
 use crate::common::{RegParams, load_test_image};

--- a/tests/color/colorfill_reg.rs
+++ b/tests/color/colorfill_reg.rs
@@ -1,6 +1,6 @@
 //! Color fill regression test
 //!
-//! C version: reference/leptonica/prog/colorfill_reg.c
+//! C version: prog/colorfill_reg.c
 //! Tests color_fill, color_fill_from_seed, pixel_is_on_color_boundary.
 //!
 //! Expanded in Phase 5 to add:

--- a/tests/color/coloring_reg.rs
+++ b/tests/color/coloring_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/coloring_reg.c`
+//! C Leptonica: `prog/coloring_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/color/colorize_reg.rs
+++ b/tests/color/colorize_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/colorize_reg.c`
+//! C Leptonica: `prog/colorize_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/color/colormask_reg.rs
+++ b/tests/color/colormask_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/colormask_reg.c`
+//! C Leptonica: `prog/colormask_reg.c`
 
 /// Test HSV histogram peak detection and mask generation (C checks 0-10).
 ///

--- a/tests/color/colorquant_reg.rs
+++ b/tests/color/colorquant_reg.rs
@@ -1,6 +1,6 @@
 //! Color quantization regression test
 //!
-//! C version: reference/leptonica/prog/colorquant_reg.c
+//! C version: prog/colorquant_reg.c
 //! Tests MedianCut and Octree quantization with various parameters.
 
 use crate::common::{RegParams, load_test_image};

--- a/tests/color/colorseg_reg.rs
+++ b/tests/color/colorseg_reg.rs
@@ -1,6 +1,6 @@
 //! Color segmentation regression test
 //!
-//! C version: reference/leptonica/prog/colorseg_reg.c
+//! C version: prog/colorseg_reg.c
 //! Tests color_segment, color_segment_simple, color_segment_cluster.
 
 use crate::common::{RegParams, load_test_image};

--- a/tests/color/colorspace_reg.rs
+++ b/tests/color/colorspace_reg.rs
@@ -1,6 +1,6 @@
 //! Colorspace conversion regression test
 //!
-//! C version: reference/leptonica/prog/colorspace_reg.c
+//! C version: prog/colorspace_reg.c
 //! Tests RGB<->HSV, RGB<->Lab, RGB<->YUV conversions.
 //!
 //! Expanded in Phase 5 to add:

--- a/tests/color/dither_reg.rs
+++ b/tests/color/dither_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/dither_reg.c`
+//! C Leptonica: `prog/dither_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/color/falsecolor_reg.rs
+++ b/tests/color/falsecolor_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/falsecolor_reg.c`
+//! C Leptonica: `prog/falsecolor_reg.c`
 
 use crate::common::RegParams;
 use leptonica::color::{

--- a/tests/color/grayquant_reg.rs
+++ b/tests/color/grayquant_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/grayquant_reg.c`
+//! C Leptonica: `prog/grayquant_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/color/hardlight_reg.rs
+++ b/tests/color/hardlight_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/hardlight_reg.c`
+//! C Leptonica: `prog/hardlight_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/color/paint_reg.rs
+++ b/tests/color/paint_reg.rs
@@ -13,7 +13,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/paint_reg.c`
+//! C Leptonica: `prog/paint_reg.c`
 
 use crate::common::RegParams;
 use leptonica::color::{ColorGrayOptions, PaintType, pix_color_gray, threshold_to_binary};

--- a/tests/color/paintcmap_reg.rs
+++ b/tests/color/paintcmap_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/paintcmap_reg.c`
+//! C Leptonica: `prog/paintcmap_reg.c`
 
 use leptonica::core::{Pix, PixColormap, PixelDepth, RgbaQuad};
 

--- a/tests/color/paintmask_reg.rs
+++ b/tests/color/paintmask_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/paintmask_reg.c`
+//! C Leptonica: `prog/paintmask_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/color/threshnorm_reg.rs
+++ b/tests/color/threshnorm_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/threshnorm_reg.c`
+//! C Leptonica: `prog/threshnorm_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/core/bmf_reg.rs
+++ b/tests/core/bmf_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/textops_reg.c`
+//! C Leptonica: `prog/textops_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::bmf;

--- a/tests/core/boxa1_reg.rs
+++ b/tests/core/boxa1_reg.rs
@@ -5,7 +5,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/boxa1_reg.c`
+//! C Leptonica: `prog/boxa1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Box, Boxa};

--- a/tests/core/boxa2_reg.rs
+++ b/tests/core/boxa2_reg.rs
@@ -6,7 +6,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/boxa2_reg.c`
+//! C Leptonica: `prog/boxa2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Box, Boxa};

--- a/tests/core/boxa3_reg.rs
+++ b/tests/core/boxa3_reg.rs
@@ -6,7 +6,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/boxa3_reg.c`
+//! C Leptonica: `prog/boxa3_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Boxa;

--- a/tests/core/boxa4_reg.rs
+++ b/tests/core/boxa4_reg.rs
@@ -6,7 +6,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/boxa4_reg.c`
+//! C Leptonica: `prog/boxa4_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Boxa;

--- a/tests/core/bytea_reg.rs
+++ b/tests/core/bytea_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/bytea_reg.c`
+//! C Leptonica: `prog/bytea_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Pix, PixMut, PixelDepth, decode_base64, encode_base64};

--- a/tests/core/compare_reg.rs
+++ b/tests/core/compare_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/compare_reg.c`
+//! C Leptonica: `prog/compare_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/conversion_reg.c`
+//! C Leptonica: `prog/conversion_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/core/dna_reg.rs
+++ b/tests/core/dna_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/dna_reg.c`
+//! C Leptonica: `prog/dna_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Numa, Numaa, SortOrder};

--- a/tests/core/equal_reg.rs
+++ b/tests/core/equal_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/equal_reg.c`
+//! C Leptonica: `prog/equal_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::pix::RemoveColormapTarget;

--- a/tests/core/extrema_reg.rs
+++ b/tests/core/extrema_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/extrema_reg.c`
+//! C Leptonica: `prog/extrema_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Numa;

--- a/tests/core/fpix1_reg.rs
+++ b/tests/core/fpix1_reg.rs
@@ -5,7 +5,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/fpix1_reg.c`
+//! C Leptonica: `prog/fpix1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/core/hash_reg.rs
+++ b/tests/core/hash_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/hash_reg.c`
+//! C Leptonica: `prog/hash_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::pix::HashOrientation;

--- a/tests/core/heap_reg.rs
+++ b/tests/core/heap_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/heap_reg.c`
+//! C Leptonica: `prog/heap_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Numa, SortOrder};

--- a/tests/core/insert_reg.rs
+++ b/tests/core/insert_reg.rs
@@ -5,7 +5,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/insert_reg.c`
+//! C Leptonica: `prog/insert_reg.c`
 
 use crate::common::{RegParams, load_test_image};
 use leptonica::{Box, Boxa, Numa};

--- a/tests/core/logicops_reg.rs
+++ b/tests/core/logicops_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/logicops_reg.c`
+//! C Leptonica: `prog/logicops_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Pix;

--- a/tests/core/lowaccess_reg.rs
+++ b/tests/core/lowaccess_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/lowaccess_reg.c`
+//! C Leptonica: `prog/lowaccess_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::pix::{

--- a/tests/core/numa1_reg.rs
+++ b/tests/core/numa1_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/numa1_reg.c`
+//! C Leptonica: `prog/numa1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Numa;

--- a/tests/core/numa2_reg.rs
+++ b/tests/core/numa2_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/numa2_reg.c`
+//! C Leptonica: `prog/numa2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Numa;

--- a/tests/core/numa3_reg.rs
+++ b/tests/core/numa3_reg.rs
@@ -12,7 +12,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/numa3_reg.c`
+//! C Leptonica: `prog/numa3_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Numa;

--- a/tests/core/overlap_reg.rs
+++ b/tests/core/overlap_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/overlap_reg.c`
+//! C Leptonica: `prog/overlap_reg.c`
 
 use crate::common::{RegParams, load_test_image};
 use leptonica::{Box, Boxa};

--- a/tests/core/pixa1_reg.rs
+++ b/tests/core/pixa1_reg.rs
@@ -5,7 +5,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixa1_reg.c`
+//! C Leptonica: `prog/pixa1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Box, Pix, Pixa, Pixaa, PixelDepth};

--- a/tests/core/pixa2_reg.rs
+++ b/tests/core/pixa2_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixa2_reg.c`
+//! C Leptonica: `prog/pixa2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::pix::statistics::PixelMaxType;

--- a/tests/core/pixacc_reg.rs
+++ b/tests/core/pixacc_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixacc_reg.c` (not a separate
+//! C Leptonica: `prog/pixacc_reg.c` (not a separate
 //! regression test in C, but functionality from pixacc.c)
 
 use leptonica::core::pixacc::PixAcc;

--- a/tests/core/pixalloc_reg.rs
+++ b/tests/core/pixalloc_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixalloc_reg.c`
+//! C Leptonica: `prog/pixalloc_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Pix, PixelDepth};

--- a/tests/core/pixcomp_reg.rs
+++ b/tests/core/pixcomp_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixcomp_reg.c`
+//! C Leptonica: `prog/pixcomp_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::pixcomp::{PixComp, PixaComp};

--- a/tests/core/pixmem_reg.rs
+++ b/tests/core/pixmem_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixmem_reg.c`
+//! C Leptonica: `prog/pixmem_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Pix, PixelDepth};

--- a/tests/core/pixserial_reg.rs
+++ b/tests/core/pixserial_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixserial_reg.c`
+//! C Leptonica: `prog/pixserial_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Pix;

--- a/tests/core/pta_reg.rs
+++ b/tests/core/pta_reg.rs
@@ -6,7 +6,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pta_reg.c`
+//! C Leptonica: `prog/pta_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Pta, Ptaa};

--- a/tests/core/ptra1_reg.rs
+++ b/tests/core/ptra1_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/ptra1_reg.c`
+//! C Leptonica: `prog/ptra1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Pta, Ptaa};

--- a/tests/core/ptra2_reg.rs
+++ b/tests/core/ptra2_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/ptra2_reg.c`
+//! C Leptonica: `prog/ptra2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Pta, Ptaa};

--- a/tests/core/rasterop_reg.rs
+++ b/tests/core/rasterop_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/rasterop_reg.c`
+//! C Leptonica: `prog/rasterop_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{InColor, Pix, RopOp};

--- a/tests/core/rasteropip_reg.rs
+++ b/tests/core/rasteropip_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/rasteropip_reg.c`
+//! C Leptonica: `prog/rasteropip_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{InColor, Pix};

--- a/tests/core/string_reg.rs
+++ b/tests/core/string_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/string_reg.c`
+//! C Leptonica: `prog/string_reg.c`
 
 use crate::common::RegParams;
 use leptonica::{Sarray, Sarraya};

--- a/tests/filter/adaptmap_advanced_reg.rs
+++ b/tests/filter/adaptmap_advanced_reg.rs
@@ -1,6 +1,6 @@
 //! Test advanced adaptive mapping functions
 //!
-//! C版: reference/leptonica/src/adaptmap.c
+//! C版: src/adaptmap.c
 //! - pixApplyVariableGrayMap
 //! - pixGlobalNormRGB
 //! - pixConvertTo8MinMax

--- a/tests/filter/adaptmap_bg_reg.rs
+++ b/tests/filter/adaptmap_bg_reg.rs
@@ -1,6 +1,6 @@
 //! Test background map extraction and application functions
 //!
-//! C版: reference/leptonica/src/adaptmap.c
+//! C版: src/adaptmap.c
 //! - pixGetBackgroundGrayMap
 //! - pixGetBackgroundRGBMap
 //! - pixGetInvBackgroundMap

--- a/tests/filter/adaptmap_morph_reg.rs
+++ b/tests/filter/adaptmap_morph_reg.rs
@@ -1,6 +1,6 @@
 //! Test morph-based background map extraction and normalization
 //!
-//! C版: reference/leptonica/src/adaptmap.c
+//! C版: src/adaptmap.c
 //! - pixBackgroundNormMorph
 //! - pixBackgroundNormGrayArrayMorph
 //! - pixBackgroundNormRGBArraysMorph

--- a/tests/filter/adaptmap_reg.rs
+++ b/tests/filter/adaptmap_reg.rs
@@ -1,6 +1,6 @@
 //! Adaptive mapping regression test
 //!
-//! C version: reference/leptonica/prog/adaptmap_reg.c
+//! C version: prog/adaptmap_reg.c
 //!
 //! Tests adaptive background normalization and contrast normalization.
 //!

--- a/tests/filter/adaptnorm_reg.rs
+++ b/tests/filter/adaptnorm_reg.rs
@@ -1,6 +1,6 @@
 //! Adaptive normalization regression test
 //!
-//! C version: reference/leptonica/prog/adaptnorm_reg.c
+//! C version: prog/adaptnorm_reg.c
 //!
 //! Tests adaptive normalization for two extreme cases:
 //!   (1) Variable and low contrast -> pixContrastNorm pipeline

--- a/tests/filter/bilateral1_reg.rs
+++ b/tests/filter/bilateral1_reg.rs
@@ -1,6 +1,6 @@
 //! Bilateral filtering regression test (exact)
 //!
-//! C version: reference/leptonica/prog/bilateral1_reg.c
+//! C version: prog/bilateral1_reg.c
 //!
 //! Tests bilateral filtering with both:
 //!   (1) Separable results with full res intermediate images (pixBilateral with reduction=1,2)

--- a/tests/filter/bilateral2_reg.rs
+++ b/tests/filter/bilateral2_reg.rs
@@ -1,6 +1,6 @@
 //! Bilateral filtering regression test (parameter variations)
 //!
-//! C version: reference/leptonica/prog/bilateral2_reg.c
+//! C version: prog/bilateral2_reg.c
 //!
 //! Tests bilateral filtering with various spatial/range stdev combinations.
 //!

--- a/tests/filter/bilateral_fast_reg.rs
+++ b/tests/filter/bilateral_fast_reg.rs
@@ -1,6 +1,6 @@
 //! Test fast separable bilateral filtering
 //!
-//! C版: reference/leptonica/src/bilateral.c
+//! C版: src/bilateral.c
 //! - pixBilateral
 //! - pixBilateralGray
 

--- a/tests/filter/compfilter_reg.rs
+++ b/tests/filter/compfilter_reg.rs
@@ -19,7 +19,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/compfilter_reg.c`
+//! C Leptonica: `prog/compfilter_reg.c`
 
 // ---------------------------------------------------------------------------
 // Helper: count connected components in a 1-bpp Pix (8-way)

--- a/tests/filter/convolve_reg.rs
+++ b/tests/filter/convolve_reg.rs
@@ -1,6 +1,6 @@
 //! Convolution regression test
 //!
-//! C version: reference/leptonica/prog/convolve_reg.c
+//! C version: prog/convolve_reg.c
 //!
 //! Tests convolution, box blur, Gaussian blur, census transform,
 //! blockconv, blockrank, blocksum, and windowed statistics operations.

--- a/tests/filter/edge_reg.rs
+++ b/tests/filter/edge_reg.rs
@@ -1,6 +1,6 @@
 //! Edge detection regression test
 //!
-//! C version: reference/leptonica/prog/edge_reg.c
+//! C version: prog/edge_reg.c
 //!
 //! Tests Sobel edge filter, Laplacian edge detection, sharpening,
 //! unsharp masking, and emboss operations.

--- a/tests/filter/edge_smoothness_reg.rs
+++ b/tests/filter/edge_smoothness_reg.rs
@@ -1,6 +1,6 @@
 //! Edge smoothness and two-sided edge regression tests
 //!
-//! C version: reference/leptonica/prog/edge_reg.c (extended)
+//! C version: prog/edge_reg.c (extended)
 //!
 //! Tests two-sided edge filter, edge smoothness measurement,
 //! and edge profile extraction.

--- a/tests/filter/enhance_reg.rs
+++ b/tests/filter/enhance_reg.rs
@@ -6,7 +6,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/enhance_reg.c`
+//! C Leptonica: `prog/enhance_reg.c`
 
 use crate::common::{RegParams, load_test_image};
 use leptonica::PixelDepth;

--- a/tests/filter/extend_replication_reg.rs
+++ b/tests/filter/extend_replication_reg.rs
@@ -1,6 +1,6 @@
 //! Test pixExtendByReplication()
 //!
-//! C版: reference/leptonica/src/adaptmap.c:pixExtendByReplication()
+//! C版: src/adaptmap.c:pixExtendByReplication()
 
 use leptonica::filter::extend_by_replication;
 use leptonica::{Pix, PixelDepth};

--- a/tests/filter/half_edge_reg.rs
+++ b/tests/filter/half_edge_reg.rs
@@ -1,6 +1,6 @@
 //! Half-edge by bandpass regression test
 //!
-//! C version: reference/leptonica/prog/enhance_reg.c (extended)
+//! C version: prog/enhance_reg.c (extended)
 //!
 //! Tests half-edge detection using bandpass filtering.
 //!

--- a/tests/filter/kernel_reg.rs
+++ b/tests/filter/kernel_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/kernel_reg.c`
+//! C Leptonica: `prog/kernel_reg.c`
 
 use crate::common::RegParams;
 use leptonica::filter::{

--- a/tests/filter/locminmax_reg.rs
+++ b/tests/filter/locminmax_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/locminmax_reg.c`
+//! C Leptonica: `prog/locminmax_reg.c`
 
 use crate::common::RegParams;
 use leptonica::filter::blockconv_gray;

--- a/tests/filter/lowsat_reg.rs
+++ b/tests/filter/lowsat_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/lowsat_reg.c`
+//! C Leptonica: `prog/lowsat_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/filter/rank_reg.rs
+++ b/tests/filter/rank_reg.rs
@@ -1,6 +1,6 @@
 //! Rank filter regression test
 //!
-//! C version: reference/leptonica/prog/rank_reg.c
+//! C version: prog/rank_reg.c
 //!
 //! Tests grayscale and color rank filter functions:
 //!   (1) pixRankFilterGray() -> rank_filter_gray()

--- a/tests/filter/rank_scaling_reg.rs
+++ b/tests/filter/rank_scaling_reg.rs
@@ -1,6 +1,6 @@
 //! Rank filter with scaling regression test
 //!
-//! C version: reference/leptonica/prog/rank_reg.c (extended)
+//! C version: prog/rank_reg.c (extended)
 //!
 //! Tests accelerated rank filtering via downscaling.
 //!

--- a/tests/filter/rankbin_reg.rs
+++ b/tests/filter/rankbin_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/rankbin_reg.c`
+//! C Leptonica: `prog/rankbin_reg.c`
 
 use crate::common::RegParams;
 use leptonica::filter::{max_filter, median_filter, min_filter, rank_filter_gray};

--- a/tests/filter/rankhisto_reg.rs
+++ b/tests/filter/rankhisto_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/rankhisto_reg.c`
+//! C Leptonica: `prog/rankhisto_reg.c`
 
 use crate::common::RegParams;
 use leptonica::filter::{gamma_trc_pix, rank_filter, rank_filter_color};

--- a/tests/io/encoding_reg.rs
+++ b/tests/io/encoding_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/encoding_reg.c`
+//! C Leptonica: `prog/encoding_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::encoding;

--- a/tests/io/files_reg.rs
+++ b/tests/io/files_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/files_reg.c`
+//! C Leptonica: `prog/files_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::{ImageFormat, pixa_read_files, pixa_write_files, read_image, write_image};

--- a/tests/io/jp2kio_reg.rs
+++ b/tests/io/jp2kio_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/jp2kio_reg.c`
+//! C Leptonica: `prog/jp2kio_reg.c`
 
 use crate::common::RegParams;
 

--- a/tests/io/pdfio1_reg.rs
+++ b/tests/io/pdfio1_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pdfio1_reg.c`
+//! C Leptonica: `prog/pdfio1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::pdf::{PdfCompression, PdfOptions};

--- a/tests/io/pdfio2_reg.rs
+++ b/tests/io/pdfio2_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pdfio2_reg.c`
+//! C Leptonica: `prog/pdfio2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::pdf::PdfOptions;

--- a/tests/io/pdfseg_reg.rs
+++ b/tests/io/pdfseg_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pdfseg_reg.c`
+//! C Leptonica: `prog/pdfseg_reg.c`
 
 use crate::common::RegParams;
 

--- a/tests/io/pixtile_reg.rs
+++ b/tests/io/pixtile_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixtile_reg.c`
+//! C Leptonica: `prog/pixtile_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::pixtiling::PixTiling;

--- a/tests/io/psio_reg.rs
+++ b/tests/io/psio_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/psio_reg.c`
+//! C Leptonica: `prog/psio_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ps::{PsLevel, PsOptions};

--- a/tests/io/psioseg_reg.rs
+++ b/tests/io/psioseg_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/psioseg_reg.c`
+//! C Leptonica: `prog/psioseg_reg.c`
 
 use crate::common::RegParams;
 use leptonica::color::{OctreeOptions, octree_quant, octree_quant_num_colors};

--- a/tests/io/webpanimio_reg.rs
+++ b/tests/io/webpanimio_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/webpanimio_reg.c`
+//! C Leptonica: `prog/webpanimio_reg.c`
 
 use crate::common::RegParams;
 use leptonica::core::pixel;

--- a/tests/io/writetext_reg.rs
+++ b/tests/io/writetext_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/writetext_reg.c`
+//! C Leptonica: `prog/writetext_reg.c`
 
 use crate::common::{RegParams, load_test_image};
 use leptonica::color::{threshold_to_2bpp, threshold_to_4bpp, threshold_to_binary};

--- a/tests/morph/binmorph1_reg.rs
+++ b/tests/morph/binmorph1_reg.rs
@@ -1,6 +1,6 @@
 //! Binary morphology regression test
 //!
-//! C version: reference/leptonica/prog/binmorph1_reg.c
+//! C version: prog/binmorph1_reg.c
 //! Tests dilation, erosion, opening, and closing operations.
 //!
 //! C版は複数アルゴリズム（rasterop, dwa, sequence）間の等価比較がメイン。

--- a/tests/morph/binmorph2_reg.rs
+++ b/tests/morph/binmorph2_reg.rs
@@ -1,6 +1,6 @@
 //! Binary morphology regression test 2 - safe closing
 //!
-//! C版: reference/leptonica/prog/binmorph2_reg.c
+//! C版: prog/binmorph2_reg.c
 //! Safe closing操作をテスト。通常のclosingとsafe closingの比較。
 //!
 //! Safe closingはdilationで画像境界を超える部分を考慮して

--- a/tests/morph/binmorph3_reg.rs
+++ b/tests/morph/binmorph3_reg.rs
@@ -1,6 +1,6 @@
 //! Binary morphology regression test 3 - boundary conditions
 //!
-//! C版: reference/leptonica/prog/binmorph3_reg.c
+//! C版: prog/binmorph3_reg.c
 //! 境界条件でのmorphology操作をテスト。
 //! 1x1 identity, 分離可能性, 次元保持を検証。
 //!

--- a/tests/morph/binmorph4_reg.rs
+++ b/tests/morph/binmorph4_reg.rs
@@ -1,6 +1,6 @@
 //! Binary morphology regression test 4
 //!
-//! C version: reference/leptonica/prog/binmorph4_reg.c
+//! C version: prog/binmorph4_reg.c
 //! Tests DWA brick vs standard morph comparison.
 //! Compares DWA brick operations with standard brick operations
 //! for various sizes to ensure they produce identical results.

--- a/tests/morph/binmorph5_reg.rs
+++ b/tests/morph/binmorph5_reg.rs
@@ -1,6 +1,6 @@
 //! Binary morphology regression test 5
 //!
-//! C version: reference/leptonica/prog/binmorph5_reg.c
+//! C version: prog/binmorph5_reg.c
 //! Tests expanded DWA composite morph comparison.
 //! Compares DWA composite operations with standard morph operations
 //! for larger sizes (up to 240).

--- a/tests/morph/binmorph6_reg.rs
+++ b/tests/morph/binmorph6_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/binmorph6_reg.c`
+//! C Leptonica: `prog/binmorph6_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/morph/ccthin1_reg.rs
+++ b/tests/morph/ccthin1_reg.rs
@@ -1,6 +1,6 @@
 //! Connected-component thinning 1 regression test
 //!
-//! C version: reference/leptonica/prog/ccthin1_reg.c
+//! C version: prog/ccthin1_reg.c
 //! Tests generation and display of thinning structuring element sets,
 //! and applies thinning to a clipped region of feyn.tif.
 //!

--- a/tests/morph/ccthin2_reg.rs
+++ b/tests/morph/ccthin2_reg.rs
@@ -1,6 +1,6 @@
 //! Connected-component thinning 2 regression test
 //!
-//! C version: reference/leptonica/prog/ccthin2_reg.c
+//! C version: prog/ccthin2_reg.c
 //! Tests thin_connected_by_set with various SEL sets on a clipped region
 //! of feyn.tif.
 //!

--- a/tests/morph/colormorph_reg.rs
+++ b/tests/morph/colormorph_reg.rs
@@ -1,6 +1,6 @@
 //! Color morphology regression test
 //!
-//! C version: reference/leptonica/prog/colormorph_reg.c
+//! C version: prog/colormorph_reg.c
 //! Tests dilate_color, erode_color, open_color, close_color and compares
 //! direct operations with color_morph_sequence results.
 //!

--- a/tests/morph/dwamorph1_reg.rs
+++ b/tests/morph/dwamorph1_reg.rs
@@ -1,6 +1,6 @@
 //! DWA morphology regression test
 //!
-//! C版: reference/leptonica/prog/dwamorph1_reg.c
+//! C版: prog/dwamorph1_reg.c
 //! DWA (destination word accumulation) 高速morphology操作をテスト。
 //! DWA結果が通常のbrick操作と一致することを検証。
 

--- a/tests/morph/dwamorph2_reg.rs
+++ b/tests/morph/dwamorph2_reg.rs
@@ -1,6 +1,6 @@
 //! DWA morphology regression test 2
 //!
-//! C version: reference/leptonica/prog/dwamorph2_reg.c
+//! C version: prog/dwamorph2_reg.c
 //! Compares timing and correctness of various binary morphological
 //! implementations: standard brick, DWA brick.
 //!

--- a/tests/morph/fhmtauto_reg.rs
+++ b/tests/morph/fhmtauto_reg.rs
@@ -1,6 +1,6 @@
 //! FHMT auto-generated code regression test
 //!
-//! C version: reference/leptonica/prog/fhmtauto_reg.c
+//! C version: prog/fhmtauto_reg.c
 //! Tests hit-miss transform (HMT) on a binary image.
 //! C版は auto-gen pixFHMTGen_1 / pixHMTDwa_1 vs pixHMT を比較。
 //! Rust版は pixHMT 結果のgolden化 + 性質検証。

--- a/tests/morph/fmorphauto_reg.rs
+++ b/tests/morph/fmorphauto_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/fmorphauto_reg.c`
+//! C Leptonica: `prog/fmorphauto_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/morph/graymorph1_reg.rs
+++ b/tests/morph/graymorph1_reg.rs
@@ -1,6 +1,6 @@
 //! Gray morphology regression test 1
 //!
-//! C version: reference/leptonica/prog/graymorph1_reg.c
+//! C version: prog/graymorph1_reg.c
 //! Tests:
 //!   (1) Gray morph operations and gray_morph_sequence interpreter
 //!   (2) Composite operations: tophat

--- a/tests/morph/graymorph2_reg.rs
+++ b/tests/morph/graymorph2_reg.rs
@@ -1,6 +1,6 @@
 //! Gray morphology 2 regression test
 //!
-//! C version: reference/leptonica/prog/graymorph2_reg.c
+//! C version: prog/graymorph2_reg.c
 //! Tests gray morphological operations with 3x1, 1x3, and 3x3 sizes.
 //!
 //! C版は pixDilateGray3 vs pixDilateGray 等の等価比較（12 compare_pix）。

--- a/tests/morph/morphseq_reg.rs
+++ b/tests/morph/morphseq_reg.rs
@@ -1,6 +1,6 @@
 //! Morphological sequence regression test
 //!
-//! C version: reference/leptonica/prog/morphseq_reg.c
+//! C version: prog/morphseq_reg.c
 //! Tests morph_sequence and gray_morph_sequence interpreters,
 //! including display mode and rejection of invalid sequence components.
 //!

--- a/tests/recog/baseline_reg.rs
+++ b/tests/recog/baseline_reg.rs
@@ -1,6 +1,6 @@
 //! Baseline detection regression test
 //!
-//! C版: reference/leptonica/prog/baseline_reg.c
+//! C版: prog/baseline_reg.c
 //! テキスト画像のベースライン(テキスト行の基準線)検出をテスト。
 //!
 //! C版テストの構成:

--- a/tests/recog/classapp_reg.rs
+++ b/tests/recog/classapp_reg.rs
@@ -5,7 +5,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/classapp_reg.c` (partial)
+//! C Leptonica: `prog/classapp_reg.c` (partial)
 
 use crate::common::RegParams;
 use leptonica::core::{Box, Boxa, Numa, Numaa};

--- a/tests/recog/correlscore_reg.rs
+++ b/tests/recog/correlscore_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/correlscore_reg.c`
+//! C Leptonica: `prog/correlscore_reg.c`
 
 use leptonica::core::{Pix, PixelDepth};
 use leptonica::recog::correlscore;

--- a/tests/recog/dewarp_reg.rs
+++ b/tests/recog/dewarp_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/dewarp_reg.c`
+//! C Leptonica: `prog/dewarp_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/recog/findcorners_reg.rs
+++ b/tests/recog/findcorners_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/findcorners_reg.c`
+//! C Leptonica: `prog/findcorners_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/recog/findpattern1_reg.rs
+++ b/tests/recog/findpattern1_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/findpattern1_reg.c`
+//! C Leptonica: `prog/findpattern1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/recog/findpattern2_reg.rs
+++ b/tests/recog/findpattern2_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/findpattern2_reg.c`
+//! C Leptonica: `prog/findpattern2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/recog/flipdetect_reg.rs
+++ b/tests/recog/flipdetect_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/flipdetect_reg.c`
+//! C Leptonica: `prog/flipdetect_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/recog/genfonts_reg.rs
+++ b/tests/recog/genfonts_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/genfonts_reg.c`
+//! C Leptonica: `prog/genfonts_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/recog/italic_reg.rs
+++ b/tests/recog/italic_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/italic_reg.c`
+//! C Leptonica: `prog/italic_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/recog/jbclass_reg.rs
+++ b/tests/recog/jbclass_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/jbclass_reg.c`
+//! C Leptonica: `prog/jbclass_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/recog/lineremoval_reg.rs
+++ b/tests/recog/lineremoval_reg.rs
@@ -12,7 +12,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/lineremoval_reg.c`
+//! C Leptonica: `prog/lineremoval_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/recog/nearline_reg.rs
+++ b/tests/recog/nearline_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/nearline_reg.c`
+//! C Leptonica: `prog/nearline_reg.c`
 
 use crate::common::RegParams;
 use leptonica::recog::pageseg::{

--- a/tests/recog/newspaper_reg.rs
+++ b/tests/recog/newspaper_reg.rs
@@ -14,7 +14,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/newspaper_reg.c`
+//! C Leptonica: `prog/newspaper_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/recog/pageseg_reg.rs
+++ b/tests/recog/pageseg_reg.rs
@@ -1,6 +1,6 @@
 //! Page segmentation regression test
 //!
-//! C版: reference/leptonica/prog/pageseg_reg.c
+//! C版: prog/pageseg_reg.c
 //! ページセグメンテーション（ハーフトーン/テキストライン/テキストブロック領域分離）をテスト。
 //!
 //! C版テストの構成:

--- a/tests/recog/partition_reg.rs
+++ b/tests/recog/partition_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/partition_reg.c`
+//! C Leptonica: `prog/partition_reg.c`
 
 use crate::common::RegParams;
 use leptonica::color::threshold_to_binary;

--- a/tests/recog/pixadisp_reg.rs
+++ b/tests/recog/pixadisp_reg.rs
@@ -12,7 +12,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/pixadisp_reg.c`
+//! C Leptonica: `prog/pixadisp_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/recog/skew_reg.rs
+++ b/tests/recog/skew_reg.rs
@@ -1,6 +1,6 @@
 //! Skew detection regression test
 //!
-//! C版: reference/leptonica/prog/skew_reg.c
+//! C版: prog/skew_reg.c
 //! テキスト画像のスキュー(傾き)検出と補正をテスト。
 
 use crate::common::{RegParams, load_test_image};

--- a/tests/recog/wordboxes_reg.rs
+++ b/tests/recog/wordboxes_reg.rs
@@ -12,7 +12,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/wordboxes_reg.c`
+//! C Leptonica: `prog/wordboxes_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/region/ccbord_reg.rs
+++ b/tests/region/ccbord_reg.rs
@@ -1,6 +1,6 @@
 //! Component borders regression test
 //!
-//! C reference: reference/leptonica/prog/ccbord_reg.c
+//! C reference: prog/ccbord_reg.c
 //!
 //! Verifies:
 //! 1. get_all_borders retrieves all borders (outer + holes)

--- a/tests/region/conncomp_reg.rs
+++ b/tests/region/conncomp_reg.rs
@@ -2,7 +2,7 @@
 //!
 //! This test corresponds to conncomp_reg.c in the C version.
 //!
-//! C reference: reference/leptonica/prog/conncomp_reg.c
+//! C reference: prog/conncomp_reg.c
 //!
 //! Verifies:
 //! 1. 4-way and 8-way connected component counting

--- a/tests/region/distance_reg.rs
+++ b/tests/region/distance_reg.rs
@@ -7,7 +7,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/distance_reg.c`
+//! C Leptonica: `prog/distance_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/region/grayfill_reg.rs
+++ b/tests/region/grayfill_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/grayfill_reg.c`
+//! C Leptonica: `prog/grayfill_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/region/label_reg.rs
+++ b/tests/region/label_reg.rs
@@ -1,6 +1,6 @@
 //! Labeling regression test
 //!
-//! C reference: reference/leptonica/prog/label_reg.c
+//! C reference: prog/label_reg.c
 //!
 //! Verifies:
 //! 1. 4-connected and 8-connected labeling produce correct dimensions

--- a/tests/region/maze_reg.rs
+++ b/tests/region/maze_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/maze_reg.c`
+//! C Leptonica: `prog/maze_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/region/quadtree_reg.rs
+++ b/tests/region/quadtree_reg.rs
@@ -1,6 +1,6 @@
 //! Quadtree regression test
 //!
-//! C reference: reference/leptonica/prog/quadtree_reg.c
+//! C reference: prog/quadtree_reg.c
 //!
 //! Verifies:
 //! 1. quadtree_regions generates correct box hierarchies (C regTest 0-1)

--- a/tests/region/rectangle_reg.rs
+++ b/tests/region/rectangle_reg.rs
@@ -5,7 +5,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/rectangle_reg.c`
+//! C Leptonica: `prog/rectangle_reg.c`
 
 /// Test finding largest rectangles iteratively in image background.
 ///

--- a/tests/region/smoothedge_reg.rs
+++ b/tests/region/smoothedge_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/smoothedge_reg.c`
+//! C Leptonica: `prog/smoothedge_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/region/speckle_reg.rs
+++ b/tests/region/speckle_reg.rs
@@ -6,11 +6,11 @@
 //! Expanded in Phase 5 to implement the full speckle removal pipeline:
 //! background_norm_flex → gamma_trc_masked → threshold → HMT → dilate → subtract
 //!
-//! C version: `reference/leptonica/prog/speckle_reg.c`
+//! C version: `prog/speckle_reg.c`
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/speckle_reg.c`
+//! C Leptonica: `prog/speckle_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/region/splitcomp_reg.rs
+++ b/tests/region/splitcomp_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/splitcomp_reg.c`
+//! C Leptonica: `prog/splitcomp_reg.c`
 
 use crate::common::RegParams;
 use leptonica::region::conncomp::count_conn_comp;

--- a/tests/region/texturefill_reg.rs
+++ b/tests/region/texturefill_reg.rs
@@ -4,7 +4,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/texturefill_reg.c`
+//! C Leptonica: `prog/texturefill_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/region/watershed_reg.rs
+++ b/tests/region/watershed_reg.rs
@@ -1,6 +1,6 @@
 //! Watershed segmentation regression test
 //!
-//! C reference: reference/leptonica/prog/watershed_reg.c
+//! C reference: prog/watershed_reg.c
 //!
 //! Verifies:
 //! 1. Local minima and maxima detection in synthetic images

--- a/tests/transform/affine_reg.rs
+++ b/tests/transform/affine_reg.rs
@@ -1,6 +1,6 @@
 //! Affine transform regression test
 //!
-//! C version: `reference/leptonica/prog/affine_reg.c`
+//! C version: `prog/affine_reg.c`
 //!
 //! Tests affine transforms including invertability and large distortions.
 //!

--- a/tests/transform/alphaxform_reg.rs
+++ b/tests/transform/alphaxform_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/alphaxform_reg.c`
+//! C Leptonica: `prog/alphaxform_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/transform/bilinear_reg.rs
+++ b/tests/transform/bilinear_reg.rs
@@ -1,6 +1,6 @@
 //! Bilinear transform regression test
 //!
-//! C version: `reference/leptonica/prog/bilinear_reg.c`
+//! C version: `prog/bilinear_reg.c`
 //!
 //! Tests bilinear transforms including invertability and large distortions.
 //!

--- a/tests/transform/checkerboard_reg.rs
+++ b/tests/transform/checkerboard_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/checkerboard_reg.c`
+//! C Leptonica: `prog/checkerboard_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/transform/circle_reg.rs
+++ b/tests/transform/circle_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/circle_reg.c`
+//! C Leptonica: `prog/circle_reg.c`
 
 use leptonica::morph::erode_brick;
 use leptonica::region::{ConnectivityType, conncomp::count_conn_comp};

--- a/tests/transform/crop_reg.rs
+++ b/tests/transform/crop_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/crop_reg.c`
+//! C Leptonica: `prog/crop_reg.c`
 
 use crate::common::RegParams;
 use leptonica::Box as LeptBox;

--- a/tests/transform/expand_reg.rs
+++ b/tests/transform/expand_reg.rs
@@ -7,7 +7,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/expand_reg.c`
+//! C Leptonica: `prog/expand_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/transform/multitype_reg.rs
+++ b/tests/transform/multitype_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/multitype_reg.c`
+//! C Leptonica: `prog/multitype_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/transform/projection_reg.rs
+++ b/tests/transform/projection_reg.rs
@@ -8,7 +8,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/projection_reg.c`
+//! C Leptonica: `prog/projection_reg.c`
 
 use crate::common::RegParams;
 use leptonica::StatsRequest;

--- a/tests/transform/projective_reg.rs
+++ b/tests/transform/projective_reg.rs
@@ -1,6 +1,6 @@
 //! Projective transform regression test
 //!
-//! C version: `reference/leptonica/prog/projective_reg.c`
+//! C version: `prog/projective_reg.c`
 //!
 //! Tests projective transforms including invertability and large distortions.
 //!

--- a/tests/transform/rotate1_reg.rs
+++ b/tests/transform/rotate1_reg.rs
@@ -1,6 +1,6 @@
 //! Rotation regression test 1 - basic rotation and flip operations
 //!
-//! C version: `reference/leptonica/prog/rotate1_reg.c`
+//! C version: `prog/rotate1_reg.c`
 //!
 //! Tests basic orthogonal rotation and flip operations:
 //!   1. Four successive 90-degree rotations = identity (all depths)

--- a/tests/transform/rotate2_reg.rs
+++ b/tests/transform/rotate2_reg.rs
@@ -1,6 +1,6 @@
 //! Rotation regression test 2 - advanced arbitrary angle rotation
 //!
-//! C version: `reference/leptonica/prog/rotate2_reg.c`
+//! C version: `prog/rotate2_reg.c`
 //!
 //! Tests various rotation methods (shear, sampling, area-map) at different
 //! angles, comparing results across methods and validating that rotated images

--- a/tests/transform/rotateorth_reg.rs
+++ b/tests/transform/rotateorth_reg.rs
@@ -1,6 +1,6 @@
 //! Orthogonal rotation regression test
 //!
-//! C version: `reference/leptonica/prog/rotateorth_reg.c`
+//! C version: `prog/rotateorth_reg.c`
 //!
 //! Tests orthogonal rotation operations across all bit depths:
 //!   1. Four successive 90-degree rotations = identity

--- a/tests/transform/scale_reg.rs
+++ b/tests/transform/scale_reg.rs
@@ -1,6 +1,6 @@
 //! Scale regression test
 //!
-//! C version: `reference/leptonica/prog/scale_reg.c`
+//! C version: `prog/scale_reg.c`
 //!
 //! Tests various scaling operations:
 //!   1. Scale up by 2x — dimensions double

--- a/tests/transform/shear1_reg.rs
+++ b/tests/transform/shear1_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/shear1_reg.c`
+//! C Leptonica: `prog/shear1_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/transform/shear2_reg.rs
+++ b/tests/transform/shear2_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/shear2_reg.c`
+//! C Leptonica: `prog/shear2_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/transform/smallpix_reg.rs
+++ b/tests/transform/smallpix_reg.rs
@@ -12,7 +12,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/smallpix_reg.c`
+//! C Leptonica: `prog/smallpix_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/transform/subpixel_reg.rs
+++ b/tests/transform/subpixel_reg.rs
@@ -9,7 +9,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/subpixel_reg.c`
+//! C Leptonica: `prog/subpixel_reg.c`
 
 /// Test grayscale-to-subpixel-RGB conversion (C check 0).
 ///

--- a/tests/transform/translate_reg.rs
+++ b/tests/transform/translate_reg.rs
@@ -11,7 +11,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/translate_reg.c`
+//! C Leptonica: `prog/translate_reg.c`
 
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;

--- a/tests/transform/warper_reg.rs
+++ b/tests/transform/warper_reg.rs
@@ -10,7 +10,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/warper_reg.c`
+//! C Leptonica: `prog/warper_reg.c`
 
 use crate::common::RegParams;
 use leptonica::PixelDepth;

--- a/tests/transform/xformbox_reg.rs
+++ b/tests/transform/xformbox_reg.rs
@@ -6,7 +6,7 @@
 //!
 //! # See also
 //!
-//! C Leptonica: `reference/leptonica/prog/xformbox_reg.c`
+//! C Leptonica: `prog/xformbox_reg.c`
 
 use crate::common::RegParams;
 use leptonica::transform::AffineMatrix;


### PR DESCRIPTION
## 概要

移植作業がほぼ完了（関数カバレッジ82%、回帰テスト100%）したため、C版leptonicaのgit submoduleを除去し、リポジトリ構成を簡素化する。

## 変更点

- `reference/leptonica` submoduleと `.gitmodules` を削除
- `.gitignore` に `/reference/` を追加（手動clone後も追跡されない）
- `README.md` / `README.ja.md`: submodule記述をC版公式リポジトリリンクに変更、取得セクション削除
- `CLAUDE.md`: submodule固有のパス・コマンド記述を更新
- `scripts/audit-regression-tests.py`: エラーメッセージを手動clone案内に変更
- テスト・ソースの163箇所コメントから `reference/leptonica/` プレフィックスを一括削除

## テスト

- [x] `cargo check --all-features` 通過
- [x] `cargo test --all-features` 通過
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --all -- --check` 通過
- [x] `markdownlint` 通過
- [x] `.gitignore` が `reference/` を無視することを確認