### PR TITLE
test(core): exercise octcube_quant_from_cmap in conversion_reg

### DIFF
--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -236,8 +236,19 @@ fn conversion_reg_from_32bpp() {
     rp.compare_values(pix32.width() as f64, pix8.width() as f64, 0.0);
     rp.compare_values(pix32.height() as f64, pix8.height() as f64, 0.0);
 
-    // Octcube quantization (not available)
-    // TODO: pixOctcubeQuantFromCmap not available
+    // Octcube quantization onto an existing colormap (C: pixOctcubeQuantFromCmap).
+    // First derive a 64-color cmap via octree_quant_num_colors, then re-quantize
+    // the original RGB image against that cmap by nearest-color search.
+    let pix_oct = leptonica::color::quantize::octree_quant_num_colors(&pix32, 64, 1)
+        .expect("octree_quant_num_colors");
+    let cmap = pix_oct
+        .colormap()
+        .expect("octree result must carry a colormap")
+        .clone();
+    let pix_q = leptonica::color::quantize::octcube_quant_from_cmap(&pix32, &cmap, 8)
+        .expect("octcube_quant_from_cmap");
+    rp.write_pix_and_check(&pix_q, ImageFormat::Png)
+        .expect("check: conversion_from_32bpp octcube_quant_from_cmap");
 
     assert!(rp.cleanup(), "conversion from 32bpp test failed");
 }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -181,6 +181,7 @@ conversion_from_16bpp.05.png	ff9aba5ee2aaace0
 conversion_from_1bpp.07.png	ff9aba5ee2aaace0
 conversion_from_2bpp.05.png	536739402d73641e
 conversion_from_2bpp.06.png	af7f58945e330afe
+conversion_from_32bpp.05.png	6aa975402f2589f4
 conversion_from_4bpp.03.png	368eed4016fed93a
 conversion_from_4bpp.05.png	8f7b016c981b0817
 conversion_from_8bpp.04.png	34396ef54eddf107


### PR DESCRIPTION
## Summary
- `conversion_reg_from_32bpp` に「pixOctcubeQuantFromCmap not available」の旧 TODO が残っていたが、`octcube_quant_from_cmap` は既に実装済み (`src/color/quantize.rs`) なのでテストに反映。
- `octree_quant_num_colors` で 64 色 cmap 画像を生成 → `colormap()` を取り出して元 RGB 画像を最近傍探索で再量子化する流れを WPAC で確認。
- `tests/golden_manifest.tsv` に 1 件追加。

C: `prog/conversion_reg.c` の octcube quantization 検査相当。

## Test plan
- [x] `REGTEST_MODE=generate cargo test --test core conversion_reg_from_32bpp`
- [x] `cargo test --test core conversion_reg`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)