### PR TITLE
test: add C parity tests for find_baselines and fill_map_holes

### DIFF
--- a/scripts/verify_fillmapholes.c
+++ b/scripts/verify_fillmapholes.c
@@ -1,0 +1,139 @@
+/* Verify Rust fill_map_holes() matches C pixFillMapHoles().
+ *
+ * Mirrors tests/filter/adaptmap_reg.rs adaptmap_reg_fill_map_holes_{weasel,simple}.
+ * Holes are encoded as zero pixels (Rust API convention) and filled with
+ * L_FILL_BLACK so the algorithm input is identical on both sides.
+ *
+ * Build (from reference/leptonica):
+ *   nix-shell -p libpng libjpeg libtiff libwebp giflib zlib openjpeg \
+ *             pkg-config cmake clang \
+ *     --run 'gcc -I src -I build/src scripts/verify_fillmapholes.c \
+ *            -L build/src -llept -lm -o /tmp/verify_fillmapholes'
+ *
+ * Run from the repository root:
+ *   LD_LIBRARY_PATH=reference/leptonica/build/src /tmp/verify_fillmapholes
+ */
+#include "allheaders.h"
+#include <stdio.h>
+
+static int compare_with_rust(const char *c_path, const char *r_path,
+                             const char *desc) {
+    PIX *c_pix = pixRead(c_path);
+    PIX *r_pix = pixRead(r_path);
+    if (!c_pix || !r_pix) {
+        printf("%-30s CANNOT READ (c=%p r=%p)\n", desc,
+               (void *)c_pix, (void *)r_pix);
+        if (c_pix) pixDestroy(&c_pix);
+        if (r_pix) pixDestroy(&r_pix);
+        return 1;
+    }
+
+    l_int32 w = pixGetWidth(c_pix), h = pixGetHeight(c_pix);
+    l_int32 d = pixGetDepth(c_pix);
+    l_int32 rw = pixGetWidth(r_pix), rh = pixGetHeight(r_pix);
+    l_int32 rd = pixGetDepth(r_pix);
+
+    int rc = 0;
+    if (w != rw || h != rh || d != rd) {
+        printf("%-30s DIMENSION MISMATCH C=%dx%dx%d R=%dx%dx%d\n",
+               desc, w, h, d, rw, rh, rd);
+        rc = 1;
+    } else {
+        l_int32 same = 0;
+        pixEqual(c_pix, r_pix, &same);
+        if (same) {
+            printf("%-30s %dx%dx%d  IDENTICAL\n", desc, w, h, d);
+        } else {
+            l_float32 fract = 0.0f, ave = 0.0f;
+            pixGetDifferenceStats(c_pix, r_pix, 0, 1, &fract, &ave, 0);
+            /* Also compute pixel-level differences manually for max delta. */
+            l_int32 ndiff = 0, maxd = 0;
+            for (l_int32 y = 0; y < h; ++y) {
+                for (l_int32 x = 0; x < w; ++x) {
+                    l_uint32 cv = 0, rv = 0;
+                    pixGetPixel(c_pix, x, y, &cv);
+                    pixGetPixel(r_pix, x, y, &rv);
+                    l_int32 delta = (l_int32)cv - (l_int32)rv;
+                    if (delta < 0) delta = -delta;
+                    if (delta > 0) {
+                        ++ndiff;
+                        if (delta > maxd) maxd = delta;
+                    }
+                }
+            }
+            printf("%-30s %dx%dx%d  DIFFER  fract>=1=%.4f ave=%.3f "
+                   "ndiff=%d maxd=%d\n",
+                   desc, w, h, d, fract, ave, ndiff, maxd);
+            rc = 1;
+        }
+    }
+
+    pixDestroy(&c_pix);
+    pixDestroy(&r_pix);
+    return rc;
+}
+
+/* Reproduce the weasel test from adaptmap_reg.rs (zero-hole convention). */
+static PIX *build_weasel_input(void) {
+    PIX *pix = pixRead("reference/leptonica/prog/weasel8.png");
+    if (!pix) {
+        fprintf(stderr, "cannot load weasel8.png\n");
+        return NULL;
+    }
+    pixGammaTRC(pix, pix, 1.0, 0, 200);
+
+    l_int32 w = pixGetWidth(pix), h = pixGetHeight(pix);
+    /* Match Rust hole pattern: set zero strips. */
+    for (l_int32 y = 0; y < h; ++y) {
+        for (l_int32 x = 0; x < 5 && x < w; ++x)  pixSetPixel(pix, x, y, 0);
+        for (l_int32 x = 20; x < 22 && x < w; ++x) pixSetPixel(pix, x, y, 0);
+        for (l_int32 x = 40; x < 43 && x < w; ++x) pixSetPixel(pix, x, y, 0);
+    }
+    for (l_int32 y = 0; y < 3 && y < h; ++y)
+        for (l_int32 x = 0; x < w; ++x) pixSetPixel(pix, x, y, 0);
+    for (l_int32 y = 15; y < 18 && y < h; ++y)
+        for (l_int32 x = 0; x < w; ++x) pixSetPixel(pix, x, y, 0);
+    for (l_int32 y = 35; y < 37 && y < h; ++y)
+        for (l_int32 x = 0; x < w; ++x) pixSetPixel(pix, x, y, 0);
+
+    return pix;
+}
+
+int main(void) {
+    setLeptDebugOK(1);
+
+    /* === weasel === */
+    PIX *pix_w = build_weasel_input();
+    if (!pix_w) return 1;
+    /* Snapshot the input before fill so we can isolate gamma+hole vs algorithm. */
+    pixWrite("/tmp/c_fillmapholes_weasel_input.png", pix_w, IFF_PNG);
+    l_int32 w = pixGetWidth(pix_w), h = pixGetHeight(pix_w);
+    if (pixFillMapHoles(pix_w, w, h, L_FILL_BLACK) != 0) {
+        fprintf(stderr, "pixFillMapHoles failed (weasel)\n");
+        pixDestroy(&pix_w);
+        return 1;
+    }
+    pixWrite("/tmp/c_fillmapholes_weasel.png", pix_w, IFF_PNG);
+    pixDestroy(&pix_w);
+
+    /* === 3x3 simple === */
+    PIX *pix_s = pixCreate(3, 3, 8);
+    pixSetPixel(pix_s, 1, 0, 128);
+    if (pixFillMapHoles(pix_s, 3, 3, L_FILL_BLACK) != 0) {
+        fprintf(stderr, "pixFillMapHoles failed (simple)\n");
+        pixDestroy(&pix_s);
+        return 1;
+    }
+    pixWrite("/tmp/c_fillmapholes_simple.png", pix_s, IFF_PNG);
+    pixDestroy(&pix_s);
+
+    /* === Compare === */
+    int rc = 0;
+    rc |= compare_with_rust("/tmp/c_fillmapholes_weasel.png",
+                            "tests/golden/adaptmap_fill_holes_weasel_golden.04.png",
+                            "fill_map_holes weasel");
+    rc |= compare_with_rust("/tmp/c_fillmapholes_simple.png",
+                            "tests/golden/adaptmap_fill_holes_simple_golden.06.png",
+                            "fill_map_holes simple 3x3");
+    return rc;
+}

