### PR TITLE
test(core): exercise quant/colormap APIs in equal_reg

### DIFF
--- a/tests/core/equal_reg.rs
+++ b/tests/core/equal_reg.rs
@@ -13,6 +13,8 @@
 //! C Leptonica: `prog/equal_reg.c`
 
 use crate::common::RegParams;
+use leptonica::color::quantize::octree_quant_num_colors;
+use leptonica::color::threshold::threshold_to_4bpp;
 use leptonica::core::pix::RemoveColormapTarget;
 use leptonica::io::ImageFormat;
 
@@ -95,8 +97,17 @@ fn equal_reg_8bpp_gray() {
     // Round-trip should preserve the image
     rp.compare_pix(&pix1, &pix_8);
 
-    // TODO: pixThresholdTo4bpp (not available)
-    // TODO: pixConvertRGBToColormap (not available)
+    // 8bpp gray → 4bpp 16-level quantization (C: pixThresholdTo4bpp)
+    let pix_4 = threshold_to_4bpp(&pix1, 16, false).expect("threshold to 4bpp");
+    rp.write_pix_and_check(&pix_4, ImageFormat::Png)
+        .expect("check: equal 8bpp threshold_to_4bpp");
+
+    // 8bpp gray → 32bpp RGB → 8bpp colormapped (C: pixConvertRGBToColormap)
+    let pix_cmap = pix_32
+        .convert_rgb_to_colormap(false)
+        .expect("convert rgb to colormap");
+    rp.write_pix_and_check(&pix_cmap, ImageFormat::Png)
+        .expect("check: equal 8bpp convert_rgb_to_colormap");
 
     assert!(rp.cleanup(), "equal 8bpp gray test failed");
 }
@@ -119,8 +130,17 @@ fn equal_reg_rgb() {
     let pix_gray2 = pix_32.convert_to_8().expect("gray2");
     rp.compare_pix(&pix_gray1, &pix_gray2);
 
-    // TODO: pixOctreeQuantNumColors (not available)
-    // TODO: pixConvertRGBToColormap (not available)
+    // RGB → octree quantized 8bpp colormapped (C: pixOctreeQuantNumColors)
+    let pix_oct = octree_quant_num_colors(&pix1, 256, 1).expect("octree quant 256 colors");
+    rp.write_pix_and_check(&pix_oct, ImageFormat::Png)
+        .expect("check: equal rgb octree_quant_num_colors");
+
+    // RGB → 8bpp colormapped via direct conversion (C: pixConvertRGBToColormap)
+    let pix_cmap = pix1
+        .convert_rgb_to_colormap(false)
+        .expect("convert rgb to colormap");
+    rp.write_pix_and_check(&pix_cmap, ImageFormat::Png)
+        .expect("check: equal rgb convert_rgb_to_colormap");
 
     assert!(rp.cleanup(), "equal rgb test failed");
 }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -277,6 +277,10 @@ equal_4bpp_cmap.02.png	cd34d6b1baac3e94
 equal_4bpp_cmap.03.png	6154f8fdeb266424
 equal_8bpp_cmap.02.png	76b9de133d57ab94
 equal_8bpp_cmap.03.png	b4b89fdb658d98dc
+equal_8bpp_gray.02.png	71c88e4d6490cca6
+equal_8bpp_gray.03.png	4424ca59bbf3fc2a
+equal_rgb.02.png	e42ca00190f52b60
+equal_rgb.03.png	5e13242c9a0a8bd4
 expand_1bpp.03.tif	7d3831a84b195e51
 expand_2bpp.03.png	dfbc3460d7005de1
 expand_4bpp.03.png	c9eef43703f3af87


### PR DESCRIPTION
## Summary
- `equal_reg_8bpp_gray` / `equal_reg_rgb` には「未実装のためスキップ」の旧 TODO が残っていたが、参照していた API はいずれも既に実装済み (`threshold_to_4bpp`, `octree_quant_num_colors`, `convert_rgb_to_colormap`) なのでテストに反映。
- `equal_reg_8bpp_gray`: 8bpp gray → `threshold_to_4bpp`、32bpp 経由 `convert_rgb_to_colormap` の出力を WPAC で確認。
- `equal_reg_rgb`: 32bpp RGB → `octree_quant_num_colors`、`convert_rgb_to_colormap` の出力を WPAC で確認。
- `tests/golden_manifest.tsv` に 4 件のハッシュエントリを追加。

C: `prog/equal_reg.c` checks 11-13, 14-16 相当。

## Test plan
- [x] `REGTEST_MODE=generate cargo test --test core equal_reg`（manifest 再生成）
- [x] `cargo test --test core equal_reg`（compare モードでパス）
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)