### PR TITLE
chore: ignore .cargo/credential.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cargo/credential.toml
 /target
 /Cargo.lock
 /reference/


### PR DESCRIPTION
## Summary
- `.cargo/credential.toml` を `.gitignore` に追加し、ローカルの cargo クレデンシャルが誤ってコミットされないようにする。

## Test plan
- [x] `git status` で当該ファイルが追跡対象から外れていることを確認