--- a/scripts/verify_fillmapholes.c
+++ b/scripts/verify_fillmapholes.c
@@ -4,14 +4,28 @@
  * Holes are encoded as zero pixels (Rust API convention) and filled with
  * L_FILL_BLACK so the algorithm input is identical on both sides.
  *
- * Build (from reference/leptonica):
+ * Prerequisites:
+ *   1. Build C reference (from repo root):
+ *      cd reference/leptonica && nix-shell -p libpng libjpeg libtiff libwebp \
+ *        giflib zlib openjpeg pkg-config cmake clang \
+ *        --run 'mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release \
+ *               -DBUILD_PROG=ON && cmake --build . -j$(nproc)'
+ *   2. Generate Rust regout artifacts that this script reads:
+ *      cargo test --test filter adaptmap_reg_fill_map_holes
+ *      (writes tests/regout/adaptmap_fill_holes_{weasel.04,simple.06}.png)
+ *
+ * Build (from repo root):
  *   nix-shell -p libpng libjpeg libtiff libwebp giflib zlib openjpeg \
- *             pkg-config cmake clang \
- *     --run 'gcc -I src -I build/src scripts/verify_fillmapholes.c \
- *            -L build/src -llept -lm -o /tmp/verify_fillmapholes'
+ *             pkg-config gcc \
+ *     --run 'gcc -I reference/leptonica/src -I reference/leptonica/build/src \
+ *            scripts/verify_fillmapholes.c \
+ *            reference/leptonica/build/src/libleptonica.a \
+ *            $(pkg-config --libs libpng libjpeg libtiff-4 libwebp libopenjp2 zlib) \
+ *            -lwebpmux -lwebpdemux -lgif -lm \
+ *            -o /tmp/verify_fillmapholes'
  *
  * Run from the repository root:
