### PR TITLE
chore(core): remove unused pix/ops.rs placeholder

### DIFF
--- a/docs/plans/001_git-history-rebuild.md
+++ b/docs/plans/001_git-history-rebuild.md
@@ -90,7 +90,7 @@ TDD不要（テスト対象のコードを含まないため）。
 対象ファイル:
 
 - `src/core/src/`（error.rs, lib.rs）
-- `src/core/src/pix/`（mod.rs, ops.rs, access.rs, convert.rs, clip.rs）
+- `src/core/src/pix/`（mod.rs, access.rs, convert.rs, clip.rs）
 - `src/core/src/box_/mod.rs`
 - `src/core/src/pta/mod.rs`
 

--- a/docs/porting/c-file-mapping.md
+++ b/docs/porting/c-file-mapping.md
@@ -130,7 +130,7 @@ C版ソースファイル・回帰テストファイルとRust版の対応。
 | `pdfio2stub.c`     | src/io/pdf.rs                                                                                                   |
 | `pix1.c`           | src/core/pix/mod.rs                                                                                             |
 | `pix2.c`           | src/core/pix/access.rs, src/core/pix/rgb.rs, src/core/pix/clip.rs, src/core/pix/border.rs                       |
-| `pix3.c`           | src/core/pix/mask.rs, src/core/pix/statistics.rs, src/core/pix/ops.rs                                           |
+| `pix3.c`           | src/core/pix/mask.rs, src/core/pix/statistics.rs, src/core/pix/rop.rs, src/core/pix/arith.rs                    |
 | `pix4.c`           | src/core/pix/histogram.rs, src/core/pix/statistics.rs, src/core/pix/access.rs                                   |
 | `pix5.c`           | src/core/pix/clip.rs, src/core/pix/extract.rs, src/core/pix/measurement.rs                                      |
 | `pixabasic.c`      | src/core/pixa/mod.rs, src/core/pixa/serial.rs                                                                   |

--- a/src/core/pix/mod.rs
+++ b/src/core/pix/mod.rs
@@ -33,7 +33,6 @@ pub mod graphics;
 mod histogram;
 mod mask;
 mod measurement;
-mod ops;
 mod rgb;
 pub mod rop;
 pub mod serial;

--- a/src/core/pix/ops.rs
+++ b/src/core/pix/ops.rs
@@ -1,9 +1,0 @@
-//! Pixel operations
-//!
-//! Logical and arithmetic operations on images.
-
-// TODO: Implement pixel operations
-// - AND, OR, XOR
-// - Add, Subtract, Multiply
-// - Invert
-// etc.


### PR DESCRIPTION
## Summary
- 論理演算は `src/core/pix/rop.rs`、算術演算は `src/core/pix/arith.rs` で既に提供されている
- `src/core/pix/ops.rs` は TODO コメントのみのプレースホルダで、参照箇所なし
- ファイルと `mod ops;` 宣言を削除

## Test plan
- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)