### PR TITLE
docs: flip plan 029 to IMPLEMENTED

### DIFF
--- a/docs/plans/029_adaptmap-pipeline-c-alignment.md
+++ b/docs/plans/029_adaptmap-pipeline-c-alignment.md
@@ -1,6 +1,6 @@
 # adaptmap pipeline 全体を C版と bit 同等に揃える
 
-Status: PLANNED
+Status: IMPLEMENTED
 
 ## Context
 


### PR DESCRIPTION
## Summary

Plan 029 全 5 PR (PR #299, #300, #301, #302, #303) merged。adaptmap pipeline 全体（gray bg + RGB bg + contrast）が C と bit-identical。Status を `PLANNED` → `IMPLEMENTED` に更新。

## What's verified

| 機能 | parity test | C bit-identical |
|---|---|---|
| `fill_map_holes` | `c_parity_simple_3x3`, `c_parity_weasel` (plan 028) | ✅ |
| `get_background_gray_map` | `c_parity_bg_gray_map_dreyfus` | ✅ |
| `get_inv_background_map` | `c_parity_inv_bg_map_dreyfus` | ✅ |
| `apply_inv_background_gray_map` (gray pipeline) | `c_parity_background_norm_dreyfus` | ✅ |
| `get_background_rgb_map` (RGB) | `c_parity_bg_rgb_map_church` | ✅ |
| `pixBackgroundNorm` RGB end-to-end | `c_parity_background_norm_rgb_church` | ✅ |
| `pixContrastNorm` (`pixMinMaxTiles` + `pixSetLowContrast` + `pixLinearTRCTiled`) | `c_parity_contrast_norm_dreyfus` | ✅ |
| Colormap auto-decode regression | `bg_gray_map_auto_decodes_colormap` | ✅ |

合計 9 件の c_parity test が PNG fixture (lossless) で C と bit-identical を保証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)