### PR TITLE
perf(region): skip second-pass relabel in count_conn_comp

### DIFF
--- a/src/region/conncomp.rs
+++ b/src/region/conncomp.rs
@@ -139,6 +139,44 @@ pub fn find_connected_components(
 ///
 /// Returns an error if the image is not 1-bit depth.
 pub fn label_connected_components(pix: &Pix, connectivity: ConnectivityType) -> RegionResult<Pix> {
+    let (mut output, mut uf, _) = first_pass_label(pix, connectivity)?;
+
+    let width = output.width();
+    let height = output.height();
+
+    // Second pass: resolve labels using union-find.
+    // Build a mapping from root labels to sequential labels [1, N].
+    let mut label_map = std::collections::HashMap::new();
+    let mut final_label: u32 = 1;
+
+    for y in 0..height {
+        for x in 0..width {
+            let label = output.get_pixel_unchecked(x, y);
+            if label > 0 {
+                let root = uf.find(label);
+                let mapped = *label_map.entry(root).or_insert_with(|| {
+                    let l = final_label;
+                    final_label += 1;
+                    l
+                });
+                output.set_pixel_unchecked(x, y, mapped);
+            }
+        }
+    }
+
+    Ok(output.into())
+}
+
+/// First-pass connected-component labeling.
+///
+/// Scans the binary image once, assigning provisional labels to foreground
+/// pixels and recording equivalences in a union-find. The returned image
+/// holds the provisional labels (not yet remapped to sequential ids).
+/// `next_label` is one past the largest provisional label allocated.
+fn first_pass_label(
+    pix: &Pix,
+    connectivity: ConnectivityType,
+) -> RegionResult<(PixMut, UnionFind, u32)> {
     if pix.depth() != PixelDepth::Bit1 {
         return Err(RegionError::UnsupportedDepth {
             expected: "1-bit",
@@ -149,14 +187,13 @@ pub fn label_connected_components(pix: &Pix, connectivity: ConnectivityType) -> 
     let width = pix.width();
     let height = pix.height();
 
-    // Create output image with 32-bit depth for labels
     let mut output = Pix::new(width, height, PixelDepth::Bit32)
         .map_err(RegionError::Core)?
         .try_into_mut()
         .unwrap_or_else(|p| p.to_mut());
 
     if width == 0 || height == 0 {
-        return Ok(output.into());
+        return Ok((output, UnionFind::new(1), 1));
     }
 
     // Maximum possible labels (worst case: every other pixel is a separate component)
@@ -164,7 +201,6 @@ pub fn label_connected_components(pix: &Pix, connectivity: ConnectivityType) -> 
     let mut uf = UnionFind::new(max_labels);
     let mut next_label: u32 = 1;
 
-    // First pass: assign provisional labels and record equivalences
     for y in 0..height {
         for x in 0..width {
             if pix.get_pixel_unchecked(x, y) == 0 {
@@ -225,27 +261,7 @@ pub fn label_connected_components(pix: &Pix, connectivity: ConnectivityType) -> 
         }
     }
 
-    // Second pass: resolve labels using union-find
-    // Create a mapping from root labels to sequential labels
-    let mut label_map = std::collections::HashMap::new();
-    let mut final_label: u32 = 1;
-
-    for y in 0..height {
-        for x in 0..width {
-            let label = output.get_pixel_unchecked(x, y);
-            if label > 0 {
-                let root = uf.find(label);
-                let mapped = *label_map.entry(root).or_insert_with(|| {
-                    let l = final_label;
-                    final_label += 1;
-                    l
-                });
-                output.set_pixel_unchecked(x, y, mapped);
-            }
-        }
-    }
-
-    Ok(output.into())
+    Ok((output, uf, next_label))
 }
 
 /// Extract component information from a labeled image
@@ -640,17 +656,18 @@ pub fn get_sorted_neighbor_values(
 /// Returns an error if the image is not 1-bit depth, or if the component count
 /// exceeds `u32::MAX`.
 pub fn count_conn_comp(pix: &Pix, connectivity: ConnectivityType) -> RegionResult<u32> {
-    if pix.depth() != PixelDepth::Bit1 {
-        return Err(RegionError::UnsupportedDepth {
-            expected: "1-bit",
-            actual: pix.depth().bits(),
-        });
+    let (_output, mut uf, next_label) = first_pass_label(pix, connectivity)?;
+
+    // Each connected component is one root in the union-find. Count distinct
+    // roots across all provisional labels in [1, next_label) — no second-pass
+    // relabeling, no per-component bookkeeping.
+    let mut roots =
+        std::collections::HashSet::with_capacity((next_label as usize).saturating_sub(1));
+    for label in 1..next_label {
+        roots.insert(uf.find(label));
     }
 
-    // For now, use find_connected_components as implementation
-    // TODO: Optimize to avoid storing all component info
-    let components = find_connected_components(pix, connectivity)?;
-    u32::try_from(components.len())
+    u32::try_from(roots.len())
         .map_err(|_| RegionError::InvalidParameters("component count exceeds u32::MAX".into()))
 }
 

--- a/src/region/conncomp.rs
+++ b/src/region/conncomp.rs
@@ -666,17 +666,22 @@ pub fn get_sorted_neighbor_values(
 pub fn count_conn_comp(pix: &Pix, connectivity: ConnectivityType) -> RegionResult<u32> {
     let (_output, mut uf, next_label) = first_pass_label(pix, connectivity)?;
 
-    // Each connected component is one root in the union-find. Count distinct
-    // roots across all provisional labels in [1, next_label) — no second-pass
-    // relabeling, no per-component bookkeeping.
-    let mut roots =
-        std::collections::HashSet::with_capacity((next_label as usize).saturating_sub(1));
+    // Each connected component is one root in the union-find. Provisional
+    // labels live in [1, next_label) and roots are bounded by the same range,
+    // so a dense `Vec<bool>` indexed by root id avoids the hashing overhead a
+    // `HashSet<u32>` would pay on every insert.
+    let mut seen_root = vec![false; next_label as usize];
+    let mut count: u32 = 0;
     for label in 1..next_label {
-        roots.insert(uf.find(label));
+        let root = uf.find(label) as usize;
+        if !seen_root[root] {
+            seen_root[root] = true;
+            count = count.checked_add(1).ok_or_else(|| {
+                RegionError::InvalidParameters("component count exceeds u32::MAX".into())
+            })?;
+        }
     }
-
-    u32::try_from(roots.len())
-        .map_err(|_| RegionError::InvalidParameters("component count exceeds u32::MAX".into()))
+    Ok(count)
 }
 
 /// Find the next ON pixel in raster scan order starting from a given position

--- a/src/region/conncomp.rs
+++ b/src/region/conncomp.rs
@@ -196,8 +196,13 @@ fn first_pass_label(
         return Ok((output, UnionFind::new(1), 1));
     }
 
-    // Maximum possible labels (worst case: every other pixel is a separate component)
-    let max_labels = ((width as usize) * (height as usize) / 2) + 1;
+    // Maximum possible provisional labels (worst case: every other pixel is a
+    // separate component, e.g. a 1D checkerboard of ON/OFF). Use ceil division
+    // so a 1x1 ON pixel still gets a slot, then add one for the unused 0
+    // background slot. Without `+1`, `UnionFind::new(1)` would panic for a 1x1
+    // image when `uf.find(1)` indexes out of bounds.
+    let pixel_count = (width as usize) * (height as usize);
+    let max_labels = pixel_count.div_ceil(2) + 1;
     let mut uf = UnionFind::new(max_labels);
     let mut next_label: u32 = 1;
 

--- a/src/region/conncomp.rs
+++ b/src/region/conncomp.rs
@@ -139,14 +139,17 @@ pub fn find_connected_components(
 ///
 /// Returns an error if the image is not 1-bit depth.
 pub fn label_connected_components(pix: &Pix, connectivity: ConnectivityType) -> RegionResult<Pix> {
-    let (mut output, mut uf, _) = first_pass_label(pix, connectivity)?;
+    let (mut output, mut uf, next_label) = first_pass_label(pix, connectivity)?;
 
     let width = output.width();
     let height = output.height();
 
     // Second pass: resolve labels using union-find.
-    // Build a mapping from root labels to sequential labels [1, N].
-    let mut label_map = std::collections::HashMap::new();
+    // Build a mapping from root labels to sequential labels [1, N]. Pre-size to
+    // the upper bound on distinct roots (`next_label - 1`) so the second pass
+    // does not rehash as components are encountered.
+    let mut label_map =
+        std::collections::HashMap::with_capacity((next_label.saturating_sub(1)) as usize);
     let mut final_label: u32 = 1;
 
     for y in 0..height {

--- a/tests/region/splitcomp_reg.rs
+++ b/tests/region/splitcomp_reg.rs
@@ -54,3 +54,38 @@ fn splitcomp_reg() {
 
     assert!(rp.cleanup(), "splitcomp regression test failed");
 }
+
+/// Regression for the under-allocated union-find on very small images.
+///
+/// A 1x1 image with one ON pixel allocates label=1, so the union-find must
+/// have at least 2 slots (for indices 0 and 1). With the previous formula
+/// `max_labels = (w*h)/2 + 1`, a 1x1 image got `UnionFind::new(1)` and
+/// `uf.find(1)` panicked from out-of-bounds indexing.
+///
+/// Refs: https://github.com/tagawa0525/leptonica-rs/pull/308#discussion_r3143724762
+#[test]
+fn count_conn_comp_small_image() {
+    let pix = Pix::new(1, 1, PixelDepth::Bit1).expect("create 1x1");
+    let mut pm = pix.try_into_mut().expect("mutable 1x1");
+    pm.set_pixel_unchecked(0, 0, 1);
+    let pix = pm.into();
+
+    let count = count_conn_comp(&pix, ConnectivityType::FourWay).expect("count_conn_comp on 1x1");
+    assert_eq!(
+        count, 1,
+        "1x1 image with one ON pixel must have one component"
+    );
+
+    // 3x1 with two separated ON pixels exercises a second label.
+    let pix = Pix::new(3, 1, PixelDepth::Bit1).expect("create 3x1");
+    let mut pm = pix.try_into_mut().expect("mutable 3x1");
+    pm.set_pixel_unchecked(0, 0, 1);
+    pm.set_pixel_unchecked(2, 0, 1);
+    let pix = pm.into();
+
+    let count = count_conn_comp(&pix, ConnectivityType::FourWay).expect("count_conn_comp on 3x1");
+    assert_eq!(
+        count, 2,
+        "3x1 with two separated ON pixels must have two components"
+    );
+}


### PR DESCRIPTION
## Summary
- `count_conn_comp` は連結成分の個数のみ必要だが、これまでは `find_connected_components` を経由して「ラベリング → bbox/画素数の HashMap 構築 → `Vec<ConnectedComponent>` 構築」までを行っていた。
- ラベリング first pass を内部ヘルパ `first_pass_label` に切り出し、`count_conn_comp` は first pass で得た UnionFind 上で root の個数だけを数える実装に置換。
- second pass の O(W*H) 走査・再ラベリング HashMap・bbox 集計 HashMap・`Vec<ConnectedComponent>` 確保がすべて不要になる。
- `label_connected_components` の公開挙動は不変（first pass 結果を受け取り従来どおり sequential labels へ再マップ）。

## Test plan
- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features`（既存の `test_count_conn_comp_basic` ほかパス）

C: `pixCountConnComp()` (conncomp.c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)