### PR TITLE
feat(io): support pixSetChromaSampling for JPEG writing

### DIFF
--- a/docs/plans/202_io-jpeg-chroma-sampling.md
+++ b/docs/plans/202_io-jpeg-chroma-sampling.md
@@ -81,9 +81,9 @@ else
 
 ## ステータス
 
-- [ ] jpeg-encoder API 調査
-- [ ] RED コミット
-- [ ] GREEN コミット
-- [ ] PR 作成・Copilot レビュー対応
+- [x] jpeg-encoder API 調査（0.7.0 に `Encoder::set_sampling_factor(SamplingFactor)` 確認、`F_1_1` / `F_2_2` 利用可）
+- [x] RED コミット（056a811）
+- [x] GREEN コミット（e19d01b）
+- [x] PR 作成・Copilot レビュー対応（PR #319）
 - [ ] /gh-pr-merge --merge
-- [ ] 031 全体計画書を IMPLEMENTED に更新
+- [ ] 031 全体計画書の表に PR #319 を反映

--- a/docs/plans/202_io-jpeg-chroma-sampling.md
+++ b/docs/plans/202_io-jpeg-chroma-sampling.md
@@ -1,6 +1,6 @@
 # io/jpeg: クロマサブサンプリング設定
 
-Status: PLANNED
+Status: IN_PROGRESS
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 E)
 
 ## Context

--- a/docs/plans/202_io-jpeg-chroma-sampling.md
+++ b/docs/plans/202_io-jpeg-chroma-sampling.md
@@ -1,6 +1,6 @@
 # io/jpeg: クロマサブサンプリング設定
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 E)
 
 ## Context

--- a/src/io/jpeg.rs
+++ b/src/io/jpeg.rs
@@ -160,6 +160,9 @@ pub fn read_jpeg<R: Read>(reader: R) -> IoResult<Pix> {
 /// C Leptonica: `pixWriteStreamJpeg()` in `jpegio.c`
 pub fn write_jpeg<W: Write>(pix: &Pix, writer: W, options: &JpegOptions) -> IoResult<()> {
     let quality = options.quality.clamp(1, 100);
+    // Capture the per-image chroma flag before any colormap/depth conversion
+    // produces a fresh Pix that drops the original `special` value.
+    let pix_orig_special = pix.special();
 
     // Convert pix to a form suitable for JPEG encoding.
     // Following C version logic: remove colormap based on source content,
@@ -187,7 +190,16 @@ pub fn write_jpeg<W: Write>(pix: &Pix, writer: W, options: &JpegOptions) -> IoRe
         )));
     }
 
-    let encoder = jpeg_encoder::Encoder::new(writer, quality);
+    // Honor the per-image chroma subsampling flag set by `set_chroma_sampling`.
+    // After `remove_colormap`/`convert_to_8` the working `pix` is a fresh copy,
+    // so look up `special` on the *original* input.
+    let no_subsample = pix_orig_special == NO_CHROMA_SAMPLING_JPEG;
+    let mut encoder = jpeg_encoder::Encoder::new(writer, quality);
+    encoder.set_sampling_factor(if no_subsample {
+        jpeg_encoder::SamplingFactor::F_1_1
+    } else {
+        jpeg_encoder::SamplingFactor::F_2_2
+    });
 
     // Cast to usize once to avoid repeated casts and u32 overflow in arithmetic.
     // Near the 65535×65535 limit: 65535 * 65535 * 3 = ~12.9 GB, which exceeds

--- a/src/io/jpeg.rs
+++ b/src/io/jpeg.rs
@@ -47,6 +47,10 @@ pub fn read_header_jpeg(data: &[u8]) -> IoResult<ImageHeader> {
     })
 }
 
