### PR TITLE
feat(core): port FPix orthogonal rotation, flips, and border ops

### DIFF
--- a/docs/plans/103_core-fpix-rotate-orth.md
+++ b/docs/plans/103_core-fpix-rotate-orth.md
@@ -1,69 +1,87 @@
-# core/fpix: 直交回転・反転の移植
+# core/fpix: 直交回転・反転・境界拡張の移植
 
-Status: PLANNED
+Status: IN_PROGRESS
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 B)
 
 ## Context
 
-C 版 `fpix2.c` のうち、FPix（浮動小数点画像）の直交回転・反転系が Rust に未移植。
+C 版 `fpix2.c` のうち、FPix（浮動小数点画像）の直交回転・反転・境界拡張系が
+Rust に未移植。`tests/core/fpix2_reg.rs` には 5 件の `#[ignore]` テストが残っている。
 
-| C 関数           | 行   | 役割                                      |
-| ---------------- | ---- | ----------------------------------------- |
-| `fpixRotateOrth` | 1706 | quads∈{0,1,2,3} で 90° 回転をディスパッチ |
-| `fpixRotate90`   | 1778 | direction=±1 の 90° 回転                  |
-| `fpixRotate180`  | 1747 | LR + TB flip                              |
-| `fpixFlipLR`     | 1844 | 左右反転（in-place 可）                   |
-| `fpixFlipTB`     | 後続 | 上下反転（in-place 可）                   |
+| C 関数                   | 行   | 役割                                      |
+| ------------------------ | ---- | ----------------------------------------- |
+| `fpixRotateOrth`         | 1706 | quads∈{0,1,2,3} で 90° 回転をディスパッチ |
+| `fpixRotate90`           | 1778 | direction=±1 の 90° 回転                  |
+| `fpixRotate180`          | 1747 | LR + TB flip                              |
+| `fpixFlipLR`             | 1844 | 左右反転                                  |
+| `fpixFlipTB`             | 1894 | 上下反転                                  |
+| `fpixAddBorder`          | -    | 単色（0 埋め）境界拡張                    |
+| `fpixAddMirroredBorder`  | 1433 | ミラー境界拡張                            |
+| `fpixAddContinuedBorder` | 1478 | エッジ値の延長境界拡張                    |
 
-Pix 側の `rotate_orth` は実装済み。FPix 側は座標移動のみで色変換不要なので素直に移植可能。
+Pix 側の `rotate_orth` / `add_mirrored_border` / `add_continued_border` は既に実装済み。
+FPix 側は座標移動と単純コピーのみで色変換不要なので素直に移植可能。
 
 ## 配置先・API 設計
 
-- ファイル: 既存 `src/core/fpix/mod.rs` に追記、または分割して `src/core/fpix/transform.rs` を新設
+- ファイル: `src/core/fpix/transform.rs` を新設（`mod.rs` から `pub mod transform`）
 - API:
 
 ```rust
 impl FPix {
     /// fpixRotateOrth 相当（quads ∈ 0..=3, 時計回り回数）
     pub fn rotate_orth(&self, quads: u8) -> Result<FPix>;
+    /// fpixRotate90 相当
     pub fn rotate_90(&self, direction: RotateDirection) -> Result<FPix>;
+    /// fpixRotate180 相当
     pub fn rotate_180(&self) -> Result<FPix>;
+    /// fpixFlipLR 相当
     pub fn flip_lr(&self) -> Result<FPix>;
+    /// fpixFlipTB 相当
     pub fn flip_tb(&self) -> Result<FPix>;
+
+    /// fpixAddBorder 相当（fill 値で四方を拡張）
+    pub fn add_border(&self, left: u32, right: u32, top: u32, bot: u32, fill: f32) -> Result<FPix>;
+    /// fpixAddMirroredBorder 相当
+    pub fn add_mirrored_border(&self, left: u32, right: u32, top: u32, bot: u32) -> Result<FPix>;
+    /// fpixAddContinuedBorder 相当
+    pub fn add_continued_border(&self, left: u32, right: u32, top: u32, bot: u32) -> Result<FPix>;
 }
 ```
 
-`RotateDirection` は `transform` モジュールの既存 enum を流用（無ければ `core::fpix` 内に定義）。
+`RotateDirection` は新規に `core::fpix::RotateDirection { Cw, Ccw }` として定義。
 in-place 版は提供せず、Rust では `&self → 新 FPix` のシンプル形に統一。
 
 ## TDD ステップ
 
