### PR TITLE
feat(core): port arrayFindSequence and unignore sarray I/O tests

### DIFF
--- a/docs/plans/105_core-sarray-io.md
+++ b/docs/plans/105_core-sarray-io.md
@@ -1,0 +1,103 @@
+# core/sarray: ファイル/ストリーム I/O とバイト列検索
+
+Status: IN_PROGRESS
+親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 D)
+
+## Context
+
+C 版の以下が Rust に未移植。`tests/core/string_reg.rs` には 4 件の `#[ignore]`
+が残っている（うち hash 系 2 件は 031 で「不要」分類）。
+
+| C 関数              | 行             | 役割                                   |
+| ------------------- | -------------- | -------------------------------------- |
+| `sarrayWrite`       | sarray1.c:1483 | ASCII シリアライズしてファイル書き出し |
+| `sarrayWriteStream` | sarray1.c:1518 | 上記の Stream 版                       |
+| `sarrayWriteMem`    | sarray1.c:1581 | 上記の Memory 版                       |
+| `sarrayRead`        | sarray1.c:1351 | ASCII シリアライズからファイル読み込み |
+| `sarrayReadStream`  | sarray1.c:1388 | 上記の Stream 版                       |
+| `sarrayReadMem`     | sarray1.c:1457 | 上記の Memory 版                       |
+| `arrayFindSequence` | utils2.c:1205  | バイト列内で部分列を線形探索           |
+
+シリアライズフォーマット:
+
+```text
+\nSarray Version 1\n
+Number of strings = N\n
+  0[len0]:  string0\n
+  1[len1]:  string1\n
+  ...
+\n
+```
+
+`SARRAY_VERSION_NUMBER` は 1。
+
+## 配置先・API 設計
+
+- ファイル: `src/core/sarray/serial.rs` を新設（または `mod.rs` に追記）
+- 公開 API:
+
+```rust
+impl Sarray {
+    /// sarrayWrite 相当
+    pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()>;
+    /// sarrayWriteStream 相当
+    pub fn write_to_writer<W: Write>(&self, writer: &mut W) -> Result<()>;
+    /// sarrayWriteMem 相当
+    pub fn to_serialized_bytes(&self) -> Result<Vec<u8>>;
+
+    /// sarrayRead 相当
+    pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Sarray>;
+    /// sarrayReadStream 相当
+    pub fn read_from_reader<R: BufRead>(reader: R) -> Result<Sarray>;
+    /// sarrayReadMem 相当
+    pub fn from_serialized_bytes(bytes: &[u8]) -> Result<Sarray>;
+}
+
+/// arrayFindSequence 相当: data 中で sequence の最初の出現オフセットを返す。
+///
+/// 該当 C シグネチャは `(*poffset, *pfound)` だが、Rust では `Option<usize>`
+/// を返す形に圧縮する。
+pub fn array_find_sequence(data: &[u8], sequence: &[u8]) -> Option<usize>;
+```
+
+`array_find_sequence` は既存の Sarray 関連でなく純粋なバイト操作なので、
+`src/core/sarray/mod.rs` に free function として置く。
+
+## TDD ステップ
+
+1. **RED** (`test(core): RED - sarray file I/O and arrayFindSequence`)
+   - `tests/core/string_reg.rs::string_reg_binary_sequence` の `#[ignore]` を
+
+     RED に書き換え、空配列 / 1 byte / 部分一致 / 末尾一致のケースを追加
+
+   - `string_reg_file_io` の `#[ignore]` を RED に書き換え、
+
+     write_to_writer + read_from_reader / write_to_file + read_from_file
+     のラウンドトリップを 4 ケース (empty / 1 string / multiple / containing
+     spaces) で検証
+
+   - 公開 API stub を `unimplemented!()` で公開
+2. **GREEN** (`feat(core): port sarray file I/O and arrayFindSequence`)
+   - シリアライズ/デシリアライズ実装、`#[ignore]` 解除
+
+## 不要分類
+
+- `sarrayFindStringByHash`, `sarrayReplaceString` (hash) — 031 で不要分類済。
+
+  これらの ignored test (`string_reg_find_by_hash`, `string_reg_replace_string`)
+  はそのまま残す。
+
+## ブランチ・PR
+
+- ブランチ: `feat/core-sarray-io`
+- PR: `feat(core): port sarray file/stream I/O and arrayFindSequence`
+- 1PR、RED → GREEN
+
+## ステータス
+
+- [x] 計画書作成
+- [ ] RED コミット
+- [ ] GREEN コミット
+- [ ] PR 作成・Copilot レビュー対応
+- [ ] /gh-pr-merge --merge
+- [ ] 031 全体計画書を IMPLEMENTED に更新