+/// `Pix::special` flag value for "no chroma subsampling" on JPEG write
+/// (matches C Leptonica's `L_NO_CHROMA_SAMPLING_JPEG`).
+pub const NO_CHROMA_SAMPLING_JPEG: i32 = 1;
+
 /// Options for JPEG encoding
 pub struct JpegOptions {
     /// Quality setting (1-100, default 75)
@@ -56,6 +60,22 @@ pub struct JpegOptions {
 impl Default for JpegOptions {
     fn default() -> Self {
         Self { quality: 75 }
+    }
+}
+
+/// Configure chroma subsampling for the next JPEG write.
+///
+/// When `sampling` is `true` (the default), JPEG writes use 4:2:0 (2x2)
+/// subsampling — smaller files at minor quality cost. When `false`, writes
+/// use 4:4:4 (full chroma resolution) by stamping `NO_CHROMA_SAMPLING_JPEG`
+/// into [`Pix::special`].
+///
+/// C Leptonica equivalent: `pixSetChromaSampling`
+pub fn set_chroma_sampling(pix: &mut crate::core::PixMut, sampling: bool) {
+    if sampling {
+        pix.set_special(0);
+    } else {
+        pix.set_special(NO_CHROMA_SAMPLING_JPEG);
     }
 }
 

--- a/src/io/jpeg.rs
+++ b/src/io/jpeg.rs
@@ -63,7 +63,11 @@ impl Default for JpegOptions {
     }
 }
 
-/// Configure chroma subsampling for the next JPEG write.
+/// Configure chroma subsampling for JPEG writes of this `Pix`.
+///
+/// The choice is persisted on the image itself via [`Pix::special`], so it
+/// applies to every subsequent JPEG write of this `Pix` (or any deep clone
+/// that copies `special`) until changed again.
 ///
 /// When `sampling` is `true` (the default), JPEG writes use 4:2:0 (2x2)
 /// subsampling — smaller files at minor quality cost. When `false`, writes

--- a/tests/io/iomisc_reg.rs
+++ b/tests/io/iomisc_reg.rs
@@ -70,12 +70,50 @@ fn iomisc_reg_16bit_png() {
 }
 
 // ============================================================================
-// Tests 3-5: JPEG chroma sampling (not ported -- JPEG writer unavailable)
+// Tests 3-5: JPEG chroma sampling
 // ============================================================================
+/// Verify that `pixSetChromaSampling(false)` produces a different (typically
+/// larger and higher-fidelity) JPEG than the default 4:2:0 subsampling, and
+/// that the choice round-trips through the `Pix::special` field.
 #[test]
-#[ignore = "JPEG writer not implemented; pixSetChromaSampling() not implemented"]
+#[ignore = "RED: pixSetChromaSampling not yet implemented (plan 202)"]
 fn iomisc_reg_jpeg_chroma() {
-    eprintln!("SKIP: JPEG writer and chroma sampling control not yet implemented");
+    use leptonica::io::jpeg::{
+        JpegOptions, NO_CHROMA_SAMPLING_JPEG, set_chroma_sampling, write_jpeg,
+    };
+
+    let pixs = load_test_image("Leptonica.jpg").expect("load Leptonica.jpg");
+    assert_eq!(pixs.depth().bits(), 32, "expected RGB image");
+
+    // Default (4:2:0).
+    let mut buf_default: Vec<u8> = Vec::new();
+    write_jpeg(&pixs, &mut buf_default, &JpegOptions::default()).expect("default jpeg");
+
+    // Full chroma resolution via Pix::special.
+    let mut pm = pixs.to_mut();
+    set_chroma_sampling(&mut pm, false);
+    let pix_full: leptonica::Pix = pm.into();
+    assert_eq!(pix_full.special(), NO_CHROMA_SAMPLING_JPEG);
+    let mut buf_full: Vec<u8> = Vec::new();
+    write_jpeg(&pix_full, &mut buf_full, &JpegOptions::default()).expect("full-chroma jpeg");
+
+    // The two streams must differ, and full-chroma should not be smaller.
+    assert_ne!(
+        buf_default, buf_full,
+        "different chroma settings should produce different bytes",
+    );
+    assert!(
+        buf_full.len() >= buf_default.len(),
+        "full chroma ({}) should not be smaller than 4:2:0 ({})",
+        buf_full.len(),
+        buf_default.len(),
+    );
+
+    // set_chroma_sampling(true) restores the default state.
+    let mut pm_back = pix_full.to_mut();
+    set_chroma_sampling(&mut pm_back, true);
+    let pix_back: leptonica::Pix = pm_back.into();
+    assert_eq!(pix_back.special(), 0);
 }
 
 // ============================================================================

--- a/tests/io/iomisc_reg.rs
+++ b/tests/io/iomisc_reg.rs
@@ -72,9 +72,11 @@ fn iomisc_reg_16bit_png() {
 // ============================================================================
 // Tests 3-5: JPEG chroma sampling
 // ============================================================================
-/// Verify that `pixSetChromaSampling(false)` produces a different (typically
-/// larger and higher-fidelity) JPEG than the default 4:2:0 subsampling, and
-/// that the choice round-trips through the `Pix::special` field.
+/// Verify that `set_chroma_sampling(false)` produces a different (typically
+/// larger) JPEG than the default 4:2:0 subsampling, and that the choice
+/// round-trips through the `Pix::special` field. Fidelity checks (e.g. PSNR
+/// vs. the original) are intentionally out of scope here; we only assert the
+/// configuration is wired through to the encoder.
 #[test]
 
 fn iomisc_reg_jpeg_chroma() {

--- a/tests/io/iomisc_reg.rs
+++ b/tests/io/iomisc_reg.rs
@@ -76,7 +76,7 @@ fn iomisc_reg_16bit_png() {
 /// larger and higher-fidelity) JPEG than the default 4:2:0 subsampling, and
 /// that the choice round-trips through the `Pix::special` field.
 #[test]
-#[ignore = "RED: pixSetChromaSampling not yet implemented (plan 202)"]
+
 fn iomisc_reg_jpeg_chroma() {
     use leptonica::io::jpeg::{
         JpegOptions, NO_CHROMA_SAMPLING_JPEG, set_chroma_sampling, write_jpeg,


### PR DESCRIPTION
## Summary

- 計画 [202_io-jpeg-chroma-sampling.md](https://github.com/tagawa0525/leptonica-rs/blob/feat/io-jpeg-chroma-sampling/docs/plans/202_io-jpeg-chroma-sampling.md) (項目 E) に従い、C 版 `jpegio.c::pixSetChromaSampling` を Rust に移植
- `tests/io/iomisc_reg.rs::iomisc_reg_jpeg_chroma` の `#[ignore]` を解除（io ignored 37 → 36）

## What

`src/io/jpeg.rs` に以下を追加:

- `pub const NO_CHROMA_SAMPLING_JPEG: i32 = 1` (Leptonica `L_NO_CHROMA_SAMPLING_JPEG` 相当)
- `pub fn set_chroma_sampling(pix: &mut PixMut, sampling: bool)` — `Pix::special` を操作
- `write_jpeg` で入力 Pix の `special()` を見て `jpeg_encoder::SamplingFactor::F_1_1` (4:4:4) または `F_2_2` (4:2:0) を選択

## API 調査結果

`jpeg-encoder` 0.7.0 には `Encoder::set_sampling_factor(SamplingFactor)` があり、`F_1_1` (4:4:4 = no subsampling) と `F_2_2` (4:2:0 = 2x2 subsampling) を含む 8 種の YCbCr サンプリング比を指定できる。これを使えば C 版と等価な動作を実現可能。

## Test plan

- [x] `cargo test --test io iomisc_reg_jpeg_chroma` 通過
- [x] `cargo test --all-features` 全件通過（io ignored 37→36）
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)