### PR TITLE
feat(color): attach grayscale colormap in threshold_to_Nbpp

### DIFF
--- a/src/color/threshold.rs
+++ b/src/color/threshold.rs
@@ -641,13 +641,11 @@ fn threshold_to_nbpp(
     }
 
     if with_colormap {
+        // Both public entry points (`threshold_to_2bpp` / `threshold_to_4bpp`)
+        // reject `nlevels < 2`, so `nlevels - 1 >= 1` here.
         let mut cmap = PixColormap::new(out_depth.bits())?;
         for level in 0..nlevels {
-            let gray_val = if nlevels == 1 {
-                0
-            } else {
-                (level * 255 / (nlevels - 1)) as u8
-            };
+            let gray_val = (level * 255 / (nlevels - 1)) as u8;
             cmap.add_rgb(gray_val, gray_val, gray_val)?;
         }
         out_mut.set_colormap(Some(cmap))?;

--- a/src/color/threshold.rs
+++ b/src/color/threshold.rs
@@ -580,8 +580,8 @@ pub fn generate_mask_by_band(pix: &Pix, lower: u32, upper: u32, in_band: bool) -
 
 /// Quantize an 8bpp grayscale image to 2bpp (2, 3, or 4 levels).
 ///
-/// Returns a 2bpp image. The `with_colormap` parameter is accepted for API
-/// compatibility but colormap attachment is not yet implemented.
+/// Returns a 2bpp image. When `with_colormap` is true, an `nlevels`-entry
+/// grayscale colormap spanning `[0, 255]` linearly is attached to the output.
 ///
 /// # See also
 ///
@@ -597,8 +597,8 @@ pub fn threshold_to_2bpp(pix: &Pix, nlevels: u32, with_colormap: bool) -> ColorR
 
 /// Quantize an 8bpp grayscale image to 4bpp (2-16 levels).
 ///
-/// Returns a 4bpp image. The `with_colormap` parameter is accepted for API
-/// compatibility but colormap attachment is not yet implemented.
+/// Returns a 4bpp image. When `with_colormap` is true, an `nlevels`-entry
+/// grayscale colormap spanning `[0, 255]` linearly is attached to the output.
 ///
 /// # See also
 ///
@@ -617,7 +617,7 @@ fn threshold_to_nbpp(
     pix: &Pix,
     nlevels: u32,
     out_depth: PixelDepth,
-    _with_colormap: bool,
+    with_colormap: bool,
 ) -> ColorResult<Pix> {
     let gray = ensure_grayscale(pix)?;
     let w = gray.width();
@@ -640,7 +640,19 @@ fn threshold_to_nbpp(
         }
     }
 
-    // TODO: add colormap support when with_colormap is true
+    if with_colormap {
+        let mut cmap = PixColormap::new(out_depth.bits())?;
+        for level in 0..nlevels {
+            let gray_val = if nlevels == 1 {
+                0
+            } else {
+                (level * 255 / (nlevels - 1)) as u8
+            };
+            cmap.add_rgb(gray_val, gray_val, gray_val)?;
+        }
+        out_mut.set_colormap(Some(cmap))?;
+    }
+
     Ok(out_mut.into())
 }
 

--- a/tests/color/binarize_advanced_reg.rs
+++ b/tests/color/binarize_advanced_reg.rs
@@ -213,7 +213,6 @@ fn test_threshold_to_4bpp_invalid_levels() {
 }
 
 #[test]