--- a/docs/plans/105_core-sarray-io.md
+++ b/docs/plans/105_core-sarray-io.md
@@ -33,30 +33,30 @@ Number of strings = N\n
 
 ## 配置先・API 設計
 
-- ファイル: `src/core/sarray/serial.rs` を新設（または `mod.rs` に追記）
-- 公開 API:
+- ファイル: 既存 `src/core/sarray/serial.rs` で全シリアライズ I/O が
+  実装済みだったため、本タスクではテストの `#[ignore]` 解除のみ
+- 既存公開 API（再掲、本 PR で新規追加するものではない）:
 
 ```rust
 impl Sarray {
     /// sarrayWrite 相当
-    pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()>;
+    pub fn write_to_file(&self, path: impl AsRef<Path>) -> Result<()>;
     /// sarrayWriteStream 相当
-    pub fn write_to_writer<W: Write>(&self, writer: &mut W) -> Result<()>;
+    pub fn write_to_writer(&self, writer: &mut impl Write) -> Result<()>;
     /// sarrayWriteMem 相当
-    pub fn to_serialized_bytes(&self) -> Result<Vec<u8>>;
+    pub fn write_to_bytes(&self) -> Result<Vec<u8>>;
 
     /// sarrayRead 相当
-    pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Sarray>;
+    pub fn read_from_file(path: impl AsRef<Path>) -> Result<Sarray>;
     /// sarrayReadStream 相当
-    pub fn read_from_reader<R: BufRead>(reader: R) -> Result<Sarray>;
+    pub fn read_from_reader(reader: &mut impl Read) -> Result<Sarray>;
     /// sarrayReadMem 相当
-    pub fn from_serialized_bytes(bytes: &[u8]) -> Result<Sarray>;
+    pub fn read_from_bytes(data: &[u8]) -> Result<Sarray>;
 }
 
 /// arrayFindSequence 相当: data 中で sequence の最初の出現オフセットを返す。
-///
 /// 該当 C シグネチャは `(*poffset, *pfound)` だが、Rust では `Option<usize>`
-/// を返す形に圧縮する。
+/// を返す形に圧縮する。本 PR で新規追加。
 pub fn array_find_sequence(data: &[u8], sequence: &[u8]) -> Option<usize>;
 ```
 
@@ -95,9 +95,9 @@ pub fn array_find_sequence(data: &[u8], sequence: &[u8]) -> Option<usize>;
 
 ## ステータス
 
-- [x] 計画書作成
-- [ ] RED コミット
-- [ ] GREEN コミット
-- [ ] PR 作成・Copilot レビュー対応
+- [x] 計画書作成（c7612a2）
+- [x] sarray I/O は実装済みと確認（テスト `#[ignore]` 解除のみ）
+- [x] `array_find_sequence` 実装 + テスト追加（17ccb94）
+- [x] PR 作成・Copilot レビュー対応（PR #320）
 - [ ] /gh-pr-merge --merge
-- [ ] 031 全体計画書を IMPLEMENTED に更新
+- [ ] 031 全体計画書の表に PR #320 を反映

--- a/docs/plans/105_core-sarray-io.md
+++ b/docs/plans/105_core-sarray-io.md
@@ -1,6 +1,6 @@
 # core/sarray: ファイル/ストリーム I/O とバイト列検索
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 D)
 
 ## Context

