### PR TITLE
feat(filter): bring background_norm to bit-equivalence with C (plan 029 PR3)

### DIFF
--- a/scripts/verify_apply_inv_bg.c
+++ b/scripts/verify_apply_inv_bg.c
@@ -1,0 +1,85 @@
+/* Verify Rust apply_inv_background_gray_map matches C
+ * pixApplyInvBackgroundGrayMap, and the full pixBackgroundNorm pipeline.
+ *
+ * All intermediate steps run in-memory (16 bpp inv map cannot survive a
+ * PNG roundtrip — leptonica downconverts on read — so we recompute the
+ * bg+inv chain inside this binary).
+ *
+ * Outputs:
+ *   /tmp/c_apply_inv_bg_dreyfus.png       (apply step in isolation, 8 bpp)
+ *   /tmp/c_bg_norm_dreyfus.png            (full pixBackgroundNorm output, 8 bpp)
+ *
+ * Build (from repo root):
+ *   nix-shell -p libpng libjpeg libtiff libwebp giflib zlib openjpeg \
+ *             pkg-config gcc \
+ *     --run 'gcc -I reference/leptonica/src -I reference/leptonica/build/src \
+ *            scripts/verify_apply_inv_bg.c \
+ *            reference/leptonica/build/src/libleptonica.a \
+ *            $(pkg-config --libs libpng libjpeg libtiff-4 libwebp libopenjp2 zlib) \
+ *            -lwebpmux -lwebpdemux -lgif -lm \
+ *            -o /tmp/verify_apply_inv_bg'
+ */
+#include "allheaders.h"
+#include <stdio.h>
+
+static int write_pix(const char *path, PIX *pix, const char *desc) {
+    if (pixWrite(path, pix, IFF_PNG) != 0) {
+        fprintf(stderr, "%-30s pixWrite %s failed\n", desc, path);
+        return 1;
+    }
+    printf("%-30s wrote %dx%dx%d to %s\n", desc,
+           pixGetWidth(pix), pixGetHeight(pix), pixGetDepth(pix), path);
+    return 0;
+}
+
+int main(void) {
+    setLeptDebugOK(1);
+    int rc = 0;
+
+    PIX *pixs = pixRead("tests/data/images/dreyfus8.png");
+    PIX *gray = pixGetColormap(pixs)
+        ? pixRemoveColormap(pixs, REMOVE_CMAP_TO_GRAYSCALE)
+        : pixClone(pixs);
+    if (!gray) {
+        fprintf(stderr, "could not load gray\n");
+        return 1;
+    }
+
+    /* Apply step: bg_map (8 bpp) -> inv_map (16 bpp) -> apply.
+     * Use the same smooth sizes as Rust BackgroundNormOptions::default(),
+     * which mirrors C DefaultXSmoothSize=2, DefaultYSmoothSize=1. */
+    PIX *bg_map = NULL;
+    if (pixGetBackgroundGrayMap(gray, NULL, 10, 15, 60, 40, &bg_map) != 0) {
+        fprintf(stderr, "pixGetBackgroundGrayMap failed\n");
+        return 1;
+    }
+    PIX *inv = pixGetInvBackgroundMap(bg_map, 200, 2, 1);
+    if (!inv) {
+        fprintf(stderr, "pixGetInvBackgroundMap failed\n");
+        return 1;
+    }
+    PIX *applied = pixApplyInvBackgroundGrayMap(gray, inv, 10, 15);
+    if (!applied) {
+        fprintf(stderr, "pixApplyInvBackgroundGrayMap failed\n");
+        return 1;
+    }
+    rc |= write_pix("/tmp/c_apply_inv_bg_dreyfus.png", applied,
+                    "apply_inv_bg dreyfus8");
+
+    /* Full pixBackgroundNorm via the high-level API. */
+    PIX *normed = pixBackgroundNorm(gray, NULL, NULL, 10, 15, 60, 40, 200, 2, 1);
+    if (!normed) {
+        fprintf(stderr, "pixBackgroundNorm failed\n");
+        return 1;
+    }
+    rc |= write_pix("/tmp/c_bg_norm_dreyfus.png", normed,
+                    "bg_norm dreyfus8 (full)");
+
+    pixDestroy(&pixs);
+    pixDestroy(&gray);
+    pixDestroy(&bg_map);
+    pixDestroy(&inv);
+    pixDestroy(&applied);
+    pixDestroy(&normed);
+    return rc;
+}

