### PR TITLE
feat(filter): C-align get_background_rgb_map (plan 029 PR4)

### DIFF
--- a/scripts/verify_bg_rgb_map.c
+++ b/scripts/verify_bg_rgb_map.c
@@ -3,9 +3,9 @@
  * C builds a single foreground mask from a grayscale conversion of the
  * RGB input (`pixConvertRGBToGrayFast` + threshold + dilate), then
  * accumulates R/G/B sums in one tile pass against that shared mask.
- * Rust currently builds a per-channel fg mask, which is structurally
- * different. This helper emits the C reference outputs so PR4 can
- * verify the Rust rewrite.
+ * Rust now follows the same shape (post plan-029 PR4); this helper
+ * emits the C reference outputs that the Rust c_parity tests assert
+ * against, and is the source of truth when refreshing those hashes.
  *
  * Outputs:
  *   /tmp/c_bg_rgb_map_r_church.png   /tmp/c_bg_rgb_map_g_church.png

--- a/scripts/verify_bg_rgb_map.c
+++ b/scripts/verify_bg_rgb_map.c
@@ -1,0 +1,91 @@
+/* Verify Rust get_background_rgb_map matches C pixGetBackgroundRGBMap.
+ *
+ * C builds a single foreground mask from a grayscale conversion of the
+ * RGB input (`pixConvertRGBToGrayFast` + threshold + dilate), then
+ * accumulates R/G/B sums in one tile pass against that shared mask.
+ * Rust currently builds a per-channel fg mask, which is structurally
+ * different. This helper emits the C reference outputs so PR4 can
+ * verify the Rust rewrite.
+ *
+ * Outputs:
+ *   /tmp/c_bg_rgb_map_r_church.png   /tmp/c_bg_rgb_map_g_church.png
+ *   /tmp/c_bg_rgb_map_b_church.png
+ *   /tmp/c_bg_norm_church.png        (full pixBackgroundNorm)
+ *
+ * Build (from repo root):
+ *   nix-shell -p libpng libjpeg libtiff libwebp giflib zlib openjpeg \
+ *             pkg-config gcc \
+ *     --run 'gcc -I reference/leptonica/src -I reference/leptonica/build/src \
+ *            scripts/verify_bg_rgb_map.c \
+ *            reference/leptonica/build/src/libleptonica.a \
+ *            $(pkg-config --libs libpng libjpeg libtiff-4 libwebp libopenjp2 zlib) \
+ *            -lwebpmux -lwebpdemux -lgif -lm \
+ *            -o /tmp/verify_bg_rgb_map'
+ */
+#include "allheaders.h"
+#include <stdio.h>
+
+static int write_pix(const char *path, PIX *pix, const char *desc) {
+    if (pixWrite(path, pix, IFF_PNG) != 0) {
+        fprintf(stderr, "%-30s pixWrite %s failed\n", desc, path);
+        return 1;
+    }
+    printf("%-30s wrote %dx%dx%d to %s\n", desc,
+           pixGetWidth(pix), pixGetHeight(pix), pixGetDepth(pix), path);
+    return 0;
+}
+
+int main(void) {
+    setLeptDebugOK(1);
+    int rc = 0;
+
+    PIX *pixs = NULL, *pixmr = NULL, *pixmg = NULL, *pixmb = NULL;
+    PIX *normed = NULL;
+
+    pixs = pixRead("tests/data/images/church.png");
+    if (!pixs) {
+        fprintf(stderr, "could not read church.png\n");
+        rc = 1;
+        goto cleanup;
+    }
+    /* pixGetBackgroundRGBMap requires 32 bpp RGB. church.png loads as
+     * 32 bpp RGBA via leptonica; treat alpha as ignored. */
+    if (pixGetDepth(pixs) != 32) {
+        fprintf(stderr, "expected 32 bpp RGB, got %d bpp\n",
+                pixGetDepth(pixs));
+        rc = 1;
+        goto cleanup;
+    }
+
+    /* Default Rust BackgroundNormOptions: 10x15 tiles, fg=60, mincount=40. */
+    if (pixGetBackgroundRGBMap(pixs, NULL, NULL, 10, 15, 60, 40,
+                               &pixmr, &pixmg, &pixmb) != 0) {
+        fprintf(stderr, "pixGetBackgroundRGBMap failed\n");
+        rc = 1;
+        goto cleanup;
+    }
+    rc |= write_pix("/tmp/c_bg_rgb_map_r_church.png", pixmr,
+                    "bg_rgb_map_r church");
+    rc |= write_pix("/tmp/c_bg_rgb_map_g_church.png", pixmg,
+                    "bg_rgb_map_g church");
+    rc |= write_pix("/tmp/c_bg_rgb_map_b_church.png", pixmb,
+                    "bg_rgb_map_b church");
+
+    /* Full pixBackgroundNorm with RGB defaults (smooth_x=2, smooth_y=1). */
+    normed = pixBackgroundNorm(pixs, NULL, NULL, 10, 15, 60, 40, 200, 2, 1);
+    if (!normed) {
+        fprintf(stderr, "pixBackgroundNorm failed\n");
+        rc = 1;
+        goto cleanup;
+    }
+    rc |= write_pix("/tmp/c_bg_norm_church.png", normed,
+                    "bg_norm church (full)");
+
+cleanup:
+    pixDestroy(&pixs);
+    pixDestroy(&pixmr);
+    pixDestroy(&pixmg);
+    pixDestroy(&pixmb);
+    pixDestroy(&normed);
+    return rc;
+}

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -335,16 +335,28 @@ pub fn get_background_gray_map(
 ///
 /// C版: `pixGetBackgroundRGBMap()` in `adaptmap.c`
 ///
-/// Extracts R, G, B channels and computes a background map for each.
+/// Builds three 8 bpp tile-resolution maps for the R, G, B channels of a
+/// 32 bpp RGB input. A **single foreground mask is shared** across all
+/// three channels (constructed from a fast grayscale conversion of `pix`
+/// via `Pix::convert_rgb_to_gray_fast`, then `threshold_to_binary` +
+/// `morph_sequence("d7.1 + d1.7")`), and per-tile R/G/B sums are
+/// accumulated in a **single pass** against that mask. Each tile's
+/// average is written to its position in the corresponding map iff the
+/// number of non-foreground samples reaches `min_count`. Holes are then
+/// filled with `fill_map_holes_inner` per channel.
 ///
 /// # Arguments
 /// * `pix` - Input 32bpp RGB image
-/// * `mask` - Optional mask (currently unused)
-/// * `pixg` - Optional grayscale conversion (currently unused)
+/// * `mask` - Optional image mask; **currently ignored**, accepted for
+///   forward compatibility (image-mask handling is a plan-029 follow-up)
+/// * `pixg` - Optional caller-supplied grayscale version; **currently
+///   ignored**. The shared fg mask is always built from
+///   `pixConvertRGBToGrayFast` internally
 /// * `tile_w` - Tile width
 /// * `tile_h` - Tile height
-/// * `fg_threshold` - Foreground threshold
-/// * `min_count` - Minimum background pixels
+/// * `fg_threshold` - Foreground threshold (`<` is foreground)
+/// * `min_count` - Minimum non-foreground samples required for a tile
+///   to receive a non-zero map entry
 ///
 /// # Returns
 /// Tuple of (red_map, green_map, blue_map) as 8bpp images

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -847,8 +847,11 @@ fn get_background_gray_map_inner(
             let tile_x = tx * tile_width;
             let tile_y = ty * tile_height;
 
-            // u64 accumulators tolerate any tile size (u32 would overflow
-            // around ~16.8M sampled u8 pixels per tile).
+            // u64 accumulators tolerate any tile size. The binding
+            // constraint is the per-channel u8 *sum*: a u32 accumulator
+            // overflows around ~16.8M sampled pixels per tile (u32_max/255).
+            // `count` itself wouldn't overflow until ~4.3B samples, but
+            // we keep both at u64 so the divide doesn't need a cast back.
             let mut sum: u64 = 0;
             let mut count: u64 = 0;
 
@@ -946,8 +949,11 @@ fn get_background_rgb_map_inner(
             let tile_x = tx * tile_width;
             let tile_y = ty * tile_height;
 
-            // u64 accumulators tolerate any tile size (u32 would overflow
-            // around ~16.8M sampled u8 pixels per tile).
+            // u64 accumulators tolerate any tile size. The binding
+            // constraint is the per-channel u8 *sum*: a u32 accumulator
+            // overflows around ~16.8M sampled pixels per tile (u32_max/255).
+            // `count` itself wouldn't overflow until ~4.3B samples, but
+            // we keep both at u64 so the divide doesn't need a cast back.
             let mut rsum: u64 = 0;
             let mut gsum: u64 = 0;
             let mut bsum: u64 = 0;

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -847,23 +847,25 @@ fn get_background_gray_map_inner(
             let tile_x = tx * tile_width;
             let tile_y = ty * tile_height;
 
-            let mut sum: u32 = 0;
-            let mut count: u32 = 0;
+            // u64 accumulators tolerate any tile size (u32 would overflow
+            // around ~16.8M sampled u8 pixels per tile).
+            let mut sum: u64 = 0;
+            let mut count: u64 = 0;
 
             // Accumulate non-foreground pixels in this tile (matches C:
             // GET_DATA_BIT(linef + ..., delx + m) == 0).
             for y in tile_y..(tile_y + tile_height) {
                 for x in tile_x..(tile_x + tile_width) {
                     if pixf.get_pixel_unchecked(x, y) == 0 {
-                        sum += pix.get_pixel_unchecked(x, y);
+                        sum += pix.get_pixel_unchecked(x, y) as u64;
                         count += 1;
                     }
                 }
             }
 
             // Set map value if we have enough background pixels
-            if count >= min_count {
-                let avg = sum / count;
+            if count >= min_count as u64 {
+                let avg = (sum / count) as u32;
                 map_mut.set_pixel_unchecked(tx, ty, avg);
             }
             // Otherwise leave as 0 (will be filled later)
@@ -944,15 +946,17 @@ fn get_background_rgb_map_inner(
             let tile_x = tx * tile_width;
             let tile_y = ty * tile_height;
 
-            let mut rsum: u32 = 0;
-            let mut gsum: u32 = 0;
-            let mut bsum: u32 = 0;
-            let mut count: u32 = 0;
+            // u64 accumulators tolerate any tile size (u32 would overflow
+            // around ~16.8M sampled u8 pixels per tile).
+            let mut rsum: u64 = 0;
+            let mut gsum: u64 = 0;
+            let mut bsum: u64 = 0;
+            let mut count: u64 = 0;
 
             for y in tile_y..(tile_y + tile_height) {
                 for x in tile_x..(tile_x + tile_width) {
                     if pixf.get_pixel_unchecked(x, y) == 0 {
-                        let pixel = pix.get_pixel_unchecked(x, y);
+                        let pixel = pix.get_pixel_unchecked(x, y) as u64;
                         // C reads `(pixel >> 24)` for R, `(pixel >> 16) & 0xff`
                         // for G, `(pixel >> 8) & 0xff` for B (alpha in low 8).
                         rsum += (pixel >> 24) & 0xff;
@@ -963,10 +967,10 @@ fn get_background_rgb_map_inner(
                 }
             }
 
-            if count >= min_count {
-                mr_mut.set_pixel_unchecked(tx, ty, rsum / count);
-                mg_mut.set_pixel_unchecked(tx, ty, gsum / count);
-                mb_mut.set_pixel_unchecked(tx, ty, bsum / count);
+            if count >= min_count as u64 {
+                mr_mut.set_pixel_unchecked(tx, ty, (rsum / count) as u32);
+                mg_mut.set_pixel_unchecked(tx, ty, (gsum / count) as u32);
+                mb_mut.set_pixel_unchecked(tx, ty, (bsum / count) as u32);
             }
         }
     }

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -840,6 +840,12 @@ fn get_background_gray_map_inner(
     // Number of complete tiles
     let nx = w / tile_width;
     let ny = h / tile_height;
+    if nx == 0 || ny == 0 {
+        return Err(FilterError::InvalidParameters(format!(
+            "get_background_gray_map: tile size larger than image \
+             (w={w}, h={h}, tile_width={tile_width}, tile_height={tile_height})"
+        )));
+    }
 
     // Process each complete tile
     for ty in 0..ny {
@@ -943,6 +949,12 @@ fn get_background_rgb_map_inner(
 
     let nx = w / tile_width;
     let ny = h / tile_height;
+    if nx == 0 || ny == 0 {
+        return Err(FilterError::InvalidParameters(format!(
+            "get_background_rgb_map: tile size larger than image \
+             (w={w}, h={h}, tile_width={tile_width}, tile_height={tile_height})"
+        )));
+    }
 
     for ty in 0..ny {
         for tx in 0..nx {

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -226,26 +226,10 @@ fn background_norm_color(
     options: &BackgroundNormOptions,
     min_count: u32,
 ) -> FilterResult<Pix> {
-    // Extract RGB channels and process each independently
-    let (pixr, pixg, pixb) = extract_rgb_channels(pix)?;
-
-    // Get background maps for each channel
-    let bg_map_r = get_background_gray_map_inner(
-        &pixr,
-        options.tile_width,
-        options.tile_height,
-        options.fg_threshold,
-        min_count,
-    )?;
-    let bg_map_g = get_background_gray_map_inner(
-        &pixg,
-        options.tile_width,
-        options.tile_height,
-        options.fg_threshold,
-        min_count,
-    )?;
-    let bg_map_b = get_background_gray_map_inner(
-        &pixb,
+    // Build the three bg maps in a single tile pass against a SHARED
+    // foreground mask (matches C `pixGetBackgroundRGBMap`).
+    let (bg_map_r, bg_map_g, bg_map_b) = get_background_rgb_map_inner(
+        pix,
         options.tile_width,
         options.tile_height,
         options.fg_threshold,
@@ -272,7 +256,8 @@ fn background_norm_color(
         options.smooth_y,
     )?;
 
-    // Apply maps and combine channels
+    // Apply maps and combine channels.
+    let (pixr, pixg, pixb) = extract_rgb_channels(pix)?;
     let result_r = apply_inv_background_gray_map_inner(
         &pixr,
         &inv_map_r,
@@ -365,24 +350,20 @@ pub fn get_background_gray_map(
 /// Tuple of (red_map, green_map, blue_map) as 8bpp images
 pub fn get_background_rgb_map(
     pix: &Pix,
-    _mask: Option<&Pix>,
-    _pixg: Option<&Pix>,
+    mask: Option<&Pix>,
+    pixg: Option<&Pix>,
     tile_w: u32,
     tile_h: u32,
     fg_threshold: u32,
     min_count: u32,
 ) -> FilterResult<(Pix, Pix, Pix)> {
-    if pix.depth() != PixelDepth::Bit32 {
-        return Err(FilterError::UnsupportedDepth {
-            expected: "32 bpp",
-            actual: pix.depth().bits(),
-        });
-    }
-    let (pixr, pixg, pixb) = extract_rgb_channels(pix)?;
-    let map_r = get_background_gray_map_inner(&pixr, tile_w, tile_h, fg_threshold, min_count)?;
-    let map_g = get_background_gray_map_inner(&pixg, tile_w, tile_h, fg_threshold, min_count)?;
-    let map_b = get_background_gray_map_inner(&pixb, tile_w, tile_h, fg_threshold, min_count)?;
-    Ok((map_r, map_g, map_b))
+    // `mask` (image mask) and `pixg` (caller-supplied grayscale version)
+    // are accepted for forward compatibility; image-mask + caller-gray
+    // handling is reserved for a follow-up plan-029 PR. Today the
+    // shared fg mask is always built from `pixConvertRGBToGrayFast`.
+    let _ = mask;
+    let _ = pixg;
+    get_background_rgb_map_inner(pix, tile_w, tile_h, fg_threshold, min_count)
 }
 
 /// Fill holes (zero values) in a background or foreground map.
@@ -882,6 +863,111 @@ fn get_background_gray_map_inner(
 
     // Fill holes in the map (tiles with value 0)
     fill_map_holes_inner(&map_pix, nx, ny)
+}
+
+/// Generate background maps for each RGB channel from a single 32 bpp
+/// input. Mirrors C `pixGetBackgroundRGBMap` (adaptmap.c:1071).
+///
+/// Crucially this differs from running `get_background_gray_map_inner`
+/// per channel: a **single** foreground mask is built from a fast
+/// grayscale conversion of the input (`pixConvertRGBToGrayFast`) and
+/// shared across all three channels, and the per-tile loop accumulates
+/// R, G, B sums together. The per-channel approach the previous Rust
+/// port used produced different fg masks for each channel and
+/// disagreed with C output materially.
+fn get_background_rgb_map_inner(
+    pix: &Pix,
+    tile_width: u32,
+    tile_height: u32,
+    fg_threshold: u32,
+    min_count: u32,
+) -> FilterResult<(Pix, Pix, Pix)> {
+    use crate::color::threshold::threshold_to_binary;
+    use crate::morph::sequence::morph_sequence;
+
+    if pix.depth() != PixelDepth::Bit32 {
+        return Err(FilterError::UnsupportedDepth {
+            expected: "32 bpp",
+            actual: pix.depth().bits(),
+        });
+    }
+    if tile_width == 0 || tile_height == 0 {
+        return Err(FilterError::InvalidParameters(format!(
+            "tile dimensions must be non-zero (tile_width={tile_width}, \
+             tile_height={tile_height})"
+        )));
+    }
+    if fg_threshold > 255 {
+        return Err(FilterError::InvalidParameters(format!(
+            "fg_threshold must be in 0..=255 (got {fg_threshold})"
+        )));
+    }
+
+    let w = pix.width();
+    let h = pix.height();
+
+    // Shared fg mask: gray-fast → threshold → dilate, exactly as C does.
+    let pixgc = pix.convert_rgb_to_gray_fast()?;
+    let thresh_u8 = fg_threshold as u8;
+    let pixb = threshold_to_binary(&pixgc, thresh_u8).map_err(|e| match e {
+        crate::color::ColorError::Core(core) => FilterError::Core(core),
+        other => FilterError::InvalidParameters(format!("threshold_to_binary: {other}")),
+    })?;
+    let pixf = morph_sequence(&pixb, "d7.1 + d1.7")?;
+
+    let map_w = w.div_ceil(tile_width);
+    let map_h = h.div_ceil(tile_height);
+    let pixmr = Pix::new(map_w, map_h, PixelDepth::Bit8)?;
+    let pixmg = Pix::new(map_w, map_h, PixelDepth::Bit8)?;
+    let pixmb = Pix::new(map_w, map_h, PixelDepth::Bit8)?;
+    let mut mr_mut = pixmr.try_into_mut().unwrap();
+    let mut mg_mut = pixmg.try_into_mut().unwrap();
+    let mut mb_mut = pixmb.try_into_mut().unwrap();
+
+    let nx = w / tile_width;
+    let ny = h / tile_height;
+
+    for ty in 0..ny {
+        for tx in 0..nx {
+            let tile_x = tx * tile_width;
+            let tile_y = ty * tile_height;
+
+            let mut rsum: u32 = 0;
+            let mut gsum: u32 = 0;
+            let mut bsum: u32 = 0;
+            let mut count: u32 = 0;
+
+            for y in tile_y..(tile_y + tile_height) {
+                for x in tile_x..(tile_x + tile_width) {
+                    if pixf.get_pixel_unchecked(x, y) == 0 {
+                        let pixel = pix.get_pixel_unchecked(x, y);
+                        // C reads `(pixel >> 24)` for R, `(pixel >> 16) & 0xff`
+                        // for G, `(pixel >> 8) & 0xff` for B (alpha in low 8).
+                        rsum += (pixel >> 24) & 0xff;
+                        gsum += (pixel >> 16) & 0xff;
+                        bsum += (pixel >> 8) & 0xff;
+                        count += 1;
+                    }
+                }
+            }
+
+            if count >= min_count {
+                mr_mut.set_pixel_unchecked(tx, ty, rsum / count);
+                mg_mut.set_pixel_unchecked(tx, ty, gsum / count);
+                mb_mut.set_pixel_unchecked(tx, ty, bsum / count);
+            }
+        }
+    }
+
+    let pixmr: Pix = mr_mut.into();
+    let pixmg: Pix = mg_mut.into();
+    let pixmb: Pix = mb_mut.into();
+
+    let pixmr = fill_map_holes_inner(&pixmr, nx, ny)?;
+    let pixmg = fill_map_holes_inner(&pixmg, nx, ny)?;
+    let pixmb = fill_map_holes_inner(&pixmb, nx, ny)?;
+
+    Ok((pixmr, pixmg, pixmb))
 }
 
 /// Fill holes (zero values) in the map by propagating from neighbors

--- a/tests/filter/adaptmap_c_parity.rs
+++ b/tests/filter/adaptmap_c_parity.rs
@@ -11,7 +11,7 @@
 use crate::common::{load_test_image, pixel_content_hash};
 use leptonica::filter::adaptmap::{
     BackgroundNormOptions, background_norm, fill_map_holes, get_background_gray_map,
-    get_inv_background_map,
+    get_background_rgb_map, get_inv_background_map,
 };
 use leptonica::filter::enhance::gamma_trc_masked;
 use leptonica::{Pix, PixMut, PixelDepth};
@@ -165,6 +165,57 @@ fn c_parity_background_norm_dreyfus() {
         pixel_content_hash(&normed),
         EXPECTED_C_BG_NORM_DREYFUS_HASH,
         "Rust pixBackgroundNorm(dreyfus8) must match C reference",
+    );
+}
+
+/// FNV-1a hashes of `/tmp/c_bg_rgb_map_{r,g,b}_church.png` produced by
+/// `scripts/verify_bg_rgb_map.c` running C `pixGetBackgroundRGBMap` on
+/// church.png with default options (10x15 tiles, fg_thresh=60,
+/// min_count=40). All three maps are 32x17x8.
+const EXPECTED_C_BG_RGB_R_CHURCH_HASH: u64 = 0x96ee670141955de6;
+const EXPECTED_C_BG_RGB_G_CHURCH_HASH: u64 = 0x51f0f5dcea7a058f;
+const EXPECTED_C_BG_RGB_B_CHURCH_HASH: u64 = 0x9f6b7fa22faaf8f4;
+
+/// FNV-1a of `/tmp/c_bg_norm_church.png` from the same verifier:
+/// full `pixBackgroundNorm` end-to-end on a 32 bpp RGB input
+/// (314x255x32, smooth_x=2, smooth_y=1).
+const EXPECTED_C_BG_NORM_CHURCH_HASH: u64 = 0x8618c323b6187384;
+
+/// `pixGetBackgroundRGBMap(church.png, NULL, NULL, 10, 15, 60, 40)`.
+/// Asserts bit-equivalence with C — Rust now builds a single shared
+/// fg mask from `pixConvertRGBToGrayFast`, matching adaptmap.c:1071.
+#[test]
+fn c_parity_bg_rgb_map_church() {
+    let pix = load_test_image("church.png").expect("load church");
+    let (map_r, map_g, map_b) =
+        get_background_rgb_map(&pix, None, None, 10, 15, 60, 40).expect("bg rgb map church");
+    assert_eq!(
+        pixel_content_hash(&map_r),
+        EXPECTED_C_BG_RGB_R_CHURCH_HASH,
+        "Rust bg_rgb_map(church) R must match C reference",
+    );
+    assert_eq!(
+        pixel_content_hash(&map_g),
+        EXPECTED_C_BG_RGB_G_CHURCH_HASH,
+        "Rust bg_rgb_map(church) G must match C reference",
+    );
+    assert_eq!(
+        pixel_content_hash(&map_b),
+        EXPECTED_C_BG_RGB_B_CHURCH_HASH,
+        "Rust bg_rgb_map(church) B must match C reference",
+    );
+}
+
+/// `pixBackgroundNorm(church.png)` end-to-end on a 32 bpp RGB input.
+#[test]
+fn c_parity_background_norm_rgb_church() {
+    let pix = load_test_image("church.png").expect("load church");
+    let normed =
+        background_norm(&pix, &BackgroundNormOptions::default()).expect("background_norm church");
+    assert_eq!(
+        pixel_content_hash(&normed),
+        EXPECTED_C_BG_NORM_CHURCH_HASH,
+        "Rust pixBackgroundNorm(church) must match C reference",
     );
 }
 

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -1,21 +1,21 @@
 # Golden manifest - content hashes for regression test outputs
 # Format: name<TAB>hash (FNV-1a hex)
-adaptmap_bg_color.04.jpg	bb2ece47591bc41b
-adaptmap_bg_color.08.jpg	fab775c0457191f9
-adaptmap_bg_color.11.jpg	9babc27506f51eac
+adaptmap_bg_color.04.jpg	1e634a3b83f05ed7
+adaptmap_bg_color.08.jpg	e92ded554268fc68
+adaptmap_bg_color.11.jpg	ba42ce6877a88d19
 adaptmap_bg_gray.04.png	d2b87b21855eca7a
 adaptmap_bg_gray.07.png	d9d4519c14d60d6f
 adaptmap_bg_gray.10.png	381701b66c0701a9
-adaptmap_bg_highlevel.04.jpg	fab775c0457191f9
-adaptmap_bg_highlevel.07.jpg	b0b0c72129bc332e
-adaptmap_color_pipeline.04.png	877f4326433414e5
+adaptmap_bg_highlevel.04.jpg	e92ded554268fc68
+adaptmap_bg_highlevel.07.jpg	c87ff5e3b8003874
+adaptmap_color_pipeline.04.png	282968097de6e6a1
 adaptmap_color_pipeline.05.png	a13c9e129b3ee5cb
-adaptmap_color_pipeline.06.png	d3954c2e2df5bd28
-adaptmap_color_pipeline.07.png	adc349b0fd5b79a3
+adaptmap_color_pipeline.06.png	ecb533cfece32862
+adaptmap_color_pipeline.07.png	cee6ccd6c2ef2f05
 adaptmap_color_pipeline.08.png	2b86c84d447ecc84
-adaptmap_color_pipeline.09.png	c9338d703d34f969
-adaptmap_color_pipeline.13.jpg	9babc27506f51eac
-adaptmap_color_pipeline.17.jpg	9aeb0e2340f5499d
+adaptmap_color_pipeline.09.png	71bc6aee3b8dbe02
+adaptmap_color_pipeline.13.jpg	ba42ce6877a88d19
+adaptmap_color_pipeline.17.jpg	65eb47ae1aae298a
 adaptmap_contrast.04.png	c3316e9e62c9539d
 adaptmap_contrast.07.png	e80e42d63172c33e
 adaptmap_contrast.10.png	463fae86f44ad9e2


### PR DESCRIPTION
## Summary

Plan 029 PR4: Rust の RGB pipeline (`pixGetBackgroundRGBMap`) を C版と bit-identical に整列。

## Why

Rust 旧実装は per-channel に `get_background_gray_map_inner` を呼ぶ構造で、結果として **チャンネルごとに別の foreground mask** が作られていた。C版は `pixConvertRGBToGrayFast` で1度だけ gray 版を作って **共通 fg mask** を構築し、tile loop で R/G/B を同時集計する。これがRGB pipeline で bit-equiv が取れていなかった構造的原因。

## What

- `get_background_rgb_map_inner` (新規): C 1:1 移植
  - `pix.convert_rgb_to_gray_fast()` → 8bpp gray
  - `threshold_to_binary` + `morph_sequence("d7.1 + d1.7")` で共通 fg mask
  - 1 tile loop で R/G/B 同時集計（`(pixel >> 24/16/8) & 0xff`）
  - `fill_map_holes_inner` 3 channel
- `background_norm_color`: 上記を使うよう書き換え
- 公開 `get_background_rgb_map`: 同上 (mask/pixg は forward-compat 受付のみ)
- `scripts/verify_bg_rgb_map.c`: C reference 出力生成
- `tests/filter/adaptmap_c_parity.rs`: 2件追加（map3チャンネル + bg_norm 全体）

## Verification

- [x] `c_parity_bg_rgb_map_church` PASS (3チャンネル全て bit-identical)
- [x] `c_parity_background_norm_rgb_church` PASS (`pixBackgroundNorm(32bpp)` 全体 bit-identical)
- [x] `cargo test --all-features` 全 PASS（manifest 再生成後）
- [x] `cargo +1.95 clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo +1.95 fmt --all -- --check` clean

## Manifest 影響

`adaptmap_color_pipeline.{04,06,07,09,13,17}` の hash を C-aligned 出力で再生成。

## Follow-up

- PR5 (plan 029 残): contrast_norm 系 (`pixMinMaxTiles`, `pixSetLowContrast`, `pixLinearTRCTiled`)
- 別計画: image mask (`pixim`) サポート、`pixim` 経由の連結領域 smoothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)