-1. **RED** (`test(core): fpixRotateOrth/Rotate90/FlipLR/FlipTB の RED テスト`)
-   - `tests/core/fpix2_reg.rs` の `#[ignore = "fpix_rotate_orth not implemented"]` 等 5 件を unignore
-   - 既存テストは「未実装で skip」状態 → 実装を呼ぶ形に書き換え
-
-2. **GREEN** (`feat(core): FPix::rotate_orth/rotate_90/rotate_180/flip_lr/flip_tb`)
-   - 上記 API を実装
-   - row-major アクセスで wpl は 4-byte word 単位だが Rust では `Vec<f32>` ベースなので素直なインデックス計算
-
+1. **RED** (`test(core): FPix::rotate_orth/border の RED テスト`)
+   - `tests/core/fpix2_reg.rs` の 5 件の `#[ignore]` を解除し、テスト本体を埋める
+   - 実装は `unimplemented!()` の stub で公開し、テストは `#[ignore = "RED: ..."]` を付けたまま残す
+2. **GREEN** (`feat(core): FPix 直交回転・反転・境界拡張を実装`)
+   - 上記 API を本実装に置き換え、`#[ignore]` を解除
 3. **REFACTOR**: 不要
 
 ## テスト戦略
 
-- 既存 `fpix2_reg.rs` の golden manifest を `REGTEST_MODE=generate` で生成、再 compare で固定
-- Pix 側 `rotate_orth` との一貫性検証: グレー Pix → FPix 変換 → fpix.rotate_orth → Pix 戻し が pix.rotate_orth と一致
+- 既存 `fpix2_reg.rs` の 5 ケース:
+  - 90/180/270 直交回転は Pix 側 `rotate_orth` の結果と f32 値で完全一致を確認
+  - mirrored/continued border は Pix 側 `add_mirrored_border` / `add_continued_border` と
+
+    形状・値の一致を確認（int → float キャストで誤差なく比較可）
+
+- 必要に応じて `tests/golden_manifest.tsv` を `REGTEST_MODE=generate` で更新
 
 ## ブランチ・PR
 
 - ブランチ: `feat/core-fpix-rotate-orth`
-- PR: `feat(core): port fpix orthogonal rotation and flips`
+- PR: `feat(core): port FPix orthogonal rotation, flips, and border ops`
 - 1PR、RED → GREEN
 
 ## ステータス
 
-- [ ] RED コミット
-- [ ] GREEN コミット
-- [ ] manifest 更新
+- [ ] RED コミット（stub + ignored test 内容追加）
+- [ ] GREEN コミット（実装 + ignore 解除）
+- [ ] cargo test / clippy / fmt 通過
 - [ ] PR 作成・Copilot レビュー対応
 - [ ] /gh-pr-merge --merge
 - [ ] 031 全体計画書を IMPLEMENTED に更新

--- a/docs/plans/103_core-fpix-rotate-orth.md
+++ b/docs/plans/103_core-fpix-rotate-orth.md
@@ -5,8 +5,10 @@ Status: IMPLEMENTED
 
 ## Context
 
-C 版 `fpix2.c` のうち、FPix（浮動小数点画像）の直交回転・反転・境界拡張系が
-Rust に未移植。`tests/core/fpix2_reg.rs` には 5 件の `#[ignore]` テストが残っている。
+C 版 `fpix2.c` のうち、FPix（浮動小数点画像）の直交回転・反転・境界拡張系を
+Rust に移植する計画。起草時点で `tests/core/fpix2_reg.rs` には 5 件の
+`#[ignore]` テスト（rotate_orth_{90,180,270} / add_mirrored_border /
+add_continued_border）が残っていた。PR #316 で全て移植・unignore 済み。
 
 | C 関数                   | 行   | 役割                                      |
 | ------------------------ | ---- | ----------------------------------------- |
@@ -49,7 +51,8 @@ impl FPix {
 }
 ```
 
-`RotateDirection` は新規に `core::fpix::RotateDirection { Cw, Ccw }` として定義。
+`RotateDirection { Cw, Ccw }` は `core::fpix::transform` に新規定義し、
+`core::fpix` から re-export（どちらのパスでもアクセス可）。
 in-place 版は提供せず、Rust では `&self → 新 FPix` のシンプル形に統一。
 
 ## TDD ステップ

--- a/docs/plans/103_core-fpix-rotate-orth.md
+++ b/docs/plans/103_core-fpix-rotate-orth.md
@@ -1,6 +1,6 @@
 # core/fpix: 直交回転・反転・境界拡張の移植
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 B)
 
 ## Context

--- a/src/core/fpix/mod.rs
+++ b/src/core/fpix/mod.rs
@@ -23,6 +23,7 @@
 //! ```
 
 pub mod serial;
