### PR TITLE
feat(io): port rotateorthFilesToPdf from C leptonica bb244a31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ all-formats = ["bmp", "pnm", "png-format", "jpeg", "gif-format",
 [profile.dev]
 opt-level = 1
 
+[[example]]
+name = "rotateorthpdf"
+required-features = ["pdf-format"]

--- a/docs/plans/030_pdf-rotate-orth-files.md
+++ b/docs/plans/030_pdf-rotate-orth-files.md
@@ -1,6 +1,6 @@
 # rotateorthFilesToPdf の Rust 移植
 
-Status: PLANNED
+Status: IMPLEMENTED
 
 ## Context
 

--- a/docs/plans/030_pdf-rotate-orth-files.md
+++ b/docs/plans/030_pdf-rotate-orth-files.md
@@ -1,0 +1,56 @@
+# rotateorthFilesToPdf の Rust 移植
+
+Status: PLANNED
+
+## Context
+
+C 版 leptonica のコミット `bb244a3176f3d9a29acb33458548b56776f87a25`
+（"New program for selective orthogonal rotation of images in a pdf."）で、
+`src/pdfapp.c` に `rotateorthFilesToPdf()` が追加された。
+3 種類のモードを持つ回転指定文字列に従って、画像群を選択的に 90° 単位で
+回転 → スケール → PDF 化する高水準ヘルパーである。
+
+Rust 版には既に同系統の関数 (`compress_files_to_pdf`,
+`crop_files_to_pdf`, `clean_to_1bpp_files_to_pdf`) が `src/io/pdf.rs` に実装
+されているが、`rotate_orth_files_to_pdf` 相当が無いため、画像の選択的直交
+回転を伴う PDF 化を行いたい場合の標準 API が無い。
+
+## Goal
+
+| C 版                                           | Rust 版                                          | 場所                              |
+| ---------------------------------------------- | ------------------------------------------------ | --------------------------------- |
+| `rotateorthFilesToPdf` (`src/pdfapp.c`)        | `rotate_orth_files_to_pdf`                       | `src/io/pdf.rs`                   |
+| `parseRotationString` (`src/pdfapp.c`, static) | `parse_rotation_string`                          | `src/io/pdf.rs`（モジュール内）   |
+| `prog/rotateorthpdf.c`                         | `examples/rotateorthpdf.rs`                      | `examples/`                       |
+
+### 回転指定文字列の仕様
+
+- **Mode 1** (`'0'..='3'` で開始): 各文字 1 桁が画像 i の 90° cw 回転回数。
+  文字列長が画像数より短ければ、残りは 0 (無回転)。
+- **Mode 2** (`'4'` で開始): 続く 1 桁を全画像に共通で適用。
+- **Mode 3** (`'5'` で開始): `(index, rotval)` ペアの並び。区切り文字は任意
+  (`,`, `;`, `#`, 空白等は無視)。範囲外 / 無効ペアは警告してスキップ。
+  解釈は `sscanf("(%d,%d)", ...)` 相当。
+
+戻り値は長さ `n` の `Vec<u8>` (各値は `0..=3`)。
+
+## 非Goal
+
+- C 版 `l_pdfRenderFile()`（外部 `pdftoppm` 呼び出しによる PDF→画像変換）の
+  移植は対象外。これは元々 Rust 版でも未対応の領域で、独立した課題。
+- C 版が `n > 25` で `PIXAC` (圧縮 pixa) に切り替えるメモリ最適化は、
+  Rust 版では `Pixa` 1 種類で扱う（`Pixa` は `Vec<Pix>` 相当で `Arc` 共有
+  されているため、C 版ほどメモリ圧迫しない）。
+
+## TDD コミット構成
+
+1. **RED**: `parse_rotation_string` のユニットテスト（3 モード × 正常 / 異常）と、
+   `rotate_orth_files_to_pdf` の統合テスト（PNG ファイル数枚を入力に PDF 出力で
+   先頭が `%PDF-` であること、ページ数が一致することを検証）。
+   `parse_rotation_string` / `rotate_orth_files_to_pdf` のシグネチャだけ追加し、
+   本体は `unimplemented!()` で `#[ignore]` 付き。
+2. **GREEN**: 本体実装。`#[ignore]` を外す。
+3. **REFACTOR** (必要に応じて)
+
+その後 `examples/rotateorthpdf.rs` を別コミットで追加し、
+`docs/plans/030_pdf-rotate-orth-files.md` の Status を IMPLEMENTED に更新。

--- a/examples/rotateorthpdf.rs
+++ b/examples/rotateorthpdf.rs
@@ -1,0 +1,98 @@
+//! Rotate selected images by 90° increments and combine them into a PDF.
+//!
+//! Rust port of C Leptonica's `prog/rotateorthpdf.c`.
+//!
+//! # Usage
+//!
+//! ```text
+//! rotateorthpdf <indir> <substr> <rotstring> <scalefactor> <quality> <title> <fileout>
+//! ```
+//!
+//! * `indir` — directory containing input images
+//! * `substr` — substring filter (`""` for all files)
+//! * `rotstring` — rotation specifier; see `parse_rotation_string` for the
+//!   three accepted modes (per-image digits, uniform, or `(idx,rot)` pairs)
+//! * `scalefactor` — `0.0` selects the default of `1.0`, otherwise clamped to
+//!   `(0.0, 2.0]`
+//! * `quality` — JPEG quality, `0` for default 75, otherwise clamped to `[25, 95]`
+//! * `title` — pdf title; use `none` to omit
+//! * `fileout` — output pdf path
+//!
+//! # Examples
+//!
+//! ```sh
+//! # Rotate page 2 by 180° and page 4 by 90° cw
+//! cargo run --example rotateorthpdf -- ./scans "" 00201 1.0 0 "scanned" out.pdf
+//!
+//! # Rotate every page by 90° cw
+//! cargo run --example rotateorthpdf -- ./scans "" 41 1.0 0 none out.pdf
+//!
+//! # Rotate only the listed pages
+//! cargo run --example rotateorthpdf -- ./scans "" "5(3,2)(8,1)" 1.0 0 none out.pdf
+//! ```
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use leptonica::io::pdf::rotate_orth_files_to_pdf;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 8 {
+        eprintln!(
+            "usage: {} <indir> <substr> <rotstring> <scalefactor> <quality> <title> <fileout>",
+            args[0]
+        );
+        return ExitCode::from(1);
+    }
+
+    let indir = &args[1];
+    let substr = &args[2];
+    let rotstring = &args[3];
+    let scalefactor: f32 = args[4].parse().unwrap_or(1.0);
+    let quality: i32 = args[5].parse().unwrap_or(0);
+    let title = &args[6];
+    let fileout = &args[7];
+
+    let mut paths: Vec<PathBuf> = match fs::read_dir(indir) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.is_file())
+            .filter(|p| {
+                substr.is_empty()
+                    || p.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.contains(substr.as_str()))
+                        .unwrap_or(false)
+            })
+            .collect(),
+        Err(e) => {
+            eprintln!("failed to read directory {indir}: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    paths.sort();
+
+    if paths.is_empty() {
+        eprintln!("no input images matched (dir={indir}, substr={substr:?})");
+        return ExitCode::from(1);
+    }
+
+    eprintln!("rotating {} images ...", paths.len());
+    let pdf = match rotate_orth_files_to_pdf(&paths, rotstring, scalefactor, quality, title) {
+        Ok(buf) => buf,
+        Err(e) => {
+            eprintln!("rotate_orth_files_to_pdf failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    if let Err(e) = fs::write(fileout, &pdf) {
+        eprintln!("failed to write {fileout}: {e}");
+        return ExitCode::from(1);
+    }
+    eprintln!("wrote {fileout} ({} bytes)", pdf.len());
+    ExitCode::SUCCESS
+}

--- a/src/io/pdf.rs
+++ b/src/io/pdf.rs
@@ -1044,6 +1044,59 @@ pub fn clean_to_1bpp_files_to_pdf(
     Ok(buf)
 }
 
+/// Rotate selected images by orthogonal (90° cw) increments and combine into a PDF.
+///
+/// Mirrors C Leptonica `rotateorthFilesToPdf()` (`pdfapp.c`).
+///
+/// # Arguments
+///
+/// * `paths` - sorted full pathnames of input images
+/// * `rotstring` - rotation specifier; see [`parse_rotation_string`] for the
+///   three accepted modes
+/// * `scalefactor` - scaling factor applied to each image; clamped to `(0.0, 2.0]`
+/// * `quality` - JPEG quality (25–95). `<= 0` selects the default of 75
+/// * `title` - optional PDF title; `"none"` is treated as no title
+///
+/// # Reference
+///
+/// C Leptonica: `rotateorthFilesToPdf()` in `pdfapp.c`
+pub fn rotate_orth_files_to_pdf(
+    paths: &[impl AsRef<Path>],
+    rotstring: &str,
+    scalefactor: f32,
+    quality: i32,
+    title: &str,
+) -> IoResult<Vec<u8>> {
+    // Stitched together so parse_rotation_string is referenced even before
+    // the GREEN step lands (avoids a dead_code warning).
+    let _ = parse_rotation_string(paths.len(), rotstring);
+    let _ = (scalefactor, quality, title);
+    unimplemented!("rotate_orth_files_to_pdf: implementation pending (plan 030 GREEN)")
+}
+
+/// Parse a rotation specifier string into a per-image rotation table.
+///
+/// The output vector has length `n` and each entry is in `0..=3` (number of
+/// 90° clockwise rotations). The string supports three modes, matching C
+/// Leptonica's `parseRotationString()`:
+///
+/// - **Mode 1** (string starts with `'0'`–`'3'`): each character is a
+///   rotation digit for the image at that index. Trailing images beyond
+///   the string length are kept at 0. Characters past the n-th are ignored.
+/// - **Mode 2** (string starts with `'4'`): the second character supplies a
+///   single rotation that is applied to every image.
+/// - **Mode 3** (string starts with `'5'`): a sequence of `(index,rotval)`
+///   pairs. Arbitrary separators between pairs are ignored. Pairs with
+///   out-of-range index or invalid rotval are reported via `log` and
+///   skipped without failing the call.
+///
+/// Returns an error only when `rotstring` is empty or starts with an
+/// unsupported leading character.
+pub(crate) fn parse_rotation_string(n: usize, rotstring: &str) -> IoResult<Vec<u8>> {
+    let _ = (n, rotstring);
+    unimplemented!("parse_rotation_string: implementation pending (plan 030 GREEN)")
+}
+
 /// Simple threshold binarization for PDF app functions.
 fn pix_to_1bpp(pix: &Pix, threshold: u32) -> Pix {
     let w = pix.width();
@@ -1317,6 +1370,89 @@ mod tests {
         assert!(buffer.len() > 200);
 
         // Cleanup
+        let _ = std::fs::remove_dir_all(&outdir);
+    }
+
+    // ------------------------------------------------------------------
+    // parse_rotation_string / rotate_orth_files_to_pdf (plan 030, RED)
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_parse_rotation_string_mode1_basic() {
+        // "00201" → image 2 rotated 180°, image 4 rotated 90°.
+        let rot = parse_rotation_string(7, "00201").unwrap();
+        assert_eq!(rot, vec![0, 0, 2, 0, 1, 0, 0]);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_parse_rotation_string_mode1_truncates_to_n() {
+        // String longer than n: extra characters are ignored.
+        let rot = parse_rotation_string(3, "31230").unwrap();
+        assert_eq!(rot, vec![3, 1, 2]);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_parse_rotation_string_mode2_all_same() {
+        // "41" → every image rotated 90° cw.
+        let rot = parse_rotation_string(4, "41").unwrap();
+        assert_eq!(rot, vec![1, 1, 1, 1]);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_parse_rotation_string_mode3_pairs() {
+        // "5(3,2)(2,1)(8,1)(23,1)" with n=10:
+        //   image 2 → 1, image 3 → 2, image 8 → 1; image 23 is out of range
+        //   and silently skipped.
+        let rot = parse_rotation_string(10, "5(3,2)(2,1)(8,1)(23,1)").unwrap();
+        assert_eq!(rot, vec![0, 0, 1, 2, 0, 0, 0, 0, 1, 0]);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_parse_rotation_string_mode3_with_separators() {
+        // Arbitrary separators between parenthesized pairs are tolerated.
+        let rot = parse_rotation_string(5, "5::(3,2),(2,1)##(4,3)").unwrap();
+        assert_eq!(rot, vec![0, 0, 1, 2, 3]);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_parse_rotation_string_invalid_mode() {
+        // Leading character outside '0'..='5' is rejected.
+        assert!(parse_rotation_string(3, "9").is_err());
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_parse_rotation_string_empty_string() {
+        assert!(parse_rotation_string(3, "").is_err());
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_rotate_orth_files_to_pdf_basic() {
+        let outdir = std::env::temp_dir().join("leptonica_rotate_orth_pdf");
+        std::fs::create_dir_all(&outdir).unwrap();
+
+        // Create three small RGB pages at distinct sizes.
+        let mut paths = Vec::new();
+        for i in 0..3 {
+            let pix = Pix::new(40 + i * 10, 30 + i * 5, PixelDepth::Bit32).unwrap();
+            let p = outdir.join(format!("page_{i}.pnm"));
+            crate::io::write_image(&pix, &p, crate::core::ImageFormat::Pnm).unwrap();
+            paths.push(p);
+        }
+
+        // Rotate page 1 by 90° cw, page 2 by 180°.
+        let pdf = rotate_orth_files_to_pdf(&paths, "012", 1.0, 0, "rotate-orth").unwrap();
+        assert!(pdf.starts_with(b"%PDF-"));
+        let pages = get_pdf_page_count(&pdf).unwrap();
+        assert_eq!(pages, 3);
+
         let _ = std::fs::remove_dir_all(&outdir);
     }
 }

--- a/src/io/pdf.rs
+++ b/src/io/pdf.rs
@@ -1131,8 +1131,14 @@ pub fn rotate_orth_files_to_pdf(
     } else {
         Some(title.to_string())
     };
+    // Pick compression from the first page so the documented `quality`
+    // parameter actually influences encoding (Auto would always pick Flate
+    // and ignore `quality`). select_default_encoding gives Jpeg for 32bpp
+    // RGB and Flate for low-depth, matching C 版 rotateorthFilesToPdf which
+    // writes RGB pages with DCT.
+    let compression = select_default_encoding(first);
     let options = PdfOptions {
-        compression: PdfCompression::Auto,
+        compression,
         quality: quality_clamped,
         resolution: res.max(0) as u32,
         title: title_owned,

--- a/src/io/pdf.rs
+++ b/src/io/pdf.rs
@@ -1137,10 +1137,13 @@ pub fn rotate_orth_files_to_pdf(
     // RGB and Flate for low-depth, matching C 版 rotateorthFilesToPdf which
     // writes RGB pages with DCT.
     let compression = select_default_encoding(first);
+    // Clamp to >= 1: PdfOptions treats resolution == 0 as "unset" and falls
+    // back to the image's xres / DEFAULT_RESOLUTION, which would defeat the
+    // intent of infer_resolution for very small images (1px long side, etc.).
     let options = PdfOptions {
         compression,
         quality: quality_clamped,
-        resolution: res.max(0) as u32,
+        resolution: (res.max(1)) as u32,
         title: title_owned,
     };
 

--- a/src/io/pdf.rs
+++ b/src/io/pdf.rs
@@ -1067,11 +1067,81 @@ pub fn rotate_orth_files_to_pdf(
     quality: i32,
     title: &str,
 ) -> IoResult<Vec<u8>> {
-    // Stitched together so parse_rotation_string is referenced even before
-    // the GREEN step lands (avoids a dead_code warning).
-    let _ = parse_rotation_string(paths.len(), rotstring);
-    let _ = (scalefactor, quality, title);
-    unimplemented!("rotate_orth_files_to_pdf: implementation pending (plan 030 GREEN)")
+    if paths.is_empty() {
+        return Err(IoError::InvalidData("no files provided".into()));
+    }
+
+    let scale_clamped = if scalefactor <= 0.0 {
+        1.0
+    } else if scalefactor > 2.0 {
+        2.0
+    } else {
+        scalefactor
+    };
+    let quality_clamped: u8 = if quality <= 0 {
+        75
+    } else if quality < 25 {
+        25
+    } else if quality > 95 {
+        95
+    } else {
+        quality as u8
+    };
+
+    let rotations = parse_rotation_string(paths.len(), rotstring)?;
+
+    let mut pixa = crate::core::Pixa::new();
+    for (i, path) in paths.iter().enumerate() {
+        let pix = crate::io::read_image(path.as_ref())?;
+        let pix = pix
+            .remove_colormap(crate::core::pix::RemoveColormapTarget::BasedOnSrc)
+            .map_err(|e| IoError::InvalidData(format!("remove_colormap failed: {e}")))?;
+        let rotated = if rotations[i] != 0 {
+            crate::transform::rotate_orth(&pix, rotations[i] as u32)
+                .map_err(|e| IoError::InvalidData(format!("rotate_orth failed: {e}")))?
+        } else {
+            pix
+        };
+        let scaled = if (scale_clamped - 1.0).abs() < f32::EPSILON {
+            rotated
+        } else {
+            crate::transform::scale(
+                &rotated,
+                scale_clamped,
+                scale_clamped,
+                crate::transform::ScaleMethod::Auto,
+            )
+            .map_err(|e| IoError::InvalidData(format!("scale failed: {e}")))?
+        };
+        pixa.push(scaled);
+    }
+
+    // Infer resolution from the first image: the longest side maps to
+    // (scalefactor * 11.0) inches when printed.
+    let first = pixa
+        .pix_slice()
+        .first()
+        .ok_or_else(|| IoError::InvalidData("pixa is empty after processing".into()))?;
+    let res = first
+        .infer_resolution(scale_clamped * 11.0)
+        .map_err(|e| IoError::InvalidData(format!("infer_resolution failed: {e}")))?;
+
+    let title_owned = if title == "none" {
+        None
+    } else {
+        Some(title.to_string())
+    };
+    let options = PdfOptions {
+        compression: PdfCompression::Auto,
+        quality: quality_clamped,
+        resolution: res.max(0) as u32,
+        title: title_owned,
+    };
+
+    let pix_refs: Vec<&Pix> = pixa.pix_slice().iter().collect();
+    let mut buf = Vec::new();
+    write_pdf_multi(&pix_refs, &mut buf, &options)?;
+    Ok(buf)
 }
 
 /// Parse a rotation specifier string into a per-image rotation table.
@@ -1093,8 +1163,82 @@ pub fn rotate_orth_files_to_pdf(
 /// Returns an error only when `rotstring` is empty or starts with an
 /// unsupported leading character.
 pub(crate) fn parse_rotation_string(n: usize, rotstring: &str) -> IoResult<Vec<u8>> {
-    let _ = (n, rotstring);
-    unimplemented!("parse_rotation_string: implementation pending (plan 030 GREEN)")
+    if rotstring.is_empty() {
+        return Err(IoError::InvalidData("rotstring is empty".into()));
+    }
+
+    let bytes = rotstring.as_bytes();
+    let mut out = vec![0u8; n];
+
+    match bytes[0] {
+        b'0'..=b'3' => {
+            // Mode 1: each character is the rotation digit for that index.
+            // Characters past min(len, n) are ignored. Non-digit or out-of-range
+            // characters are treated as 0 rather than returning garbage values
+            // (C Leptonica computes `c - '0'` blindly).
+            let max = bytes.len().min(n);
+            for (i, &c) in bytes.iter().take(max).enumerate() {
+                if (b'0'..=b'3').contains(&c) {
+                    out[i] = c - b'0';
+                }
+            }
+        }
+        b'4' => {
+            // Mode 2: second character supplies one rotation for every image.
+            if bytes.len() < 2 {
+                return Err(IoError::InvalidData(
+                    "rotstring mode 2 requires a rotation digit after '4'".into(),
+                ));
+            }
+            let c = bytes[1];
+            let v = if (b'0'..=b'3').contains(&c) {
+                c - b'0'
+            } else {
+                0
+            };
+            for slot in out.iter_mut() {
+                *slot = v;
+            }
+        }
+        b'5' => {
+            // Mode 3: scan for "(idx,rotval)" pairs. Out-of-range pairs are
+            // skipped; arbitrary separator characters between pairs are ignored.
+            let mut search = &rotstring[1..];
+            let mut base = 1usize;
+            while let Some(open_off) = search.find('(') {
+                let open = base + open_off;
+                let after_open = &rotstring[open + 1..];
+                let Some(close_off) = after_open.find(')') else {
+                    break;
+                };
+                let inner = &after_open[..close_off];
+                let close = open + 1 + close_off;
+
+                if let Some((s_idx, s_val)) = inner.split_once(',')
+                    && let (Ok(image_idx), Ok(rotval)) =
+                        (s_idx.trim().parse::<i64>(), s_val.trim().parse::<i64>())
+                    && image_idx >= 0
+                    && (image_idx as usize) < n
+                    && (0..=3).contains(&rotval)
+                {
+                    out[image_idx as usize] = rotval as u8;
+                }
+
+                base = close + 1;
+                if base >= rotstring.len() {
+                    break;
+                }
+                search = &rotstring[base..];
+            }
+        }
+        other => {
+            return Err(IoError::InvalidData(format!(
+                "rotstring must start with '0'..='5', got {:?}",
+                other as char
+            )));
+        }
+    }
+    Ok(out)
 }
 
 /// Simple threshold binarization for PDF app functions.
@@ -1378,7 +1522,6 @@ mod tests {
     // ------------------------------------------------------------------
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_parse_rotation_string_mode1_basic() {
         // "00201" → image 2 rotated 180°, image 4 rotated 90°.
         let rot = parse_rotation_string(7, "00201").unwrap();
@@ -1386,7 +1529,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_parse_rotation_string_mode1_truncates_to_n() {
         // String longer than n: extra characters are ignored.
         let rot = parse_rotation_string(3, "31230").unwrap();
@@ -1394,7 +1536,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_parse_rotation_string_mode2_all_same() {
         // "41" → every image rotated 90° cw.
         let rot = parse_rotation_string(4, "41").unwrap();
@@ -1402,7 +1543,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_parse_rotation_string_mode3_pairs() {
         // "5(3,2)(2,1)(8,1)(23,1)" with n=10:
         //   image 2 → 1, image 3 → 2, image 8 → 1; image 23 is out of range
@@ -1412,7 +1552,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_parse_rotation_string_mode3_with_separators() {
         // Arbitrary separators between parenthesized pairs are tolerated.
         let rot = parse_rotation_string(5, "5::(3,2),(2,1)##(4,3)").unwrap();
@@ -1420,20 +1559,17 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_parse_rotation_string_invalid_mode() {
         // Leading character outside '0'..='5' is rejected.
         assert!(parse_rotation_string(3, "9").is_err());
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_parse_rotation_string_empty_string() {
         assert!(parse_rotation_string(3, "").is_err());
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_rotate_orth_files_to_pdf_basic() {
         let outdir = std::env::temp_dir().join("leptonica_rotate_orth_pdf");
         std::fs::create_dir_all(&outdir).unwrap();

--- a/src/io/pdf.rs
+++ b/src/io/pdf.rs
@@ -1093,9 +1093,14 @@ pub fn rotate_orth_files_to_pdf(
     let mut pixa = crate::core::Pixa::new();
     for (i, path) in paths.iter().enumerate() {
         let pix = crate::io::read_image(path.as_ref())?;
-        let pix = pix
-            .remove_colormap(crate::core::pix::RemoveColormapTarget::BasedOnSrc)
-            .map_err(|e| IoError::InvalidData(format!("remove_colormap failed: {e}")))?;
+        // remove_colormap(BasedOnSrc) deep-copies even when no colormap is
+        // present, so guard against the common no-colormap case.
+        let pix = if pix.has_colormap() {
+            pix.remove_colormap(crate::core::pix::RemoveColormapTarget::BasedOnSrc)
+                .map_err(|e| IoError::InvalidData(format!("remove_colormap failed: {e}")))?
+        } else {
+            pix
+        };
         let rotated = if rotations[i] != 0 {
             crate::transform::rotate_orth(&pix, rotations[i] as u32)
                 .map_err(|e| IoError::InvalidData(format!("rotate_orth failed: {e}")))?

--- a/src/io/pdf.rs
+++ b/src/io/pdf.rs
@@ -1171,8 +1171,8 @@ pub fn rotate_orth_files_to_pdf(
 ///   single rotation that is applied to every image.
 /// - **Mode 3** (string starts with `'5'`): a sequence of `(index,rotval)`
 ///   pairs. Arbitrary separators between pairs are ignored. Pairs with
-///   out-of-range index or invalid rotval are reported via `log` and
-///   skipped without failing the call.
+///   out-of-range index or invalid rotval are silently skipped without
+///   failing the call.
 ///
 /// Returns an error only when `rotstring` is empty or starts with an
 /// unsupported leading character.


### PR DESCRIPTION
## Summary

C 版 leptonica のコミット `bb244a3176f3d9a29acb33458548b56776f87a25` で
`src/pdfapp.c` に追加された `rotateorthFilesToPdf()` を Rust に移植する。
回転指定文字列に従って画像群を 90° 単位で回転 → スケール → PDF 化する
高水準ヘルパーを `src/io/pdf.rs` に追加し、対応する CLI サンプル
`examples/rotateorthpdf.rs` も追加した。

詳細は `docs/plans/030_pdf-rotate-orth-files.md` を参照。

## Commits (TDD 構成)

1. `docs(plans): add plan 030 for rotate_orth_files_to_pdf port`
2. `test(io): add rotate_orth_files_to_pdf and parser tests (RED)`
3. `feat(io): implement rotate_orth_files_to_pdf and parser (GREEN)`
4. `feat(examples): add rotateorthpdf CLI sample`
5. `docs(plans): mark plan 030 as IMPLEMENTED`

## API

```rust
pub fn rotate_orth_files_to_pdf(
    paths: &[impl AsRef<Path>],
    rotstring: &str,
    scalefactor: f32,
    quality: i32,
    title: &str,
) -> IoResult<Vec<u8>>
```

`rotstring` は C 版 `parseRotationString()` と同じ 3 モード:

* **Mode 1** (`'0'..='3'` で開始): 各文字が画像 i の 90° cw 回転回数
* **Mode 2** (`'4'` で開始): 第 2 文字を全画像に共通適用
* **Mode 3** (`'5'` で開始): `(idx,rotval)` ペア列。区切り文字は任意

## Differences vs. C 版

* `n > 25` で `PIXAC` (圧縮 pixa) に切り替えるメモリ最適化は未対応
  (Rust 版 `Pixa` は `Vec<Pix>` 相当で問題化しにくい)
* C 版は `c - '0'` を無条件に行うため非数字 / 範囲外文字でも値が入るが、
  Rust 版は 0 へクランプ / スキップして無効値の混入を防ぐ
* `l_pdfRenderFile()` (外部 `pdftoppm` 呼び出し) は元々 Rust 版未対応で
  本 PR でも対象外

## Test plan

- [x] `cargo test --all-features` 全パス (2489 + 各モジュール)
- [x] `cargo clippy --all-features --tests --lib -- -D warnings` クリーン
- [x] `cargo fmt --all -- --check` クリーン
- [x] `cargo build --example rotateorthpdf --features pdf-format` 成功
- [x] `parse_rotation_string` の 3 モード × 正常 / 異常系 計 7 テストを追加
- [x] `rotate_orth_files_to_pdf` の統合テスト (3 ページ PNM → PDF) を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)