- *   LD_LIBRARY_PATH=reference/leptonica/build/src /tmp/verify_fillmapholes
+ *   /tmp/verify_fillmapholes
  */
 #include "allheaders.h"
 #include <stdio.h>
@@ -130,10 +144,10 @@ int main(void) {
     /* === Compare === */
     int rc = 0;
     rc |= compare_with_rust("/tmp/c_fillmapholes_weasel.png",
-                            "tests/golden/adaptmap_fill_holes_weasel_golden.04.png",
+                            "tests/regout/adaptmap_fill_holes_weasel.04.png",
                             "fill_map_holes weasel");
     rc |= compare_with_rust("/tmp/c_fillmapholes_simple.png",
-                            "tests/golden/adaptmap_fill_holes_simple_golden.06.png",
+                            "tests/regout/adaptmap_fill_holes_simple.06.png",
                             "fill_map_holes simple 3x3");
     return rc;
 }

--- a/scripts/verify_findbaselines.c
+++ b/scripts/verify_findbaselines.c
@@ -1,8 +1,12 @@
 /* Verify Rust find_baselines() matches C pixFindBaselines() / Gen.
  *
  * Mirrors tests/recog/baseline_reg.rs test_3/11/13/15.
- * Writes per-image y-coordinate lists to /tmp/c_baseline_<name>.txt so a Rust
- * test can compare against /tmp/r_baseline_<name>.txt.
+ * Writes per-image y-coordinate lists to /tmp/c_baseline_<name>.txt.
+ * The values from these files are then transcribed into
+ * tests/recog/baseline_c_parity.rs as `const C_*: &[i32]` arrays — the
+ * Rust tests assert against those embedded constants rather than reading
+ * the .txt files at test time, so the C build is only needed when
+ * refreshing the constants.
  *
  * Build (from repo root):
  *   nix-shell -p libpng libjpeg libtiff libwebp giflib zlib openjpeg \

--- a/scripts/verify_findbaselines.c
+++ b/scripts/verify_findbaselines.c
@@ -1,0 +1,74 @@
+/* Verify Rust find_baselines() matches C pixFindBaselines() / Gen.
+ *
+ * Mirrors tests/recog/baseline_reg.rs test_3/11/13/15.
+ * Writes per-image y-coordinate lists to /tmp/c_baseline_<name>.txt so a Rust
+ * test can compare against /tmp/r_baseline_<name>.txt.
+ *
+ * Build (from repo root):
+ *   nix-shell -p libpng libjpeg libtiff libwebp giflib zlib openjpeg \
+ *             pkg-config gcc \
+ *     --run 'gcc -I reference/leptonica/src -I reference/leptonica/build/src \
+ *            scripts/verify_findbaselines.c \
+ *            reference/leptonica/build/src/libleptonica.a \
+ *            $(pkg-config --libs libpng libjpeg libtiff-4 libwebp libopenjp2 zlib) \
+ *            -lwebpmux -lwebpdemux -lgif -lm \
+ *            -o /tmp/verify_findbaselines'
+ */
+#include "allheaders.h"
+#include <stdio.h>
+
+static int dump_baselines(const char *img_path, l_int32 minw,
+                          const char *out_path, const char *desc) {
+    PIX *pix = pixRead(img_path);
+    if (!pix) {
+        fprintf(stderr, "%-30s CANNOT READ %s\n", desc, img_path);
+        return 1;
+    }
+    NUMA *na = pixFindBaselinesGen(pix, minw, NULL, NULL);
+    if (!na) {
+        fprintf(stderr, "%-30s pixFindBaselinesGen returned NULL\n", desc);
+        pixDestroy(&pix);
+        return 1;
+    }
+    FILE *fp = fopen(out_path, "w");
+    if (!fp) {
+        fprintf(stderr, "cannot open %s\n", out_path);
+        numaDestroy(&na);
+        pixDestroy(&pix);
+        return 1;
+    }
+    l_int32 n = numaGetCount(na);
+    fprintf(fp, "# %s: pixFindBaselinesGen minw=%d count=%d\n", desc, minw, n);
+    for (l_int32 i = 0; i < n; ++i) {
+        l_int32 y = 0;
+        numaGetIValue(na, i, &y);
+        fprintf(fp, "%d\n", y);
+    }
+    fclose(fp);
+    printf("%-30s wrote %d baselines to %s\n", desc, n, out_path);
+    numaDestroy(&na);
+    pixDestroy(&pix);
+    return 0;
+}
+
+int main(void) {
+    setLeptDebugOK(1);
+    int rc = 0;
+    /* test_3: keystone.png - C pixFindBaselines uses default minw=80. */
+    rc |= dump_baselines("reference/leptonica/prog/keystone.png", 80,
+                         "/tmp/c_baseline_keystone.txt",
+                         "find_baselines keystone");
+    /* test_11: baseline1.png - default minw=80. */
+    rc |= dump_baselines("reference/leptonica/prog/baseline1.png", 80,
+                         "/tmp/c_baseline_short_textblock.txt",
+                         "find_baselines short_textblock");
+    /* test_13: baseline2.tif - minw=30. */
+    rc |= dump_baselines("reference/leptonica/prog/baseline2.tif", 30,
+                         "/tmp/c_baseline_short_lines.txt",
+                         "find_baselines short_lines");
+    /* test_15: baseline3.tif - minw=30. */
+    rc |= dump_baselines("reference/leptonica/prog/baseline3.tif", 30,
+                         "/tmp/c_baseline_more_short_lines.txt",
+                         "find_baselines more_short_lines");
+    return rc;
+}