+pub mod transform;
 
 use crate::core::error::{Error, Result};
 use crate::core::pix::{Pix, PixelDepth};

--- a/src/core/fpix/mod.rs
+++ b/src/core/fpix/mod.rs
@@ -25,6 +25,8 @@
 pub mod serial;
 pub mod transform;
 
+pub use transform::RotateDirection;
+
 use crate::core::error::{Error, Result};
 use crate::core::pix::{Pix, PixelDepth};
 

--- a/src/core/fpix/transform.rs
+++ b/src/core/fpix/transform.rs
@@ -1,0 +1,94 @@
+//! Orthogonal rotations, flips and border extensions for FPix.
+//!
+//! C Leptonica equivalent: portions of `fpix2.c` (`fpixRotateOrth`,
+//! `fpixRotate90`, `fpixRotate180`, `fpixFlipLR`, `fpixFlipTB`,
+//! `fpixAddBorder`, `fpixAddMirroredBorder`, `fpixAddContinuedBorder`).
+
+use crate::core::error::Result;
+use crate::core::fpix::FPix;
+
+/// Direction of a 90° rotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotateDirection {
+    /// Clockwise rotation.
+    Cw,
+    /// Counter-clockwise rotation.
+    Ccw,
+}
+
+impl FPix {
+    /// Rotate by `quads * 90°` clockwise. `quads` must be in `0..=3`.
+    ///
+    /// C Leptonica equivalent: `fpixRotateOrth`
+    pub fn rotate_orth(&self, _quads: u8) -> Result<FPix> {
+        unimplemented!("FPix::rotate_orth: implemented in GREEN commit (plan 103)")
+    }
+
+    /// Rotate 90° in the given direction.
+    ///
+    /// C Leptonica equivalent: `fpixRotate90`
+    pub fn rotate_90(&self, _direction: RotateDirection) -> Result<FPix> {
+        unimplemented!("FPix::rotate_90: implemented in GREEN commit (plan 103)")
+    }
+
+    /// Rotate 180° (= LR flip + TB flip).
+    ///
+    /// C Leptonica equivalent: `fpixRotate180`
+    pub fn rotate_180(&self) -> Result<FPix> {
+        unimplemented!("FPix::rotate_180: implemented in GREEN commit (plan 103)")
+    }
+
+    /// Flip left-right.
+    ///
+    /// C Leptonica equivalent: `fpixFlipLR`
+    pub fn flip_lr(&self) -> Result<FPix> {
+        unimplemented!("FPix::flip_lr: implemented in GREEN commit (plan 103)")
+    }
+
+    /// Flip top-bottom.
+    ///
+    /// C Leptonica equivalent: `fpixFlipTB`
+    pub fn flip_tb(&self) -> Result<FPix> {
+        unimplemented!("FPix::flip_tb: implemented in GREEN commit (plan 103)")
+    }
+
+    /// Extend the FPix on each side, filling the border with `fill`.
+    ///
+    /// C Leptonica equivalent: `fpixAddBorder`
+    pub fn add_border(
+        &self,
+        _left: u32,
+        _right: u32,
+        _top: u32,
+        _bot: u32,
+        _fill: f32,
+    ) -> Result<FPix> {
+        unimplemented!("FPix::add_border: implemented in GREEN commit (plan 103)")
+    }
+
+    /// Extend the FPix on each side using mirror reflection.
+    ///
+    /// C Leptonica equivalent: `fpixAddMirroredBorder`
+    pub fn add_mirrored_border(
+        &self,
+        _left: u32,
+        _right: u32,
+        _top: u32,
+        _bot: u32,
+    ) -> Result<FPix> {
+        unimplemented!("FPix::add_mirrored_border: implemented in GREEN commit (plan 103)")
+    }
+
+    /// Extend the FPix on each side by replicating the boundary value.
+    ///
+    /// C Leptonica equivalent: `fpixAddContinuedBorder`
+    pub fn add_continued_border(
+        &self,
+        _left: u32,
+        _right: u32,
+        _top: u32,
+        _bot: u32,
+    ) -> Result<FPix> {
+        unimplemented!("FPix::add_continued_border: implemented in GREEN commit (plan 103)")
+    }
+}

