### PR TITLE
chore: bump to 0.4.0 and correct MSRV to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "leptonica"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.88"
 license = "BSD-2-Clause"
 repository = "https://github.com/tagawa0525/leptonica-rs"
 description = "Rust port of Leptonica image processing library"


### PR DESCRIPTION
## Summary
- crates.io 公開に向けたバージョン更新。
- `version`: 0.3.0 → 0.4.0（plan 028 / 029 の機能追加が累積したため minor bump）。
- `rust-version`: 1.87 → 1.88（実際の最小要求に整合）。

## なぜ MSRV を上げる必要があったか
`cargo +1.87 check --all-features` で機械的に検証したところ、現在の宣言 `1.87` ではビルドが通らないことが判明:

1. **依存の MSRV 違反**: `hayro-jpeg2000 → fearless_simd@0.4.0` が rustc 1.88 を要求。
2. **自前コードも 1.87 では不可**: `src/transform/affine.rs:844` と `src/transform/projective.rs:357` で if-let-chains（Rust 1.88 で安定化）を使用。

CI は `toolchain: stable`（現状 1.93）で動かしているため、宣言 MSRV が実態と乖離していても検知できていなかった。1.88 toolchain での `cargo check --all-features` は通過することを確認済み。

## Impact
- 利用者の最低 Rust バージョンが 1.87 → 1.88 に厳しくなる。1.88 は 2025-06 リリース（現時点で十分に古い）。
- crates.io 公開時にバージョン重複なしで `cargo publish` 可能になる。

## Test plan
- [x] `cargo +1.87 check --all-features` が失敗することを確認（MSRV 違反の根拠）。
- [x] `cargo +1.88 check --all-features` が成功することを確認（新 MSRV の妥当性）。
- [x] `cargo fmt --all -- --check` 通過。
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過。
- [ ] CI（stable）通過。
- [ ] Copilot review 対応。

## Out of scope
- CI に MSRV 検証ジョブ（`rust-toolchain@1.88` で `cargo check`）を追加する話は別 PR とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)