--- a/tests/filter/adaptmap_c_parity.rs
+++ b/tests/filter/adaptmap_c_parity.rs
@@ -41,10 +41,15 @@ fn c_parity_simple_3x3() {
     );
 }
 
-/// weasel8 case: Rust algorithm differs from C; this test pins down the
-/// CURRENT divergence so any future bit-equivalence work surfaces here.
+/// weasel8 case: placeholder setup that runs the same input as the C side.
+/// Currently `#[ignore]` because Rust's algorithm differs from C. No
+/// assertion runs in this state — the test exists so that, once
+/// `fill_map_holes_inner` is reimplemented to match C's column-major
+/// algorithm, this can be re-enabled with a bit-equivalence assertion
+/// against `/tmp/c_fillmapholes_weasel.png` (produced by
+/// `scripts/verify_fillmapholes.c`).
 ///
-/// `scripts/verify_fillmapholes.c` reports against the same 82x73 input:
+/// `scripts/verify_fillmapholes.c` last reported on the same 82x73 input:
 ///   * IDENTICAL count: 5550 / 5986 pixels (92.7%)
 ///   * ndiff = 436 (7.3%)
 ///   * max channel delta = 233

--- a/tests/filter/adaptmap_c_parity.rs
+++ b/tests/filter/adaptmap_c_parity.rs
@@ -1,0 +1,95 @@
+//! C-parity test for `fill_map_holes`.
+//!
+//! Reference values derived from C leptonica master (commit f7082ecd) by
+//! running `scripts/verify_fillmapholes.c`.
+//!
+//! The simple 3x3 case is bit-equivalent. The weasel8 case is NOT —
+//! Rust's algorithm (4-neighbor diffusion in two passes) differs structurally
+//! from C's column-major replication, producing ~7.3% pixel divergence on
+//! the same input. The C bug fix in upstream commit 737f969e (loop bound
+//! `j < w` → `j < nx`) addressed that column-replication path, which Rust
+//! does not use, so the bug is structurally absent from the Rust port.
+//!
+//! Bringing weasel8 into bit-equivalence would require reimplementing
+//! `fill_map_holes_inner` to match C's column-then-row strategy. That is
+//! tracked as a separate decision: see `docs/plans/` if/when scoped.
+use crate::common::load_test_image;
+use leptonica::filter::adaptmap::fill_map_holes;
+use leptonica::filter::enhance::gamma_trc_masked;
+use leptonica::{Pix, PixMut, PixelDepth};
+
+/// 3x3 case from C `pixFillMapHoles(pix, 3, 3, L_FILL_BLACK)`:
+/// input has pixel (1,0)=128 and zeros elsewhere; output fills entirely with 128.
+#[test]
+fn c_parity_simple_3x3() {
+    let mut input = PixMut::new(3, 3, PixelDepth::Bit8).expect("create 3x3");
+    input.set_pixel(1, 0, 128).expect("set pixel");
+    let pix: Pix = input.into();
+
+    let filled = fill_map_holes(&pix, 3, 3).expect("fill_map_holes 3x3");
+
+    let mut grid = [[0u32; 3]; 3];
+    for y in 0..3 {
+        for x in 0..3 {
+            grid[y as usize][x as usize] = filled.get_pixel(x, y).expect("get_pixel");
+        }
+    }
+    assert_eq!(
+        grid,
+        [[128, 128, 128], [128, 128, 128], [128, 128, 128]],
+        "Rust 3x3 output must match C version exactly"
+    );
+}
+
+/// weasel8 case: Rust algorithm differs from C; this test pins down the
+/// CURRENT divergence so any future bit-equivalence work surfaces here.
+///
+/// `scripts/verify_fillmapholes.c` reports against the same 82x73 input:
+///   * IDENTICAL count: 5550 / 5986 pixels (92.7%)
+///   * ndiff = 436 (7.3%)
+///   * max channel delta = 233
+///
+/// Mirrors the input setup in
+/// `tests/filter/adaptmap_reg.rs::adaptmap_reg_fill_map_holes_weasel`.
+#[test]
+#[ignore = "Rust fill_map_holes uses 4-neighbor diffusion; bit-equivalence with \
+            C column-then-row replication requires reimplementation"]
+fn c_parity_weasel_known_divergence() {
+    let pix = load_test_image("weasel8.png").expect("load weasel8.png");
+    let darkened = gamma_trc_masked(&pix, None, 1.0, 0, 200).expect("darken");
+    let w = darkened.width();
+    let h = darkened.height();
+    let mut m = darkened.try_into_mut().expect("mut");
+    for y in 0..h {
+        for x in 0..5u32.min(w) {
+            m.set_pixel_unchecked(x, y, 0);
+        }
+        for x in 20u32..22u32.min(w) {
+            m.set_pixel_unchecked(x, y, 0);
+        }
+        for x in 40u32..43u32.min(w) {
+            m.set_pixel_unchecked(x, y, 0);
+        }
+    }
+    for y in 0..3u32.min(h) {
+        for x in 0..w {
+            m.set_pixel_unchecked(x, y, 0);
+        }
+    }
+    for y in 15u32..18u32.min(h) {
+        for x in 0..w {
+            m.set_pixel_unchecked(x, y, 0);
+        }
+    }
+    for y in 35u32..37u32.min(h) {
+        for x in 0..w {
+            m.set_pixel_unchecked(x, y, 0);
+        }
+    }
+    let pix_with_holes: Pix = m.into();
+    let _filled = fill_map_holes(&pix_with_holes, w, h).expect("fill weasel");
+    // No assertion: this test is a placeholder while Rust implementation
+    // diverges from C. Re-enable bit-equivalence assertion (against
+    // /tmp/c_fillmapholes_weasel.png produced by verify_fillmapholes.c) once
+    // the algorithm is aligned.
+}

