### PR TITLE
refactor: address clippy 1.95 lints (manual_checked_ops + others)

### DIFF
--- a/src/color/analysis.rs
+++ b/src/color/analysis.rs
@@ -102,7 +102,7 @@ fn analyze_grayscale(pix: &Pix) -> ColorResult<ColorStats> {
         .filter(|(_, c)| **c > 0)
         .map(|(i, c)| (i, *c))
         .collect();
-    indexed.sort_by(|a, b| b.1.cmp(&a.1));
+    indexed.sort_by_key(|a| std::cmp::Reverse(a.1));
 
     let dominant_colors: Vec<(u8, u8, u8, u32)> = indexed
         .iter()
@@ -176,7 +176,7 @@ fn analyze_color(pix: &Pix) -> ColorResult<ColorStats> {
 
     // Find dominant colors
     let mut color_vec: Vec<(u32, u32)> = color_counts.into_iter().collect();
-    color_vec.sort_by(|a, b| b.1.cmp(&a.1));
+    color_vec.sort_by_key(|a| std::cmp::Reverse(a.1));
 
     let dominant_colors: Vec<(u8, u8, u8, u32)> = color_vec
         .iter()

--- a/src/color/colorfill.rs
+++ b/src/color/colorfill.rs
@@ -625,10 +625,11 @@ pub fn color_content_by_location(
             // Map color content to an output value
             let val = if max_c < min_max {
                 0u32
-            } else if max_diff == 0 {
-                if diff > 0 { 255 } else { 0 }
             } else {
-                ((diff * 255) / max_diff).min(255)
+                (diff * 255)
+                    .checked_div(max_diff)
+                    .map(|v| v.min(255))
+                    .unwrap_or(if diff > 0 { 255 } else { 0 })
             };
 
             for y in y0..y1 {

--- a/src/color/quantize.rs
+++ b/src/color/quantize.rs
@@ -514,10 +514,11 @@ impl Octree {
 
     fn build_palette_impl(node: &mut OctreeNode, palette: &mut Vec<(u8, u8, u8)>) {
         if node.is_leaf {
-            if node.pixel_count > 0 {
-                let r = (node.red / node.pixel_count) as u8;
-                let g = (node.green / node.pixel_count) as u8;
-                let b = (node.blue / node.pixel_count) as u8;
+            if let Some(count) = std::num::NonZeroU64::new(node.pixel_count) {
+                let count = count.get();
+                let r = (node.red / count) as u8;
+                let g = (node.green / count) as u8;
+                let b = (node.blue / count) as u8;
                 node.palette_index = palette.len();
                 palette.push((r, g, b));
             }
@@ -666,7 +667,7 @@ pub fn octree_quant_by_population(pix: &Pix, level: u32) -> ColorResult<Pix> {
         .filter(|(_, c)| **c > 0)
         .map(|(i, c)| (i, *c))
         .collect();
-    occupied.sort_by(|a, b| b.1.cmp(&a.1));
+    occupied.sort_by_key(|a| std::cmp::Reverse(a.1));
 
     // Limit to 256 colors
     let ncolors = occupied.len().min(256);
@@ -1346,10 +1347,11 @@ pub fn octcube_quant_mixed_with_gray(
 
     // Average the colors in each occupied octcube and update the colormap
     for i in 0..size as usize {
-        if carray[i] > 0 {
-            let r = (rarray[i] / carray[i]) as u8;
-            let g = (garray[i] / carray[i]) as u8;
-            let b = (barray[i] / carray[i]) as u8;
+        if let Some(count) = std::num::NonZeroU64::new(carray[i]) {
+            let count = count.get();
+            let r = (rarray[i] / count) as u8;
+            let g = (garray[i] / count) as u8;
+            let b = (barray[i] / count) as u8;
             if let Some(entry) = colormap.get_mut(i) {
                 entry.red = r;
                 entry.green = g;
@@ -1442,10 +1444,11 @@ pub fn few_colors_octcube_quant1(pix: &Pix, level: u32) -> ColorResult<Pix> {
     // Build colormap from averaged colors
     let mut colormap = PixColormap::new(out_depth_bits)?;
     for i in 0..size as usize {
-        if carray[i] > 0 {
-            let r = (rarray[i] / carray[i]) as u8;
-            let g = (garray[i] / carray[i]) as u8;
-            let b = (barray[i] / carray[i]) as u8;
+        if let Some(count) = std::num::NonZeroU64::new(carray[i]) {
+            let count = count.get();
+            let r = (rarray[i] / count) as u8;
+            let g = (garray[i] / count) as u8;
+            let b = (barray[i] / count) as u8;
             colormap.add_rgb(r, g, b)?;
         }
     }

--- a/src/color/segment.rs
+++ b/src/color/segment.rs
@@ -400,8 +400,8 @@ fn cluster_try(pix: &Pix, max_dist: u32, max_colors: u32) -> Result<Pix, Cluster
     let mut colormap = PixColormap::new(8).map_err(|e| ClusterError::Other(e.into()))?;
 
     for k in 0..rmap.len() {
-        let count = counts[k];
-        if count > 0 {
+        if let Some(count) = std::num::NonZeroU64::new(counts[k]) {
+            let count = count.get();
             let avg_r = (rsum[k] / count) as u8;
             let avg_g = (gsum[k] / count) as u8;
             let avg_b = (bsum[k] / count) as u8;

--- a/src/core/box_/sort.rs
+++ b/src/core/box_/sort.rs
@@ -179,7 +179,7 @@ impl Boxa {
 
         // Sort boxes in each row horizontally (by x)
         for boxa_row in baa.boxas_mut() {
-            boxa_row.boxes_mut().sort_by(|a, b| a.x.cmp(&b.x));
+            boxa_row.boxes_mut().sort_by_key(|a| a.x);
         }
 
         // Sort rows vertically (by y of first box)

--- a/src/core/pix/convert.rs
+++ b/src/core/pix/convert.rs
@@ -2378,13 +2378,11 @@ impl Pix {
                 sum += gray.get_pixel_unchecked(x, y) as u64;
             }
         }
-        let threshold = if total > 0 {
-            // Use mean as threshold, biased slightly toward binarization quality
-            let mean = sum / total;
-            mean.clamp(1, 254) as u32
-        } else {
-            128
-        };
+        // Use mean as threshold, biased slightly toward binarization quality.
+        let threshold = sum
+            .checked_div(total)
+            .map(|mean| mean.clamp(1, 254) as u32)
+            .unwrap_or(128);
 
         let result = Pix::new(w, h, PixelDepth::Bit1)?;
         let mut rm = result.try_into_mut().unwrap();

--- a/src/core/pix/histogram.rs
+++ b/src/core/pix/histogram.rs
@@ -1499,11 +1499,12 @@ impl Pix {
 
         let mut colors = Vec::with_capacity(nbins as usize);
         for i in 0..nbins as usize {
-            if counts[i] > 0 {
+            if let Some(count) = std::num::NonZeroU64::new(counts[i]) {
+                let count = count.get();
                 colors.push(pixel::compose_rgb(
-                    (r_sum[i] / counts[i]) as u8,
-                    (g_sum[i] / counts[i]) as u8,
-                    (b_sum[i] / counts[i]) as u8,
+                    (r_sum[i] / count) as u8,
+                    (g_sum[i] / count) as u8,
+                    (b_sum[i] / count) as u8,
                 ));
             } else {
                 colors.push(0);
@@ -1561,11 +1562,12 @@ impl Pix {
 
         let mut colors = Vec::with_capacity(nbins);
         for i in 0..nbins {
-            if counts[i] > 0 {
+            if let Some(count) = std::num::NonZeroU64::new(counts[i]) {
+                let count = count.get();
                 colors.push(pixel::compose_rgb(
-                    (r_sum[i] / counts[i]) as u8,
-                    (g_sum[i] / counts[i]) as u8,
-                    (b_sum[i] / counts[i]) as u8,
+                    (r_sum[i] / count) as u8,
+                    (g_sum[i] / count) as u8,
+                    (b_sum[i] / count) as u8,
                 ));
             } else {
                 colors.push(0);
@@ -1671,15 +1673,16 @@ impl Pix {
                     }
 
                     for b_idx in 0..nbins {
-                        let color = if counts[b_idx as usize] > 0 {
-                            pixel::compose_rgb(
-                                (r_sum[b_idx as usize] / counts[b_idx as usize]) as u8,
-                                (g_sum[b_idx as usize] / counts[b_idx as usize]) as u8,
-                                (b_sum[b_idx as usize] / counts[b_idx as usize]) as u8,
-                            )
-                        } else {
-                            0
-                        };
+                        let color = std::num::NonZeroU64::new(counts[b_idx as usize])
+                            .map(|count| {
+                                let count = count.get();
+                                pixel::compose_rgb(
+                                    (r_sum[b_idx as usize] / count) as u8,
+                                    (g_sum[b_idx as usize] / count) as u8,
+                                    (b_sum[b_idx as usize] / count) as u8,
+                                )
+                            })
+                            .unwrap_or(0);
                         let out_y = s * nbins + b_idx;
                         if out_y < out_h {
                             for x in 0..w {
@@ -1722,15 +1725,16 @@ impl Pix {
                     }
 
                     for b_idx in 0..nbins {
-                        let color = if counts[b_idx as usize] > 0 {
-                            pixel::compose_rgb(
-                                (r_sum[b_idx as usize] / counts[b_idx as usize]) as u8,
-                                (g_sum[b_idx as usize] / counts[b_idx as usize]) as u8,
-                                (b_sum[b_idx as usize] / counts[b_idx as usize]) as u8,
-                            )
-                        } else {
-                            0
-                        };
+                        let color = std::num::NonZeroU64::new(counts[b_idx as usize])
+                            .map(|count| {
+                                let count = count.get();
+                                pixel::compose_rgb(
+                                    (r_sum[b_idx as usize] / count) as u8,
+                                    (g_sum[b_idx as usize] / count) as u8,
+                                    (b_sum[b_idx as usize] / count) as u8,
+                                )
+                            })
+                            .unwrap_or(0);
                         let out_x = s * nbins + b_idx;
                         if out_x < out_w {
                             for y in 0..h {

--- a/src/core/pix/mask.rs
+++ b/src/core/pix/mask.rs
@@ -451,7 +451,8 @@ impl Pix {
                             count += 1;
                         }
                     }
-                    if count > 0 {
+                    if let Some(count) = std::num::NonZeroU32::new(count) {
+                        let count = count.get();
                         let avg = crate::core::pixel::compose_rgb(
                             (r_sum / count) as u8,
                             (g_sum / count) as u8,
@@ -486,8 +487,8 @@ impl Pix {
                             count += 1;
                         }
                     }
-                    if count > 0 {
-                        rm.set_pixel_unchecked(dx, dy, sum / count);
+                    if let Some(avg) = sum.checked_div(count) {
+                        rm.set_pixel_unchecked(dx, dy, avg);
                     }
                 }
             }

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -891,11 +891,8 @@ fn get_inv_background_map_inner(
     for y in 0..h {
         for x in 0..w {
             let val = smoothed.get_pixel_unchecked(x, y);
-            let factor = if val > 0 {
-                (256 * bg_val) / val
-            } else {
-                bg_val / 2 // fallback for zero values
-            };
+            // Fallback for zero values: bg_val / 2.
+            let factor = (256 * bg_val).checked_div(val).unwrap_or(bg_val / 2);
             // Store as 32-bit value (16-bit factor in 32bpp Pix for convenience)
             out_mut.set_pixel_unchecked(x, y, factor.min(65535));
         }

--- a/src/recog/baseline.rs
+++ b/src/recog/baseline.rs
@@ -696,7 +696,7 @@ fn filter_baselines(
     let mut filtered_baselines = Vec::new();
     let mut filtered_endpoints = Vec::new();
 
-    for (baseline, endpoint) in baselines.into_iter().zip(endpoints.into_iter()) {
+    for (baseline, endpoint) in baselines.into_iter().zip(endpoints) {
         if let Some(ep) = endpoint {
             filtered_baselines.push(baseline);
             filtered_endpoints.push(ep);

--- a/src/recog/jbclass/classify.rs
+++ b/src/recog/jbclass/classify.rs
@@ -294,7 +294,7 @@ impl JbClasser {
         let mut chars = Vec::new();
         let mut char_boxes = Vec::new();
 
-        for (comp, pix_box) in comps.into_iter().zip(boxes.into_iter()) {
+        for (comp, pix_box) in comps.into_iter().zip(boxes) {
             // Filter out very small or very large components
             let area = count_fg_pixels(&comp)?;
             let box_area = pix_box.w * pix_box.h;

--- a/src/recog/recog/ident.rs
+++ b/src/recog/recog/ident.rs
@@ -723,11 +723,9 @@ impl Recog {
             .map(|((s, t), b)| (*s, t, b))
         {
             match (&mut current, prev_box) {
-                (None, _) => {
-                    if score >= score_thresh {
-                        current = Some(text.clone());
-                        prev_box = Some(bx);
-                    }
+                (None, _) if score >= score_thresh => {
+                    current = Some(text.clone());
+                    prev_box = Some(bx);
                 }
                 (Some(cur), Some(pb)) => {
                     let h_sep = bx.x - (pb.x + pb.w);

--- a/src/transform/rotate.rs
+++ b/src/transform/rotate.rs
@@ -1661,11 +1661,7 @@ fn box_blur_gray(pix: &Pix, half_size: u32) -> TransformResult<Pix> {
                     count += 1;
                 }
             }
-            let val = if count > 0 {
-                (sum + count / 2) / count
-            } else {
-                0
-            };
+            let val = (sum + count / 2).checked_div(count).unwrap_or(0);
             out_mut.set_pixel_unchecked(x, y, val.min(255));
         }
     }

--- a/src/transform/scale.rs
+++ b/src/transform/scale.rs
@@ -462,7 +462,7 @@ fn convert_to_8bpp(pix: &Pix) -> TransformResult<Pix> {
         PixelDepth::Bit4 => 15u32,
         _ => 255u32,
     };
-    let scale_factor = if max_val > 0 { 255 / max_val } else { 1 };
+    let scale_factor = 255u32.checked_div(max_val).unwrap_or(1);
     for y in 0..h {
         for x in 0..w {
             let val = pix.get_pixel_unchecked(x, y);


### PR DESCRIPTION
## Summary

Rust 1.95 stable で新たに warn-by-default 化された clippy lint 群が CI (`-D warnings`) を通過しなくなったため修正。挙動変更なし。

- `manual_checked_ops` 15箇所 — `if x > 0 { a / x } else { default }` を `a.checked_div(x).unwrap_or(default)` または `NonZeroU64::new(x)` に置換
- `sort_by_key` 3箇所 — `sort_by(|a, b| b.1.cmp(&a.1))` → `sort_by_key(|a| std::cmp::Reverse(a.1))`
- `into_iter` 2箇所 — `.zip(x.into_iter())` → `.zip(x)`
- `collapsible_if` 1箇所 — match arm 内の `if` を guard 化

PR #293 含め、これらの lint に該当しない PR でも CI が落ちる状況だったため、最優先で本 PR をマージしたい。

## Test plan

- [x] `cargo +1.95 clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo +1.95 fmt --all -- --check` clean
- [x] `cargo +1.95 test --all-features` 全suite PASS（2478+213+450+152+125+104+143+118+121+118 件）
- [x] `cargo +1.93 clippy --all-features --all-targets -- -D warnings` も clean（既存環境互換）
- [x] `git diff` で挙動変更がないことを目視確認

## Note on `NonZeroU64::new` choice

同じ除数で複数回除算する箇所（quantize.rs build_palette_impl の r/g/b 計算など）では `checked_div` の繰り返しよりも `NonZeroU64::new` で divisor を一度シャドウする方が読みやすく、ゼロチェックが型レベルで担保される。単一除算では `checked_div` で十分なのでそちらを優先。

🤖 Generated with [Claude Code](https://claude.com/claude-code)