-#[ignore = "not yet implemented: with_colormap=true cmap attachment"]
 fn test_threshold_to_2bpp_with_colormap() {
     let pix = make_gradient_8bpp(256, 1);
     let quantized = threshold_to_2bpp(&pix, 4, true).unwrap();
@@ -231,7 +230,6 @@ fn test_threshold_to_2bpp_with_colormap() {
 }
 
 #[test]
-#[ignore = "not yet implemented: with_colormap=true cmap attachment"]
 fn test_threshold_to_4bpp_with_colormap() {
     let pix = make_gradient_8bpp(256, 1);
     let quantized = threshold_to_4bpp(&pix, 16, true).unwrap();
@@ -249,7 +247,6 @@ fn test_threshold_to_4bpp_with_colormap() {
 }
 
 #[test]
-#[ignore = "not yet implemented: with_colormap=true cmap attachment"]
 fn test_threshold_to_4bpp_without_colormap() {
     // with_colormap=false must NOT attach a cmap (existing behavior preserved).
     let pix = make_gradient_8bpp(256, 1);

--- a/tests/color/binarize_advanced_reg.rs
+++ b/tests/color/binarize_advanced_reg.rs
@@ -212,6 +212,51 @@ fn test_threshold_to_4bpp_invalid_levels() {
     assert!(threshold_to_4bpp(&pix, 17, false).is_err());
 }
 
+#[test]
+#[ignore = "not yet implemented: with_colormap=true cmap attachment"]
+fn test_threshold_to_2bpp_with_colormap() {
+    let pix = make_gradient_8bpp(256, 1);
+    let quantized = threshold_to_2bpp(&pix, 4, true).unwrap();
+    assert_eq!(quantized.depth(), PixelDepth::Bit2);
+
+    // 4 grayscale levels evenly spread across [0, 255]
+    let cmap = quantized
+        .colormap()
+        .expect("with_colormap=true must attach a colormap");
+    assert_eq!(cmap.len(), 4);
+    assert_eq!(cmap.get_rgb(0), Some((0, 0, 0)));
+    assert_eq!(cmap.get_rgb(1), Some((85, 85, 85)));
+    assert_eq!(cmap.get_rgb(2), Some((170, 170, 170)));
+    assert_eq!(cmap.get_rgb(3), Some((255, 255, 255)));
+}
+
+#[test]
+#[ignore = "not yet implemented: with_colormap=true cmap attachment"]
+fn test_threshold_to_4bpp_with_colormap() {
+    let pix = make_gradient_8bpp(256, 1);
+    let quantized = threshold_to_4bpp(&pix, 16, true).unwrap();
+    assert_eq!(quantized.depth(), PixelDepth::Bit4);
+
+    let cmap = quantized
+        .colormap()
+        .expect("with_colormap=true must attach a colormap");
+    assert_eq!(cmap.len(), 16);
+    // Endpoints span [0, 255]; intermediate values lie on a linear ramp.
+    assert_eq!(cmap.get_rgb(0), Some((0, 0, 0)));
+    assert_eq!(cmap.get_rgb(15), Some((255, 255, 255)));
+    let v8 = (8u32 * 255 / 15) as u8;
+    assert_eq!(cmap.get_rgb(8), Some((v8, v8, v8)));
+}
+
+#[test]
+#[ignore = "not yet implemented: with_colormap=true cmap attachment"]
+fn test_threshold_to_4bpp_without_colormap() {
+    // with_colormap=false must NOT attach a cmap (existing behavior preserved).
+    let pix = make_gradient_8bpp(256, 1);
+    let quantized = threshold_to_4bpp(&pix, 4, false).unwrap();
+    assert!(quantized.colormap().is_none());
+}
+
 // ============================================================================
 // otsu_adaptive_threshold
 // ============================================================================


### PR DESCRIPTION
## Summary
- `threshold_to_2bpp` / `threshold_to_4bpp` の `with_colormap` フラグはこれまで受理だけしていたが、cmap は生成されていなかった。
- `with_colormap=true` のとき、`nlevels` 個のグレー entry を持つ `PixColormap` を出力 Pix に添付するよう実装。
- 各 entry のグレー値は線形 ramp: `level * 255 / (nlevels - 1)`。
- `with_colormap=false` の挙動は不変（cmap は `None`）。

C: `pixThresholdTo2bpp` / `pixThresholdTo4bpp` の `cmapflag=1` 経路相当。

## Commits
- `test(color): add threshold_to_Nbpp colormap expectations (RED)` — `#[ignore]` 付きで仕様を先にコミット
- `feat(color): attach grayscale colormap in threshold_to_Nbpp (GREEN)` — 実装と `#[ignore]` 除去

## Test plan
- [x] `cargo test --test color binarize_advanced_reg::test_threshold`
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)