--- a/tests/filter/main.rs
+++ b/tests/filter/main.rs
@@ -3,6 +3,7 @@ mod common;
 
 mod adaptmap_advanced_reg;
 mod adaptmap_bg_reg;
+mod adaptmap_c_parity;
 mod adaptmap_morph_reg;
 mod adaptmap_reg;
 mod adaptnorm_reg;

--- a/tests/recog/baseline_c_parity.rs
+++ b/tests/recog/baseline_c_parity.rs
@@ -1,0 +1,98 @@
+//! C-parity test for `find_baselines`.
+//!
+//! Reference values derived from C leptonica master (commit f7082ecd) by
+//! running `scripts/verify_findbaselines.c` against the same input images.
+//! These tests assert exact y-coordinate equivalence with C, except for
+//! `keystone.png` where Rust currently lacks the second-stage "short
+//! baseline removal" filter (`pixFindBaselinesGen` connected-component pass).
+//!
+//! See also `tests/recog/baseline_reg.rs` (count-only regression tests).
+use crate::common::load_test_image;
+use leptonica::recog::baseline::{BaselineOptions, find_baselines};
+
+/// C version y-coordinates for `baseline1.png` with default minw=80.
+/// Source: scripts/verify_findbaselines.c → /tmp/c_baseline_short_textblock.txt
+const C_SHORT_TEXTBLOCK: &[i32] = &[1874, 1914];
+
+/// C version y-coordinates for `baseline2.tif` with minw=30.
+const C_SHORT_LINES: &[i32] = &[
+    564, 614, 664, 714, 763, 813, 863, 913, 963, 1012, 1062, 1112, 1162, 1212, 1262, 1311, 1361,
+    1411, 1461, 1511, 1560, 1610, 1660, 1710, 1760, 1810, 1859, 1909, 1959,
+];
+
+/// C version y-coordinates for `baseline3.tif` with minw=30.
+const C_MORE_SHORT_LINES: &[i32] = &[
+    177, 255, 300, 340, 384, 426, 473, 518, 562, 604, 650, 694, 740, 779, 825, 869, 914, 955, 999,
+    1044, 1088, 1134, 1178, 1221, 1267, 1309, 1355, 1397, 1442, 1484, 1527, 1572, 1616, 1660, 1703,
+    1747, 1791, 1834, 1878, 1922,
+];
+
+/// C version y-coordinates for `keystone.png` with default minw=80
+/// (after pixFindBaselinesGen short-baseline filter).
+const C_KEYSTONE: &[i32] = &[
+    63, 166, 247, 308, 394, 471, 543, 621, 684, 759, 832, 919, 997, 1064, 1147, 1228, 1364, 1431,
+    1525, 1712,
+];
+
+/// y-coordinates that C's pixFindBaselinesGen filters out as "short
+/// baselines" but Rust currently retains (second-stage filter unimplemented).
+const KEYSTONE_RUST_EXTRA: &[i32] = &[1277, 1488, 1574, 1651];
+
+fn baselines(img: &str, minw: u32) -> Vec<i32> {
+    let pix = load_test_image(img).unwrap_or_else(|e| panic!("load {}: {}", img, e));
+    let opts = BaselineOptions::default().with_min_block_width(minw);
+    find_baselines(&pix, &opts)
+        .unwrap_or_else(|e| panic!("find_baselines: {}", e))
+        .baselines
+}
+
+#[test]
+fn c_parity_short_textblock() {
+    let rust = baselines("baseline1.png", 80);
+    assert_eq!(
+        rust, C_SHORT_TEXTBLOCK,
+        "Rust must match C version y-coords for baseline1.png"
+    );
+}
+
+#[test]
+fn c_parity_short_lines() {
+    let rust = baselines("baseline2.tif", 30);
+    assert_eq!(
+        rust, C_SHORT_LINES,
+        "Rust must match C version y-coords for baseline2.tif"
+    );
+}
+
+#[test]
+fn c_parity_more_short_lines() {
+    let rust = baselines("baseline3.tif", 30);
+    assert_eq!(
+        rust, C_MORE_SHORT_LINES,
+        "Rust must match C version y-coords for baseline3.tif"
+    );
+}
+
+/// keystone.png: Rust returns C's set plus 4 short baselines that C's
+/// second-stage `pixFindBaselinesGen` filter removes. Once that filter
+/// lands in Rust this test should match `C_KEYSTONE` exactly.
+#[test]
+fn c_parity_keystone_with_known_divergence() {
+    let rust = baselines("keystone.png", 80);
+
+    let mut expected: Vec<i32> = C_KEYSTONE
+        .iter()
+        .chain(KEYSTONE_RUST_EXTRA)
+        .copied()
+        .collect();
+    expected.sort();
+    let mut actual = rust.clone();
+    actual.sort();
+
+    assert_eq!(
+        actual, expected,
+        "Rust keystone baselines must equal C set ∪ known-extra short baselines.\n\
+         If this fails, either find_baselines diverged further or short-baseline\n\
+         filter was implemented (then update C_KEYSTONE expectation)."
+    );
+}