--- a/scripts/verify_apply_inv_bg.c
+++ b/scripts/verify_apply_inv_bg.c
@@ -36,45 +36,62 @@ int main(void) {
     setLeptDebugOK(1);
     int rc = 0;
 
-    PIX *pixs = pixRead("tests/data/images/dreyfus8.png");
-    PIX *gray = pixGetColormap(pixs)
+    PIX *pixs = NULL;
+    PIX *gray = NULL;
+    PIX *bg_map = NULL;
+    PIX *inv = NULL;
+    PIX *applied = NULL;
+    PIX *normed = NULL;
+
+    pixs = pixRead("tests/data/images/dreyfus8.png");
+    if (!pixs) {
+        fprintf(stderr, "could not read tests/data/images/dreyfus8.png\n");
+        rc = 1;
+        goto cleanup;
+    }
+    gray = pixGetColormap(pixs)
         ? pixRemoveColormap(pixs, REMOVE_CMAP_TO_GRAYSCALE)
         : pixClone(pixs);
     if (!gray) {
         fprintf(stderr, "could not load gray\n");
-        return 1;
+        rc = 1;
+        goto cleanup;
     }
 
     /* Apply step: bg_map (8 bpp) -> inv_map (16 bpp) -> apply.
      * Use the same smooth sizes as Rust BackgroundNormOptions::default(),
      * which mirrors C DefaultXSmoothSize=2, DefaultYSmoothSize=1. */
-    PIX *bg_map = NULL;
     if (pixGetBackgroundGrayMap(gray, NULL, 10, 15, 60, 40, &bg_map) != 0) {
         fprintf(stderr, "pixGetBackgroundGrayMap failed\n");
-        return 1;
+        rc = 1;
+        goto cleanup;
     }
-    PIX *inv = pixGetInvBackgroundMap(bg_map, 200, 2, 1);
+    inv = pixGetInvBackgroundMap(bg_map, 200, 2, 1);
     if (!inv) {
         fprintf(stderr, "pixGetInvBackgroundMap failed\n");
-        return 1;
+        rc = 1;
+        goto cleanup;
     }
-    PIX *applied = pixApplyInvBackgroundGrayMap(gray, inv, 10, 15);
+    applied = pixApplyInvBackgroundGrayMap(gray, inv, 10, 15);
     if (!applied) {
         fprintf(stderr, "pixApplyInvBackgroundGrayMap failed\n");
-        return 1;
+        rc = 1;
+        goto cleanup;
     }
     rc |= write_pix("/tmp/c_apply_inv_bg_dreyfus.png", applied,
                     "apply_inv_bg dreyfus8");
 
     /* Full pixBackgroundNorm via the high-level API. */
-    PIX *normed = pixBackgroundNorm(gray, NULL, NULL, 10, 15, 60, 40, 200, 2, 1);
+    normed = pixBackgroundNorm(gray, NULL, NULL, 10, 15, 60, 40, 200, 2, 1);
     if (!normed) {
         fprintf(stderr, "pixBackgroundNorm failed\n");
-        return 1;
+        rc = 1;
+        goto cleanup;
     }
     rc |= write_pix("/tmp/c_bg_norm_dreyfus.png", normed,
                     "bg_norm dreyfus8 (full)");
 
+cleanup:
     pixDestroy(&pixs);
     pixDestroy(&gray);
     pixDestroy(&bg_map);

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -213,7 +213,6 @@ fn background_norm_gray(
         options.fg_threshold,
         min_count,
     )?;
-
     // Get inverted background map
     let inv_map =
         get_inv_background_map_inner(&bg_map, options.bg_val, options.smooth_x, options.smooth_y)?;

--- a/tests/filter/adaptmap_c_parity.rs
+++ b/tests/filter/adaptmap_c_parity.rs
@@ -10,7 +10,8 @@
 //! flips RED → GREEN by deleting the `#[ignore]`.
 use crate::common::{load_test_image, pixel_content_hash};
 use leptonica::filter::adaptmap::{
-    fill_map_holes, get_background_gray_map, get_inv_background_map,
+    BackgroundNormOptions, background_norm, fill_map_holes, get_background_gray_map,
+    get_inv_background_map,
 };
 use leptonica::filter::enhance::gamma_trc_masked;
 use leptonica::{Pix, PixMut, PixelDepth};
@@ -143,6 +144,27 @@ fn c_parity_inv_bg_map_dreyfus() {
         pixel_content_hash(&inv),
         EXPECTED_C_INV_BG_DREYFUS_HASH,
         "Rust get_inv_background_map(dreyfus8) must match C reference",
+    );
+}
+
+/// FNV-1a pixel_content_hash of `/tmp/c_bg_norm_dreyfus.png` produced by
+/// `scripts/verify_apply_inv_bg.c` running C `pixBackgroundNorm` end-to-end
+/// with C/Rust default options (10x15 tiles, fg_thresh=60, min_count=40,
+/// bg_val=200, smooth_x=2, smooth_y=1). Output is 329x400x8.
+const EXPECTED_C_BG_NORM_DREYFUS_HASH: u64 = 0xd2b87b21855eca7a;
+
+/// `pixBackgroundNorm(dreyfus8)` end-to-end. With PR1, PR2, and the
+/// already-C-shaped `apply_inv_background_gray_map_inner` loop in
+/// place, the full pipeline output should be bit-identical to C.
+#[test]
+fn c_parity_background_norm_dreyfus() {
+    let pix = load_test_image("dreyfus8.png").expect("load dreyfus8");
+    let normed =
+        background_norm(&pix, &BackgroundNormOptions::default()).expect("background_norm dreyfus");
+    assert_eq!(
+        pixel_content_hash(&normed),
+        EXPECTED_C_BG_NORM_DREYFUS_HASH,
+        "Rust pixBackgroundNorm(dreyfus8) must match C reference",
     );
 }
 