--- a/src/core/fpix/transform.rs
+++ b/src/core/fpix/transform.rs
@@ -131,8 +131,13 @@ impl FPix {
     ///
     /// C Leptonica equivalent: `fpixAddMirroredBorder`
     pub fn add_mirrored_border(&self, left: u32, right: u32, top: u32, bot: u32) -> Result<FPix> {
-        let mut dst = self.add_border(left, right, top, bot, 0.0)?;
         let (ws, hs) = (self.width(), self.height());
+        if left > ws || right > ws || top > hs || bot > hs {
+            return Err(Error::InvalidParameter(
+                "mirror border size exceeds image dimension".into(),
+            ));
+        }
+        let mut dst = self.add_border(left, right, top, bot, 0.0)?;
         let wd = dst.width();
 
         // Left/right columns: mirror against the boundary just inside the border.

--- a/src/core/fpix/transform.rs
+++ b/src/core/fpix/transform.rs
@@ -4,7 +4,7 @@
 //! `fpixRotate90`, `fpixRotate180`, `fpixFlipLR`, `fpixFlipTB`,
 //! `fpixAddBorder`, `fpixAddMirroredBorder`, `fpixAddContinuedBorder`).
 
-use crate::core::error::Result;
+use crate::core::error::{Error, Result};
 use crate::core::fpix::FPix;
 
 /// Direction of a 90° rotation.
@@ -20,75 +20,183 @@ impl FPix {
     /// Rotate by `quads * 90°` clockwise. `quads` must be in `0..=3`.
     ///
     /// C Leptonica equivalent: `fpixRotateOrth`
-    pub fn rotate_orth(&self, _quads: u8) -> Result<FPix> {
-        unimplemented!("FPix::rotate_orth: implemented in GREEN commit (plan 103)")
+    pub fn rotate_orth(&self, quads: u8) -> Result<FPix> {
+        match quads {
+            0 => Ok(self.clone()),
+            1 => self.rotate_90(RotateDirection::Cw),
+            2 => self.rotate_180(),
+            3 => self.rotate_90(RotateDirection::Ccw),
+            _ => Err(Error::InvalidParameter(format!(
+                "quads must be in 0..=3, got {quads}"
+            ))),
+        }
     }
 
     /// Rotate 90° in the given direction.
     ///
     /// C Leptonica equivalent: `fpixRotate90`
-    pub fn rotate_90(&self, _direction: RotateDirection) -> Result<FPix> {
-        unimplemented!("FPix::rotate_90: implemented in GREEN commit (plan 103)")
+    pub fn rotate_90(&self, direction: RotateDirection) -> Result<FPix> {
+        let (ws, hs) = (self.width(), self.height());
+        let (wd, hd) = (hs, ws);
+        let mut dst = FPix::new(wd, hd)?;
+        let (xres, yres) = self.resolution();
+        dst.set_resolution(xres, yres);
+
+        match direction {
+            RotateDirection::Cw => {
+                // dst[x, y] = src[y, hs - 1 - x]
+                for y in 0..hd {
+                    for x in 0..wd {
+                        let v = self.get_pixel_unchecked(y, hs - 1 - x);
+                        dst.set_pixel_unchecked(x, y, v);
+                    }
+                }
+            }
+            RotateDirection::Ccw => {
+                // dst[x, y] = src[ws - 1 - y, x]
+                for y in 0..hd {
+                    for x in 0..wd {
+                        let v = self.get_pixel_unchecked(ws - 1 - y, x);
+                        dst.set_pixel_unchecked(x, y, v);
+                    }
+                }
+            }
+        }
+        Ok(dst)
     }
 
     /// Rotate 180° (= LR flip + TB flip).
     ///
     /// C Leptonica equivalent: `fpixRotate180`
     pub fn rotate_180(&self) -> Result<FPix> {
-        unimplemented!("FPix::rotate_180: implemented in GREEN commit (plan 103)")
+        self.flip_lr()?.flip_tb()
     }
 
     /// Flip left-right.
     ///
     /// C Leptonica equivalent: `fpixFlipLR`
     pub fn flip_lr(&self) -> Result<FPix> {
-        unimplemented!("FPix::flip_lr: implemented in GREEN commit (plan 103)")
+        let (w, h) = (self.width(), self.height());
+        let mut dst = FPix::new(w, h)?;
+        let (xres, yres) = self.resolution();
+        dst.set_resolution(xres, yres);
+        for y in 0..h {
+            for x in 0..w {
+                let v = self.get_pixel_unchecked(w - 1 - x, y);
+                dst.set_pixel_unchecked(x, y, v);
+            }
+        }
+        Ok(dst)
     }
 
     /// Flip top-bottom.
     ///
     /// C Leptonica equivalent: `fpixFlipTB`
     pub fn flip_tb(&self) -> Result<FPix> {
-        unimplemented!("FPix::flip_tb: implemented in GREEN commit (plan 103)")
+        let (w, h) = (self.width(), self.height());
+        let mut dst = FPix::new(w, h)?;
+        let (xres, yres) = self.resolution();
+        dst.set_resolution(xres, yres);
+        for y in 0..h {
+            // Copy row (h - 1 - y) of src into row y of dst.
+            let src_y = h - 1 - y;
+            for x in 0..w {
+                let v = self.get_pixel_unchecked(x, src_y);
+                dst.set_pixel_unchecked(x, y, v);
+            }
+        }
+        Ok(dst)
     }
 
     /// Extend the FPix on each side, filling the border with `fill`.
     ///
     /// C Leptonica equivalent: `fpixAddBorder`
-    pub fn add_border(
-        &self,
-        _left: u32,
-        _right: u32,
-        _top: u32,
-        _bot: u32,
-        _fill: f32,
-    ) -> Result<FPix> {
-        unimplemented!("FPix::add_border: implemented in GREEN commit (plan 103)")
+    pub fn add_border(&self, left: u32, right: u32, top: u32, bot: u32, fill: f32) -> Result<FPix> {
+        let (ws, hs) = (self.width(), self.height());
+        let wd = ws + left + right;
+        let hd = hs + top + bot;
+        let mut dst = FPix::new_with_value(wd, hd, fill)?;
+        let (xres, yres) = self.resolution();
+        dst.set_resolution(xres, yres);
+        for y in 0..hs {
+            for x in 0..ws {
+                let v = self.get_pixel_unchecked(x, y);
+                dst.set_pixel_unchecked(x + left, y + top, v);
+            }
+        }
+        Ok(dst)
     }
 
     /// Extend the FPix on each side using mirror reflection.
     ///
     /// C Leptonica equivalent: `fpixAddMirroredBorder`
-    pub fn add_mirrored_border(
-        &self,
-        _left: u32,
-        _right: u32,
-        _top: u32,
-        _bot: u32,
-    ) -> Result<FPix> {
-        unimplemented!("FPix::add_mirrored_border: implemented in GREEN commit (plan 103)")
+    pub fn add_mirrored_border(&self, left: u32, right: u32, top: u32, bot: u32) -> Result<FPix> {
+        let mut dst = self.add_border(left, right, top, bot, 0.0)?;
+        let (ws, hs) = (self.width(), self.height());
+        let wd = dst.width();
+
+        // Left/right columns: mirror against the boundary just inside the border.
+        for j in 0..left {
+            for y in 0..hs {
+                let v = dst.get_pixel_unchecked(left + j, top + y);
+                dst.set_pixel_unchecked(left - 1 - j, top + y, v);
+            }
+        }
+        for j in 0..right {
+            for y in 0..hs {
+                let v = dst.get_pixel_unchecked(left + ws - 1 - j, top + y);
+                dst.set_pixel_unchecked(left + ws + j, top + y, v);
+            }
+        }
+        // Top/bottom rows: mirror the entire row (now including the freshly
+        // filled left/right border columns).
+        for i in 0..top {
+            for x in 0..wd {
+                let v = dst.get_pixel_unchecked(x, top + i);
+                dst.set_pixel_unchecked(x, top - 1 - i, v);
+            }
+        }
+        for i in 0..bot {
+            for x in 0..wd {
+                let v = dst.get_pixel_unchecked(x, top + hs - 1 - i);
+                dst.set_pixel_unchecked(x, top + hs + i, v);
+            }
+        }
+        Ok(dst)
     }
 
     /// Extend the FPix on each side by replicating the boundary value.
     ///
     /// C Leptonica equivalent: `fpixAddContinuedBorder`
-    pub fn add_continued_border(
-        &self,
-        _left: u32,
-        _right: u32,
-        _top: u32,
-        _bot: u32,
-    ) -> Result<FPix> {
-        unimplemented!("FPix::add_continued_border: implemented in GREEN commit (plan 103)")
+    pub fn add_continued_border(&self, left: u32, right: u32, top: u32, bot: u32) -> Result<FPix> {
+        let mut dst = self.add_border(left, right, top, bot, 0.0)?;
+        let (ws, hs) = (self.width(), self.height());
+        let wd = dst.width();
+
+        for j in 0..left {
+            for y in 0..hs {
+                let v = dst.get_pixel_unchecked(left, top + y);
+                dst.set_pixel_unchecked(j, top + y, v);
+            }
+        }
+        for j in 0..right {
+            for y in 0..hs {
+                let v = dst.get_pixel_unchecked(left + ws - 1, top + y);
+                dst.set_pixel_unchecked(left + ws + j, top + y, v);
+            }
+        }
+        for i in 0..top {
+            for x in 0..wd {
+                let v = dst.get_pixel_unchecked(x, top);
+                dst.set_pixel_unchecked(x, i, v);
+            }
+        }
+        for i in 0..bot {
+            for x in 0..wd {
+                let v = dst.get_pixel_unchecked(x, top + hs - 1);
+                dst.set_pixel_unchecked(x, top + hs + i, v);
+            }
+        }
+        Ok(dst)
     }
 }

--- a/tests/core/fpix2_reg.rs
+++ b/tests/core/fpix2_reg.rs
@@ -116,6 +116,19 @@ fn fpix2_reg_add_mirrored_border() {
     }
 }
 
+/// FPix add_mirrored_border rejects oversized borders.
+#[test]
+fn fpix2_reg_add_mirrored_border_oversized_rejected() {
+    let src = make_positional_fpix(5, 3);
+    // left = 6 > width = 5 should error before any pixel access.
+    assert!(src.add_mirrored_border(6, 0, 0, 0).is_err());
+    assert!(src.add_mirrored_border(0, 6, 0, 0).is_err());
+    assert!(src.add_mirrored_border(0, 0, 4, 0).is_err());
+    assert!(src.add_mirrored_border(0, 0, 0, 4).is_err());
+    // Equal-to-dimension borders are allowed.
+    assert!(src.add_mirrored_border(5, 5, 3, 3).is_ok());
+}
+
 /// FPix continued border addition (C check 4).
 #[test]
 fn fpix2_reg_add_continued_border() {

--- a/tests/core/fpix2_reg.rs
+++ b/tests/core/fpix2_reg.rs
@@ -33,7 +33,6 @@ fn make_positional_fpix(w: u32, h: u32) -> FPix {
 /// rotate_orth(1) is one clockwise quarter-turn: result[i, j] = src[j, h-1-i]
 /// where the source has dimensions (w, h) and the destination (h, w).
 #[test]
-#[ignore = "RED: FPix::rotate_orth not yet implemented (plan 103)"]
 fn fpix2_reg_rotate_orth_90() {
     let src = make_positional_fpix(5, 3);
     let dst = src.rotate_orth(1).expect("rotate_orth(1)");
@@ -48,7 +47,6 @@ fn fpix2_reg_rotate_orth_90() {
 
 /// FPix orthogonal rotation by 180 degrees (C check 1).
 #[test]
-#[ignore = "RED: FPix::rotate_orth not yet implemented (plan 103)"]
 fn fpix2_reg_rotate_orth_180() {
     let src = make_positional_fpix(5, 3);
     let dst = src.rotate_orth(2).expect("rotate_orth(2)");
@@ -65,7 +63,6 @@ fn fpix2_reg_rotate_orth_180() {
 
 /// FPix orthogonal rotation by 270 degrees (C check 2).
 #[test]
-#[ignore = "RED: FPix::rotate_orth not yet implemented (plan 103)"]
 fn fpix2_reg_rotate_orth_270() {
     let src = make_positional_fpix(5, 3);
     let dst = src.rotate_orth(3).expect("rotate_orth(3)");
@@ -90,7 +87,6 @@ fn fpix2_reg_rotate_orth_270() {
 
 /// FPix mirrored border addition (C check 3).
 #[test]
-#[ignore = "RED: FPix::add_mirrored_border not yet implemented (plan 103)"]
 fn fpix2_reg_add_mirrored_border() {
     let src = make_positional_fpix(5, 3);
     let bordered = src.add_mirrored_border(2, 2, 1, 1).expect("mirror border");
@@ -122,7 +118,6 @@ fn fpix2_reg_add_mirrored_border() {
 
 /// FPix continued border addition (C check 4).
 #[test]
-#[ignore = "RED: FPix::add_continued_border not yet implemented (plan 103)"]
 fn fpix2_reg_add_continued_border() {
     let src = make_positional_fpix(5, 3);
     let bordered = src

--- a/tests/core/fpix2_reg.rs
+++ b/tests/core/fpix2_reg.rs
@@ -9,7 +9,20 @@
 //!
 //! C Leptonica: `fpix1.c`, `fpix2.c`
 
+use leptonica::core::fpix::transform::RotateDirection;
 use leptonica::{DPix, FPix, NegativeHandling};
+
+/// Build an FPix where the (x, y) value encodes its position so we can verify
+/// rotations and flips by inspecting individual pixel values.
+fn make_positional_fpix(w: u32, h: u32) -> FPix {
+    let mut fpix = FPix::new(w, h).unwrap();
+    for y in 0..h {
+        for x in 0..w {
+            fpix.set_pixel(x, y, (y * w + x) as f32).unwrap();
+        }
+    }
+    fpix
+}
 
 // ============================================================================
 // C-equivalent regression test skeletons (C checks 0–4)
@@ -17,49 +30,114 @@ use leptonica::{DPix, FPix, NegativeHandling};
 
 /// FPix orthogonal rotation by 90 degrees (C check 0).
 ///
-/// C: fpixRotateOrth(fpix1, 1) → compare with pixRotateOrth(pix2, 1)
+/// rotate_orth(1) is one clockwise quarter-turn: result[i, j] = src[j, h-1-i]
+/// where the source has dimensions (w, h) and the destination (h, w).
 #[test]
-#[ignore = "fpix_rotate_orth not implemented"]
+#[ignore = "RED: FPix::rotate_orth not yet implemented (plan 103)"]
 fn fpix2_reg_rotate_orth_90() {
-    // fpixRotateOrth not available in Rust FPix API
+    let src = make_positional_fpix(5, 3);
+    let dst = src.rotate_orth(1).expect("rotate_orth(1)");
+    assert_eq!((dst.width(), dst.height()), (3, 5));
+    for y in 0..dst.height() {
+        for x in 0..dst.width() {
+            let expected = src.get_pixel(y, src.height() - 1 - x).unwrap();
+            assert_eq!(dst.get_pixel(x, y).unwrap(), expected, "pixel ({x}, {y})");
+        }
+    }
 }
 
 /// FPix orthogonal rotation by 180 degrees (C check 1).
-///
-/// C: fpixRotateOrth(fpix1, 2) → compare with pixRotateOrth(pix2, 2)
 #[test]
-#[ignore = "fpix_rotate_orth not implemented"]
+#[ignore = "RED: FPix::rotate_orth not yet implemented (plan 103)"]
 fn fpix2_reg_rotate_orth_180() {
-    // fpixRotateOrth not available in Rust FPix API
+    let src = make_positional_fpix(5, 3);
+    let dst = src.rotate_orth(2).expect("rotate_orth(2)");
+    assert_eq!((dst.width(), dst.height()), (5, 3));
+    for y in 0..dst.height() {
+        for x in 0..dst.width() {
+            let expected = src
+                .get_pixel(src.width() - 1 - x, src.height() - 1 - y)
+                .unwrap();
+            assert_eq!(dst.get_pixel(x, y).unwrap(), expected, "pixel ({x}, {y})");
+        }
+    }
 }
 
 /// FPix orthogonal rotation by 270 degrees (C check 2).
-///
-/// C: fpixRotateOrth(fpix1, 3) → compare with pixRotateOrth(pix2, 3)
 #[test]
-#[ignore = "fpix_rotate_orth not implemented"]
+#[ignore = "RED: FPix::rotate_orth not yet implemented (plan 103)"]
 fn fpix2_reg_rotate_orth_270() {
-    // fpixRotateOrth not available in Rust FPix API
+    let src = make_positional_fpix(5, 3);
+    let dst = src.rotate_orth(3).expect("rotate_orth(3)");
+    assert_eq!((dst.width(), dst.height()), (3, 5));
+    for y in 0..dst.height() {
+        for x in 0..dst.width() {
+            let expected = src.get_pixel(src.width() - 1 - y, x).unwrap();
+            assert_eq!(dst.get_pixel(x, y).unwrap(), expected, "pixel ({x}, {y})");
+        }
+    }
+
+    // rotate_90 cw + ccw round-trip restores the source.
+    let cw = src.rotate_90(RotateDirection::Cw).unwrap();
+    let restored = cw.rotate_90(RotateDirection::Ccw).unwrap();
+    assert_eq!(restored.data(), src.data(), "cw + ccw should round-trip");
+
+    // flip_lr applied twice is identity.
+    let lr = src.flip_lr().unwrap();
+    let lr_lr = lr.flip_lr().unwrap();
+    assert_eq!(lr_lr.data(), src.data());
 }
 
 /// FPix mirrored border addition (C check 3).
-///
-/// C: fpixAddMirroredBorder(fpix1, 21, 21, 25, 25) → compare with
-///    pixAddMirroredBorder(pix2, 21, 21, 25, 25)
 #[test]
-#[ignore = "fpix_add_mirrored_border not implemented"]
+#[ignore = "RED: FPix::add_mirrored_border not yet implemented (plan 103)"]
 fn fpix2_reg_add_mirrored_border() {
-    // fpixAddMirroredBorder not available in Rust FPix API
+    let src = make_positional_fpix(5, 3);
+    let bordered = src.add_mirrored_border(2, 2, 1, 1).expect("mirror border");
+    assert_eq!((bordered.width(), bordered.height()), (9, 5));
+    // Top-left of the original pixel block sits at (2, 1).
+    for y in 0..3 {
+        for x in 0..5 {
+            assert_eq!(
+                bordered.get_pixel(x + 2, y + 1).unwrap(),
+                src.get_pixel(x, y).unwrap(),
+                "interior pixel ({x}, {y})",
+            );
+        }
+    }
+    // Mirror columns: column 1 (one in from left) should mirror original col 0.
+    for y in 0..3 {
+        assert_eq!(
+            bordered.get_pixel(1, y + 1).unwrap(),
+            src.get_pixel(0, y).unwrap(),
+            "mirror left col @ y={y}",
+        );
+        assert_eq!(
+            bordered.get_pixel(0, y + 1).unwrap(),
+            src.get_pixel(1, y).unwrap(),
+            "mirror left col2 @ y={y}",
+        );
+    }
 }
 
 /// FPix continued border addition (C check 4).
-///
-/// C: fpixAddContinuedBorder(fpix1, 21, 21, 25, 25) → compare with
-///    pixAddContinuedBorder(pix2, 21, 21, 25, 25)
 #[test]
-#[ignore = "fpix_add_continued_border not implemented"]
+#[ignore = "RED: FPix::add_continued_border not yet implemented (plan 103)"]
 fn fpix2_reg_add_continued_border() {
-    // fpixAddContinuedBorder not available in Rust FPix API
+    let src = make_positional_fpix(5, 3);
+    let bordered = src
+        .add_continued_border(2, 2, 1, 1)
+        .expect("continued border");
+    assert_eq!((bordered.width(), bordered.height()), (9, 5));
+    // Each border column repeats the nearest-edge value of the source.
+    for y in 0..3 {
+        let left_edge = src.get_pixel(0, y).unwrap();
+        let right_edge = src.get_pixel(4, y).unwrap();
+        for bx in 0..2 {
+            assert_eq!(bordered.get_pixel(bx, y + 1).unwrap(), left_edge);
+            assert_eq!(bordered.get_pixel(7 + bx, y + 1).unwrap(), right_edge);
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- 計画 [103_core-fpix-rotate-orth.md](https://github.com/tagawa0525/leptonica-rs/blob/feat/core-fpix-rotate-orth/docs/plans/103_core-fpix-rotate-orth.md) (項目 B) に従い、C 版 `fpix2.c` の FPix 直交回転・反転・境界拡張を移植
- 新規モジュール `src/core/fpix/transform.rs` に集約し、`RotateDirection { Cw, Ccw }` を公開
- `tests/core/fpix2_reg.rs` の 5 件の `#[ignore]` を解除

## What

| C version | Rust API |
|---|---|
| `fpixRotateOrth(quads)` | `FPix::rotate_orth(quads)` (0..=3) |
| `fpixRotate90(±1)` | `FPix::rotate_90(RotateDirection::{Cw, Ccw})` |
| `fpixRotate180` | `FPix::rotate_180` |
| `fpixFlipLR` | `FPix::flip_lr` |
| `fpixFlipTB` | `FPix::flip_tb` |
| `fpixAddBorder(l, r, t, b, fill)` | `FPix::add_border` |
| `fpixAddMirroredBorder` | `FPix::add_mirrored_border` |
| `fpixAddContinuedBorder` | `FPix::add_continued_border` |

In-place バリアントは Rust では提供せず、`&self → 新 FPix` のシンプル形に統一。

## Test plan

- [x] `cargo test --test core fpix2_reg_` で 5 件の新規テスト通過（rotate_orth_{90,180,270}, add_mirrored_border, add_continued_border）
- [x] `cargo test --all-features` 全件通過（core ignored 31→26）
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)