--- a/tests/recog/main.rs
+++ b/tests/recog/main.rs
@@ -1,6 +1,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+mod baseline_c_parity;
 mod baseline_reg;
 mod classapp_reg;
 mod correlscore_reg;


### PR DESCRIPTION
## Summary

C版leptonica最新masterとのbit/座標同等性を検証するインフラ＋Rust統合テストを追加。`fill_map_holes` のC版アルゴリズム移植に向けた前準備。

- `scripts/verify_*.c` — C側で同じ入力に対して `pixFillMapHoles` / `pixFindBaselinesGen` を実行する検証ヘルパー
- `tests/recog/baseline_c_parity.rs` — find_baselines のy座標を C版と比較する4テスト（全てPASS）
- `tests/filter/adaptmap_c_parity.rs` — fill_map_holes の同等性テスト（simple 3x3 はPASS、weasel は構造的差異により `#[ignore]` で文書化）

## 検証結果

### `find_baselines`

| 入力 | C版 | Rust | y座標 |
|---|---|---|---|
| baseline1.png | 2 | 2 | bit-identical |
| baseline2.tif | 29 | 29 | bit-identical |
| baseline3.tif | 40 | 40 | bit-identical |
| keystone.png | 20 | 24 | C=Rust ∩ + 4本（C側「短baseline除去」未実装による既知差） |

### `fill_map_holes`

| ケース | 結果 |
|---|---|
| 3x3 simple | bit-identical |
| weasel8 (82×73) | 入力同一だが ndiff=436/5986 (7.3%) maxd=233 → 別アルゴリズム（4近傍 vs 列優先）による構造的差 |

## Test plan

- [x] `cargo test --test recog c_parity` — 4 passed
- [x] `cargo test --test filter c_parity` — 1 passed, 1 ignored (intentional)
- [x] `cargo test --test filter && cargo test --test recog` — 既存テストもregressionなし
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Follow-up

`c_parity_weasel_known_divergence` の `#[ignore]` 解除は別PRで対応:
1. `docs/plans/028_*.md` 策定
2. `fill_map_holes_inner` をC版列優先アルゴリズムに書き直し
3. golden_manifest 再生成 + テスト再有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)