### PR DESCRIPTION
## Summary

Plan 029 PR3: Rust `pixBackgroundNorm` end-to-end出力を C と **bit-identical** に。

## Why

PR1 (`get_background_gray_map`) と PR2 (`get_inv_background_map`) で内部関数を C 整列済み。`apply_inv_background_gray_map_inner` の loop 構造は元から C と同じだった。残る差は実は **test 側の verifier** が C `DefaultYSmoothSize=1` ではなく `2` を指定していたという verifier バグ。修正後、Rust 側 `BackgroundNormOptions::default()` (smooth_y=1) で **bit-identical** を確認。

## What

- `scripts/verify_apply_inv_bg.c` (新規): smooth_x=2, smooth_y=1 (C/Rust default に一致) で C reference 出力を生成
- `tests/filter/adaptmap_c_parity.rs::c_parity_background_norm_dreyfus` (新規): `pixBackgroundNorm(dreyfus8)` 全体の C parity assertion (PASS)
- `apply_inv_background_gray_map_inner` の実装変更は不要（loop 構造が元から C と一致）

## Verification

- [x] `c_parity_background_norm_dreyfus` PASS (bit-identical with C)
- [x] 既存 5 件の c_parity も全 PASS (合計 6/6)
- [x] `cargo test --all-features` 全 PASS
- [x] `cargo +1.95 clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo +1.95 fmt --all -- --check` clean

## マイルストーン

これで **`pixBackgroundNorm` 全体** が C と bit-identical。下流の `adaptmap_bg_*`, `adaptmap_gray_pipeline.*` 等の manifest hash は既に PR1+PR2 で「C-aligned bg map → C-aligned inv map → C-shaped apply」を経た値で pin されており、本 PR で end-to-end の bit-equivalence が確認された。

## Follow-up (plan 029 残)

- PR4: RGB variants (`pixGetBackgroundRGBMap`, `pixApplyInvBackgroundRGBMap`)
- PR5: contrast_norm 系 (`pixMinMaxTiles`, `pixSetLowContrast`, `pixLinearTRCTiled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)