--- a/src/core/sarray/mod.rs
+++ b/src/core/sarray/mod.rs
@@ -1138,9 +1138,9 @@ impl std::ops::IndexMut<usize> for Sarraya {
 ///
 /// C Leptonica equivalent: `arrayFindSequence` (utils2.c). The C signature uses
 /// out-parameters `(*poffset, *pfound)`; the Rust port collapses that to
-/// `Option<usize>`. An empty `sequence` matches at offset 0 (matching the
-/// behaviour of `slice::starts_with(&[])`); searching an empty `data` for a
-/// non-empty sequence returns `None`.
+/// `Option<usize>`. An empty `sequence` matches at offset 0 (matching
+/// `<[u8]>::starts_with(&[])`, which is `true`); searching an empty `data`
+/// for a non-empty sequence returns `None`.
 pub fn array_find_sequence(data: &[u8], sequence: &[u8]) -> Option<usize> {
     if sequence.is_empty() {
         return Some(0);

--- a/src/core/sarray/mod.rs
+++ b/src/core/sarray/mod.rs
@@ -1133,6 +1133,24 @@ impl std::ops::IndexMut<usize> for Sarraya {
     }
 }
 
+/// Find the first occurrence of `sequence` inside `data`, returning the byte
+/// offset if found.
+///
+/// C Leptonica equivalent: `arrayFindSequence` (utils2.c). The C signature uses
+/// out-parameters `(*poffset, *pfound)`; the Rust port collapses that to
+/// `Option<usize>`. An empty `sequence` matches at offset 0 (matching the
+/// behaviour of `slice::starts_with(&[])`); searching an empty `data` for a
+/// non-empty sequence returns `None`.
+pub fn array_find_sequence(data: &[u8], sequence: &[u8]) -> Option<usize> {
+    if sequence.is_empty() {
+        return Some(0);
+    }
+    if sequence.len() > data.len() {
+        return None;
+    }
+    data.windows(sequence.len()).position(|w| w == sequence)
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/tests/core/string_reg.rs
+++ b/tests/core/string_reg.rs
@@ -45,12 +45,15 @@ fn string_reg_binary_sequence() {
     assert_eq!(array_find_sequence(nul, b"\0c"), Some(3));
 }
 
-/// Sarray file/stream I/O round-trip (C: sarrayWrite/sarrayRead).
+/// Sarray stream / in-memory I/O round-trip (C: sarrayWriteStream/ReadStream
+/// + sarrayWriteMem/ReadMem).
 ///
 /// `Sarray` already exposes `read_from_reader` / `write_to_writer` /
-/// `write_to_bytes` etc.; this regression test verifies the round-trip
-/// covers empty arrays, single strings, multi-string content and strings
-/// that contain spaces.
+/// `write_to_bytes` / `read_from_bytes`. This regression test verifies the
+/// round-trip covers empty arrays, single strings, multi-string content and
+/// strings that contain spaces. Filesystem I/O (`write_to_file` /
+/// `read_from_file`) shares the stream codec so it is not exercised
+/// separately here.
 #[test]
 fn string_reg_file_io() {
     fn roundtrip(input: Vec<&str>) {

--- a/tests/core/string_reg.rs
+++ b/tests/core/string_reg.rs
@@ -25,13 +25,59 @@ fn string_reg_replace_string() {}
 
 /// Binary sequence operations (C: arrayFindSequence).
 #[test]
-#[ignore = "arrayFindSequence not implemented"]
-fn string_reg_binary_sequence() {}
+fn string_reg_binary_sequence() {
+    use leptonica::core::sarray::array_find_sequence;
 
-/// Sarray file I/O round-trip (C: sarrayWrite/sarrayRead).
+    let data: &[u8] = b"hello world";
+    assert_eq!(array_find_sequence(data, b"hello"), Some(0));
+    assert_eq!(array_find_sequence(data, b"world"), Some(6));
+    assert_eq!(array_find_sequence(data, b"o w"), Some(4));
+    assert_eq!(array_find_sequence(data, b"xyz"), None);
+    // Sequence longer than data → None.
+    assert_eq!(array_find_sequence(b"hi", b"hello"), None);
+    // Empty sequence is treated as found at offset 0.
+    assert_eq!(array_find_sequence(data, b""), Some(0));
+    // Empty data with non-empty sequence → None.
+    assert_eq!(array_find_sequence(b"", b"x"), None);
+    // Embedded null bytes are honored as part of the byte stream.
+    let nul: &[u8] = b"a\0b\0c";
+    assert_eq!(array_find_sequence(nul, b"\0b"), Some(1));
+    assert_eq!(array_find_sequence(nul, b"\0c"), Some(3));
+}
+
+/// Sarray file/stream I/O round-trip (C: sarrayWrite/sarrayRead).
+///
+/// `Sarray` already exposes `read_from_reader` / `write_to_writer` /
+/// `write_to_bytes` etc.; this regression test verifies the round-trip
+/// covers empty arrays, single strings, multi-string content and strings
+/// that contain spaces.
 #[test]
-#[ignore = "sarrayWrite/sarrayRead file I/O not implemented"]
-fn string_reg_file_io() {}
+fn string_reg_file_io() {
+    fn roundtrip(input: Vec<&str>) {
+        let sa = Sarray::from_str_slice(&input);
+        // write_to_writer + read_from_reader
+        let mut buf: Vec<u8> = Vec::new();
+        sa.write_to_writer(&mut buf).expect("write_to_writer");
+        let restored = Sarray::read_from_reader(&mut buf.as_slice()).expect("read_from_reader");
+        assert_eq!(restored.len(), sa.len());
+        for i in 0..sa.len() {
+            assert_eq!(restored.get(i), sa.get(i), "string {i} after stream rt");
+        }
+
+        // write_to_bytes + read_from_bytes
+        let bytes = sa.write_to_bytes().expect("write_to_bytes");
+        let restored2 = Sarray::read_from_bytes(&bytes).expect("read_from_bytes");
+        assert_eq!(restored2.len(), sa.len());
+        for i in 0..sa.len() {
+            assert_eq!(restored2.get(i), sa.get(i), "string {i} after mem rt");
+        }
+    }
+
+    roundtrip(vec![]);
+    roundtrip(vec!["alone"]);
+    roundtrip(vec!["alpha", "beta", "gamma"]);
+    roundtrip(vec!["hello world", "containing  multiple  spaces"]);
+}
 
 #[test]
 fn string_reg() {


### PR DESCRIPTION
## Summary

- 計画 [105_core-sarray-io.md](https://github.com/tagawa0525/leptonica-rs/blob/feat/core-sarray-io/docs/plans/105_core-sarray-io.md) (項目 D) に従い、C 版 `utils2.c::arrayFindSequence` を Rust に移植
- C 版の sarray I/O は既に `Sarray::{read_from_reader, write_to_writer, write_to_bytes, read_from_bytes, ...}` として実装済みだったため、対応する `#[ignore]` テストを解除して回帰防止のみ追加

## What

`src/core/sarray/mod.rs`:
- `pub fn array_find_sequence(data: &[u8], sequence: &[u8]) -> Option<usize>` を free function として追加。`data.windows(seq.len()).position(...)` ベースの素直な実装。空 sequence は offset 0 を返す（`slice::starts_with(&[])` の挙動に合わせた）

`tests/core/string_reg.rs`:
- `string_reg_binary_sequence`: 8 ケース (basic / sequence > data / empty seq / empty data / null bytes embedded)
- `string_reg_file_io`: stream/memory 両方で 4 ケース (empty / 1 string / multiple / containing spaces) のラウンドトリップ

`sarrayFindStringByHash` / `sarrayReplaceString` (hash 系) は 031 で「不要」分類済のため既存 `#[ignore]` 維持。

## Test plan

- [x] `cargo test --test core string_reg` で 3 件通過、2 件 hash 系 ignore
- [x] `cargo test --all-features` 全件通過（core ignored 24→22）
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)