### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptonica"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## Summary

v0.4.0 → v0.4.1 のパッチリリース。

## 含まれる変更

- feat(io): port rotateorthFilesToPdf from C leptonica bb244a31 (#313)
  - \`rotate_orth_files_to_pdf\` / \`parse_rotation_string\` を追加
  - \`examples/rotateorthpdf.rs\` CLI サンプル追加
  - Plan 030 を IMPLEMENTED に更新

## SemVer の判断

新規 \`pub\` API を追加しているので厳密には minor bump (0.5.0) が
適切だが、既存 API は不変でヘルパー追加のみのため patch として
リリースする。

## Test plan

- [x] \`cargo check --all-features\` 成功
- [x] CI (fmt / clippy / test) 通過待ち
- [ ] マージ後 \`v0.4.1\` タグを切り CD ワークフローで crates.io に publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)