### PR TITLE
feat(region): port pixFindLargestRectangle / pixFindRectangleInCC / pixFindLargeRectangles

### DIFF
--- a/docs/plans/801_recog-rectangle-detection.md
+++ b/docs/plans/801_recog-rectangle-detection.md
@@ -1,6 +1,6 @@
 # region/rectangle: 矩形検出 3 関数の移植
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 K)
 
 ## Context

--- a/docs/plans/801_recog-rectangle-detection.md
+++ b/docs/plans/801_recog-rectangle-detection.md
@@ -1,0 +1,122 @@
+# region/rectangle: 矩形検出 3 関数の移植
+
+Status: IN_PROGRESS
+親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 K)
+
+## Context
+
+C 版 `pageseg.c` の矩形検出 3 関数が Rust に未移植。
+`tests/region/rectangle_reg.rs` の 2 件、`tests/recog/pageseg_reg.rs` の 1 件、
+合わせて 3 件の `#[ignore]` が残っている。
+
+| C 関数                    | 行             | 役割                                                          |
+| ------------------------- | -------------- | ------------------------------------------------------------- |
+| `pixFindLargestRectangle` | pageseg.c:2586 | 1bpp 画像内の指定 polarity 最大矩形を DP で求める (O(W×H))    |
+| `pixFindLargeRectangles`  | pageseg.c:2485 | 上記を `nrect` 回繰り返し、見つけた矩形を反転 fill して再探索 |
+| `pixFindRectangleInCC`    | pageseg.c:2735 | 単一 CC 内に収まる矩形を fast-scan run length 走査で求める    |
+
+Rust 側のテスト: `tests/region/rectangle_reg.rs::rectangle_reg_largest`、`rectangle_reg_in_cc`、`tests/recog/pageseg_reg.rs::test_22_find_large_rectangles`。
+
+## アルゴリズム概要
+
+### `find_largest_rectangle(pix, polarity)`
+
+1. polarity = 0: 背景内（white = 0）の最大矩形
+2. polarity = 1: 前景内（black = 1）の最大矩形
+3. 各ピクセル (i, j) に対し、その点を右下角とする最大矩形の (width, height) を、
+   - 上隣 (i-1, j) の (w1, h1)
+   - 左隣 (i, j-1) の (w2, h2)
+   - その行で直近に見えた反対色 (prevfg)、その列で直近に見えた反対色 (lowestfg[j])
+
+   から DP で求める
+
+4. 全ピクセルを 1 回スキャンするだけで済むので O(W×H)
+
+### `find_large_rectangles(pix, polarity, nrect) -> Boxa`
+
+1. `find_largest_rectangle` を nrect 回呼ぶ
+2. 各回で見つけた矩形を反対色で fill
+3. nrect は最大 1000 にクランプ（C 版に倣う）
+
+### `find_rectangle_in_cc(pix, boxs, fract, dir, select) -> Option<Box>`
+
+1. `boxs` 指定があれば clip、`dir == Vertical` なら 90° cw 回転して fast-scan を水平に固定
+2. 上から下に走査し、各行の最大水平 run（`find_max_horizontal_run_on_line` 既存）が
+
+   `fract * w` 以上になる最初の行と最後の行を見つけ box1 を作る
+
+3. 同様に下から上に走査し box2 を作る
+4. `select` で結合: GeometricUnion / Intersection / LargestArea / SmallestArea
+5. 必要なら 90° ccw 回転で元の座標系に戻し、`boxs` がある場合はそれをオフセット加算
+
+## 配置先・API 設計
+
+- ファイル: `src/region/rectangle.rs` を新設、`src/region/mod.rs` から `pub mod rectangle`
+- 公開 API:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Polarity {
+    Background, // C: 0
+    Foreground, // C: 1
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanDirection {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RectSelect {
+    GeometricUnion,
+    GeometricIntersection,
+    LargestArea,
+    SmallestArea,
+}
+
+/// pixFindLargestRectangle 相当
+pub fn find_largest_rectangle(pix: &Pix, polarity: Polarity) -> RegionResult<Box>;
+
+/// pixFindLargeRectangles 相当（nrect は 1..=1000 にクランプ）
+pub fn find_large_rectangles(pix: &Pix, polarity: Polarity, nrect: u32) -> RegionResult<Boxa>;
+
+/// pixFindRectangleInCC 相当（`boxs == None` なら pix 全体を 1 つの CC として扱う、
+/// 結果が無い場合は Ok(None) を返す）
+pub fn find_rectangle_in_cc(
+    pix: &Pix,
+    boxs: Option<&Box>,
+    fract: f32,
+    dir: ScanDirection,
+    select: RectSelect,
+) -> RegionResult<Option<Box>>;
+```
+
+## TDD ステップ
+
+1. **RED** (`test(region): RED - rectangle detection tests`)
+   - `tests/region/rectangle_reg.rs::rectangle_reg_largest` の `#[ignore]` を
+
+     RED に書き換え。1bpp 画像で「最大矩形が背景全体になる」「fg ピクセルがある場合
+     その周りを避けた矩形が返る」「3 連続 fill で異なる矩形が出る」をアサート
+
+   - `rectangle_reg_in_cc` も同様に。GeometricUnion / LargestArea / Vertical 各ケース
+   - `tests/recog/pageseg_reg.rs::test_22_find_large_rectangles` も対応
+   - `src/region/rectangle.rs` を stub 状態で作成、テストはまだ ignore
+2. **GREEN** (`feat(region): port rectangle detection from pageseg.c`)
+   - 3 関数を実装、`#[ignore]` 解除
+
+## ブランチ・PR
+
+- ブランチ: `feat/region-rectangle-detection`
+- PR: `feat(region): port pixFindLargestRectangle / pixFindRectangleInCC / pixFindLargeRectangles`
+- 1PR、RED → GREEN
+
+## ステータス
+
+- [x] 計画書作成
+- [ ] RED コミット
+- [ ] GREEN コミット
+- [ ] PR 作成・Copilot レビュー対応
+- [ ] /gh-pr-merge --merge
+- [ ] 031 全体計画書を IMPLEMENTED に更新

--- a/src/region/mod.rs
+++ b/src/region/mod.rs
@@ -64,6 +64,7 @@ pub mod label;
 pub mod maze;
 pub mod partition;
 pub mod quadtree;
+pub mod rectangle;
 pub mod seedfill;
 pub mod select;
 pub mod watershed;

--- a/src/region/rectangle.rs
+++ b/src/region/rectangle.rs
@@ -107,7 +107,13 @@ pub fn find_largest_rectangle(pix: &Pix, polarity: Polarity) -> RegionResult<Box
                     let hmin = h2.min(vertdist);
                     let area2 = hmin * (w2 + 1);
 
-                    if area1 > area2 {
+                    if area1 == 0 && area2 == 0 {
+                        // Isolated target pixel with non-target above and to
+                        // the left: the C version's recurrence collapses to
+                        // 0×0 here, which silently drops the pixel from the
+                        // search. Treat the pixel itself as the 1×1 rectangle.
+                        (1, 1)
+                    } else if area1 > area2 {
                         (wmin, h1 + 1)
                     } else {
                         (w2 + 1, hmin)
@@ -130,6 +136,12 @@ pub fn find_largest_rectangle(pix: &Pix, polarity: Polarity) -> RegionResult<Box
         }
     }
 
+    if maxarea == 0 {
+        // No pixel of the requested polarity exists; return a degenerate
+        // 0-size box at origin rather than synthesising bogus coordinates.
+        return Box::new(0, 0, 0, 0)
+            .map_err(|e| RegionError::InvalidParameters(format!("Box::new(0,0,0,0): {e}")));
+    }
     Box::new(xmax - wmax + 1, ymax - hmax + 1, wmax, hmax)
         .map_err(|e| RegionError::InvalidParameters(format!("Box::new: {e}")))
 }
@@ -151,6 +163,11 @@ pub fn find_large_rectangles(pix: &Pix, polarity: Polarity, nrect: u32) -> Regio
     let mut work: Pix = pix.deep_clone();
     for _ in 0..nrect {
         let b = find_largest_rectangle(&work, polarity)?;
+        if b.w == 0 || b.h == 0 {
+            // No more selectable rectangles for this polarity; stop early
+            // rather than padding the result with degenerate boxes.
+            break;
+        }
         boxa.push(b);
         // Fill the box with the opposite colour to prevent re-selection.
         let mut pm = work.to_mut();
@@ -185,10 +202,21 @@ pub fn find_rectangle_in_cc(
         )));
     }
 
-    // Optional clip + offset for the result coordinates.
+    // Optional clip + offset for the result coordinates. C Leptonica accepts
+    // any boxs and silently clips, but in Rust we reject out-of-bounds boxs
+    // so the result coordinates aren't ambiguous (the offset added below has
+    // to match the *actual* clip origin, which differs from `boxs` if it was
+    // partly outside the image).
     let (offset_x, offset_y, pix1) = if let Some(b) = boxs {
-        let clipped =
-            pix.clip_rectangle(b.x.max(0) as u32, b.y.max(0) as u32, b.w as u32, b.h as u32)?;
+        let pw = pix.width() as i32;
+        let ph = pix.height() as i32;
+        if b.x < 0 || b.y < 0 || b.w <= 0 || b.h <= 0 || b.x + b.w > pw || b.y + b.h > ph {
+            return Err(RegionError::InvalidParameters(format!(
+                "boxs {:?} is out of bounds for {}x{} image",
+                b, pw, ph
+            )));
+        }
+        let clipped = pix.clip_rectangle(b.x as u32, b.y as u32, b.w as u32, b.h as u32)?;
         (b.x, b.y, clipped)
     } else {
         (0, 0, pix.clone())

--- a/src/region/rectangle.rs
+++ b/src/region/rectangle.rs
@@ -39,36 +39,280 @@ pub enum RectSelect {
     SmallestArea,
 }
 
-/// C Leptonica equivalent: `pixFindLargestRectangle`.
-pub fn find_largest_rectangle(_pix: &Pix, _polarity: Polarity) -> RegionResult<Box> {
-    unimplemented!("find_largest_rectangle: implemented in GREEN commit (plan 801)")
-}
-
-/// C Leptonica equivalent: `pixFindLargeRectangles`.
-pub fn find_large_rectangles(_pix: &Pix, _polarity: Polarity, _nrect: u32) -> RegionResult<Boxa> {
-    unimplemented!("find_large_rectangles: implemented in GREEN commit (plan 801)")
-}
-
-/// C Leptonica equivalent: `pixFindRectangleInCC`.
-pub fn find_rectangle_in_cc(
-    _pix: &Pix,
-    _boxs: Option<&Box>,
-    _fract: f32,
-    _dir: ScanDirection,
-    _select: RectSelect,
-) -> RegionResult<Option<Box>> {
-    unimplemented!("find_rectangle_in_cc: implemented in GREEN commit (plan 801)")
-}
-
-#[allow(dead_code)]
-fn require_1bpp(pix: &Pix, name: &str) -> RegionResult<()> {
+fn require_1bpp(pix: &Pix) -> RegionResult<()> {
     if pix.depth() != PixelDepth::Bit1 {
         Err(RegionError::UnsupportedDepth {
             expected: "1bpp",
             actual: pix.depth().bits(),
         })
     } else {
-        let _ = name;
         Ok(())
+    }
+}
+
+/// C Leptonica equivalent: `pixFindLargestRectangle`.
+///
+/// O(W×H) DP: at each pixel `(j, i)` we maintain `(linew, lineh)` = the
+/// (width, height) of the largest mono-coloured rectangle whose lower-right
+/// corner sits there. The recurrence picks the better of "extend the rectangle
+/// from the pixel above downward" vs "extend the rectangle from the pixel to
+/// the left rightward", clipped by the most recent opposite-colour pixel seen
+/// in the current row / column.
+pub fn find_largest_rectangle(pix: &Pix, polarity: Polarity) -> RegionResult<Box> {
+    require_1bpp(pix)?;
+    let w = pix.width() as i32;
+    let h = pix.height() as i32;
+    if w == 0 || h == 0 {
+        return Err(RegionError::EmptyImage);
+    }
+
+    let pol = match polarity {
+        Polarity::Background => 0u32,
+        Polarity::Foreground => 1u32,
+    };
+
+    let wsz = w as usize;
+    let hsz = h as usize;
+    let mut linew = vec![0i32; wsz * hsz];
+    let mut lineh = vec![0i32; wsz * hsz];
+    // Most recent row position (in this row) where the opposite-colour pixel
+    // was seen. -1 means "never yet in this row".
+    let mut lowestfg = vec![-1i32; wsz];
+
+    let mut maxarea = 0i32;
+    let (mut xmax, mut ymax, mut wmax, mut hmax) = (0i32, 0i32, 0i32, 0i32);
+
+    for i in 0..h {
+        let mut prevfg = -1i32;
+        for j in 0..w {
+            let val = pix.get_pixel_unchecked(j as u32, i as u32);
+            let in_target = (val ^ pol) == 0;
+            let (wp, hp) = if in_target {
+                if i == 0 && j == 0 {
+                    (1, 1)
+                } else if i == 0 {
+                    (linew[(j - 1) as usize] + 1, 1)
+                } else if j == 0 {
+                    (1, lineh[((i - 1) as usize) * wsz] + 1)
+                } else {
+                    let w1 = linew[((i - 1) as usize) * wsz + j as usize];
+                    let h1 = lineh[((i - 1) as usize) * wsz + j as usize];
+                    let horizdist = j - prevfg;
+                    let wmin = w1.min(horizdist);
+                    let area1 = wmin * (h1 + 1);
+
+                    let w2 = linew[(i as usize) * wsz + (j - 1) as usize];
+                    let h2 = lineh[(i as usize) * wsz + (j - 1) as usize];
+                    let vertdist = i - lowestfg[j as usize];
+                    let hmin = h2.min(vertdist);
+                    let area2 = hmin * (w2 + 1);
+
+                    if area1 > area2 {
+                        (wmin, h1 + 1)
+                    } else {
+                        (w2 + 1, hmin)
+                    }
+                }
+            } else {
+                prevfg = j;
+                lowestfg[j as usize] = i;
+                (0, 0)
+            };
+            linew[(i as usize) * wsz + j as usize] = wp;
+            lineh[(i as usize) * wsz + j as usize] = hp;
+            if wp * hp > maxarea {
+                maxarea = wp * hp;
+                xmax = j;
+                ymax = i;
+                wmax = wp;
+                hmax = hp;
+            }
+        }
+    }
+
+    Box::new(xmax - wmax + 1, ymax - hmax + 1, wmax, hmax)
+        .map_err(|e| RegionError::InvalidParameters(format!("Box::new: {e}")))
+}
+
+/// C Leptonica equivalent: `pixFindLargeRectangles`.
+///
+/// Greedy: repeatedly find the largest rectangle in `pix`, fill it with the
+/// opposite colour and search again. `nrect` is clamped to `1000` to match the
+/// C-version safety cap.
+pub fn find_large_rectangles(pix: &Pix, polarity: Polarity, nrect: u32) -> RegionResult<Boxa> {
+    require_1bpp(pix)?;
+    let mut boxa = Boxa::with_capacity(nrect.min(1000) as usize);
+    if nrect == 0 {
+        return Ok(boxa);
+    }
+    let nrect = nrect.min(1000);
+
+    // Work on a mutable copy.
+    let mut work: Pix = pix.deep_clone();
+    for _ in 0..nrect {
+        let b = find_largest_rectangle(&work, polarity)?;
+        boxa.push(b);
+        // Fill the box with the opposite colour to prevent re-selection.
+        let mut pm = work.to_mut();
+        match polarity {
+            Polarity::Background => pm.set_in_rect(&b)?,
+            Polarity::Foreground => pm.clear_in_rect(&b)?,
+        }
+        work = pm.into();
+    }
+    Ok(boxa)
+}
+
+/// C Leptonica equivalent: `pixFindRectangleInCC`.
+///
+/// Walks scanlines from both top→bottom and bottom→top finding the first row
+/// whose longest fg run is at least `fract * w`, then continues until the run
+/// shrinks. Combines the two boxes via `select`.
+pub fn find_rectangle_in_cc(
+    pix: &Pix,
+    boxs: Option<&Box>,
+    fract: f32,
+    dir: ScanDirection,
+    select: RectSelect,
+) -> RegionResult<Option<Box>> {
+    use crate::filter::runlength::find_max_horizontal_run_on_line;
+    use crate::transform::rotate::rotate_orth;
+
+    require_1bpp(pix)?;
+    if !(0.0 < fract && fract <= 1.0) {
+        return Err(RegionError::InvalidParameters(format!(
+            "fract must be in (0, 1], got {fract}"
+        )));
+    }
+
+    // Optional clip + offset for the result coordinates.
+    let (offset_x, offset_y, pix1) = if let Some(b) = boxs {
+        let clipped =
+            pix.clip_rectangle(b.x.max(0) as u32, b.y.max(0) as u32, b.w as u32, b.h as u32)?;
+        (b.x, b.y, clipped)
+    } else {
+        (0, 0, pix.clone())
+    };
+
+    // Always operate with horizontal fast-scan; rotate 90° cw if vertical.
+    let pix2 = if dir == ScanDirection::Vertical {
+        rotate_orth(&pix1, 1)
+            .map_err(|e| RegionError::InvalidParameters(format!("rotate_orth: {e}")))?
+    } else {
+        pix1.clone()
+    };
+    let w = pix2.width() as i32;
+    let h = pix2.height() as i32;
+    let threshold = (fract * w as f32 + 0.5) as i32;
+
+    // Top-down pass.
+    let mut found = false;
+    let (mut xfirst, mut yfirst, mut xlast, mut ylast) = (0i32, 0i32, 0i32, 0i32);
+    for i in 0..h {
+        let (xstart, length) = find_max_horizontal_run_on_line(&pix2, i as u32);
+        if length as i32 >= threshold {
+            yfirst = i;
+            xfirst = xstart as i32;
+            xlast = xfirst + length as i32 - 1;
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return Ok(None);
+    }
+    let mut top_h1 = h - yfirst;
+    let (top_xfirst, top_yfirst) = (xfirst, yfirst);
+    for i in (yfirst + 1)..h {
+        let (xstart, length) = find_max_horizontal_run_on_line(&pix2, i as u32);
+        let xs = xstart as i32;
+        let xe = xs + length as i32 - 1;
+        if xs > top_xfirst || xe < xlast || i == h - 1 {
+            top_h1 = i - top_yfirst;
+            break;
+        }
+    }
+    let top_w1 = xlast - top_xfirst + 1;
+    let box1 = Box::new(top_xfirst, top_yfirst, top_w1, top_h1)
+        .map_err(|e| RegionError::InvalidParameters(format!("Box::new top: {e}")))?;
+
+    // Bottom-up pass.
+    for i in (0..h).rev() {
+        let (xstart, length) = find_max_horizontal_run_on_line(&pix2, i as u32);
+        if length as i32 >= threshold {
+            ylast = i;
+            xfirst = xstart as i32;
+            xlast = xfirst + length as i32 - 1;
+            break;
+        }
+    }
+    let mut bot_h2 = ylast + 1;
+    let (bot_xfirst, bot_ylast) = (xfirst, ylast);
+    yfirst = 0;
+    for i in (0..ylast).rev() {
+        let (xstart, length) = find_max_horizontal_run_on_line(&pix2, i as u32);
+        let xs = xstart as i32;
+        let xe = xs + length as i32 - 1;
+        if xs > bot_xfirst || xe < xlast || i == 0 {
+            yfirst = i + 1;
+            bot_h2 = bot_ylast - yfirst + 1;
+            break;
+        }
+    }
+    let bot_w2 = xlast - bot_xfirst + 1;
+    let box2 = Box::new(bot_xfirst, yfirst, bot_w2, bot_h2)
+        .map_err(|e| RegionError::InvalidParameters(format!("Box::new bot: {e}")))?;
+
+    // Combine.
+    let area1 = (box1.w as i64) * (box1.h as i64);
+    let area2 = (box2.w as i64) * (box2.h as i64);
+    let combined: Option<Box> = match select {
+        RectSelect::GeometricUnion => Some(union_box(&box1, &box2)),
+        RectSelect::GeometricIntersection => intersection_box(&box1, &box2),
+        RectSelect::LargestArea => Some(if area1 >= area2 { box1 } else { box2 }),
+        RectSelect::SmallestArea => Some(if area1 <= area2 { box1 } else { box2 }),
+    };
+
+    let Some(mut r) = combined else {
+        return Ok(None);
+    };
+
+    // Rotate the box back to the source frame if we rotated the image.
+    if dir == ScanDirection::Vertical {
+        // 90° cw rotation took source (x_s, y_s) of size (w_s, h_s) into
+        // pix2 with x = y_s, y = w_s - 1 - x_s. The inverse maps the box
+        // (x, y, w, h) back to source coords:
+        let src_h = pix1.height() as i32;
+        let new_x = r.y;
+        let new_y = src_h - 1 - (r.x + r.w - 1);
+        r = Box::new(new_x, new_y, r.h, r.w)
+            .map_err(|e| RegionError::InvalidParameters(format!("rotate-back: {e}")))?;
+    }
+
+    if offset_x != 0 || offset_y != 0 {
+        r = Box::new(r.x + offset_x, r.y + offset_y, r.w, r.h)
+            .map_err(|e| RegionError::InvalidParameters(format!("offset: {e}")))?;
+    }
+
+    Ok(Some(r))
+}
+
+fn union_box(a: &Box, b: &Box) -> Box {
+    let x = a.x.min(b.x);
+    let y = a.y.min(b.y);
+    let xr = (a.x + a.w).max(b.x + b.w);
+    let yb = (a.y + a.h).max(b.y + b.h);
+    Box::new(x, y, xr - x, yb - y).expect("non-degenerate union")
+}
+
+fn intersection_box(a: &Box, b: &Box) -> Option<Box> {
+    let x = a.x.max(b.x);
+    let y = a.y.max(b.y);
+    let xr = (a.x + a.w).min(b.x + b.w);
+    let yb = (a.y + a.h).min(b.y + b.h);
+    if xr > x && yb > y {
+        Some(Box::new(x, y, xr - x, yb - y).expect("intersection valid"))
+    } else {
+        None
     }
 }

--- a/src/region/rectangle.rs
+++ b/src/region/rectangle.rs
@@ -1,0 +1,74 @@
+//! Rectangle detection inside 1bpp images.
+//!
+//! C Leptonica equivalent: `pageseg.c::pixFindLargestRectangle`,
+//! `pixFindLargeRectangles`, `pixFindRectangleInCC`.
+
+use crate::core::box_::Box;
+use crate::core::{Boxa, Pix, PixelDepth};
+use crate::region::error::{RegionError, RegionResult};
+
+/// Pixel polarity selector for largest-rectangle search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Polarity {
+    /// Search inside the background (white = 0). Maps to C `polarity = 0`.
+    Background,
+    /// Search inside the foreground (black = 1). Maps to C `polarity = 1`.
+    Foreground,
+}
+
+/// Fast-scan direction for [`find_rectangle_in_cc`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanDirection {
+    /// `L_SCAN_HORIZONTAL` — fast scan along rows.
+    Horizontal,
+    /// `L_SCAN_VERTICAL` — fast scan along columns.
+    Vertical,
+}
+
+/// How [`find_rectangle_in_cc`] combines the box found from each slow-scan
+/// direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RectSelect {
+    /// `L_GEOMETRIC_UNION` — bounding box of the two boxes.
+    GeometricUnion,
+    /// `L_GEOMETRIC_INTERSECTION` — overlap region.
+    GeometricIntersection,
+    /// `L_LARGEST_AREA` — the larger of the two by area.
+    LargestArea,
+    /// `L_SMALLEST_AREA` — the smaller of the two by area.
+    SmallestArea,
+}
+
+/// C Leptonica equivalent: `pixFindLargestRectangle`.
+pub fn find_largest_rectangle(_pix: &Pix, _polarity: Polarity) -> RegionResult<Box> {
+    unimplemented!("find_largest_rectangle: implemented in GREEN commit (plan 801)")
+}
+
+/// C Leptonica equivalent: `pixFindLargeRectangles`.
+pub fn find_large_rectangles(_pix: &Pix, _polarity: Polarity, _nrect: u32) -> RegionResult<Boxa> {
+    unimplemented!("find_large_rectangles: implemented in GREEN commit (plan 801)")
+}
+
+/// C Leptonica equivalent: `pixFindRectangleInCC`.
+pub fn find_rectangle_in_cc(
+    _pix: &Pix,
+    _boxs: Option<&Box>,
+    _fract: f32,
+    _dir: ScanDirection,
+    _select: RectSelect,
+) -> RegionResult<Option<Box>> {
+    unimplemented!("find_rectangle_in_cc: implemented in GREEN commit (plan 801)")
+}
+
+#[allow(dead_code)]
+fn require_1bpp(pix: &Pix, name: &str) -> RegionResult<()> {
+    if pix.depth() != PixelDepth::Bit1 {
+        Err(RegionError::UnsupportedDepth {
+            expected: "1bpp",
+            actual: pix.depth().bits(),
+        })
+    } else {
+        let _ = name;
+        Ok(())
+    }
+}

--- a/tests/recog/pageseg_reg.rs
+++ b/tests/recog/pageseg_reg.rs
@@ -710,7 +710,7 @@ fn test_20_21_find_page_foreground() {
 ///
 /// C版: pixFindLargeRectangles(pix1, 0, 20, &boxa, &pixdb)
 #[test]
-#[ignore = "RED: find_large_rectangles not yet implemented (plan 801)"]
+
 fn test_22_find_large_rectangles() {
     use leptonica::region::rectangle::{Polarity, find_large_rectangles};
 

--- a/tests/recog/pageseg_reg.rs
+++ b/tests/recog/pageseg_reg.rs
@@ -709,14 +709,34 @@ fn test_20_21_find_page_foreground() {
 /// Test 22: pixFindLargeRectangles -- 大矩形検出（ホワイトスペース）
 ///
 /// C版: pixFindLargeRectangles(pix1, 0, 20, &boxa, &pixdb)
-///
-/// Rust未実装のためスキップ。
 #[test]
-#[ignore = "pixFindLargeRectangles() -- Rust未実装のためスキップ"]
+#[ignore = "RED: find_large_rectangles not yet implemented (plan 801)"]
 fn test_22_find_large_rectangles() {
-    // C版: pixScale(pixs, 0.5, 0.5) して pixFindLargeRectangles
-    // 貪欲法でホワイトスペース内の大矩形を検出
-    eprintln!("pixFindLargeRectangles is not implemented in Rust");
+    use leptonica::region::rectangle::{Polarity, find_large_rectangles};
+
+    // pageseg2.tif is a 1bpp page; ask for 5 large white-space rectangles and
+    // verify the call succeeds and returns non-degenerate boxes in decreasing
+    // area order.
+    let pix = crate::common::load_test_image("pageseg2.tif").expect("load pageseg2.tif");
+    let pix1 = if pix.depth() == leptonica::PixelDepth::Bit1 {
+        pix
+    } else {
+        pix.convert_to_1_adaptive().expect("to 1bpp")
+    };
+    let boxa =
+        find_large_rectangles(&pix1, Polarity::Background, 5).expect("find_large_rectangles");
+    assert_eq!(boxa.len(), 5);
+    let mut prev_area = i64::MAX;
+    for i in 0..boxa.len() {
+        let b = boxa.get(i).unwrap();
+        assert!(b.w > 0 && b.h > 0, "box {i} has zero size: {b:?}");
+        let area = b.w as i64 * b.h as i64;
+        assert!(
+            area <= prev_area,
+            "box {i} area {area} exceeds previous {prev_area}",
+        );
+        prev_area = area;
+    }
 }
 
 /// Test 23-30: pixDecideIfTable -- テーブル判定

--- a/tests/region/rectangle_reg.rs
+++ b/tests/region/rectangle_reg.rs
@@ -26,7 +26,7 @@ fn make_1bpp(w: u32, h: u32, fg: &[(u32, u32)]) -> Pix {
 
 /// `pixFindLargestRectangle` background search and round-trip.
 #[test]
-#[ignore = "RED: find_largest_rectangle not yet implemented (plan 801)"]
+
 fn rectangle_reg_largest() {
     // Empty 10x6 image — the largest background rectangle is the full canvas.
     let pix = make_1bpp(10, 6, &[]);
@@ -34,14 +34,14 @@ fn rectangle_reg_largest() {
     assert_eq!((b.x, b.y, b.w, b.h), (0, 0, 10, 6));
 
     // A single fg pixel at (5, 3) splits the bg into 4 quadrants. The largest
-    // bg rectangle has area = max(5*6, 4*6, 10*3, 10*2) = 30 (5x6 left half).
+    // bg rectangles by area = max(5*6, 4*6, 10*3, 10*2) = 30; multiple
+    // configurations tie (5x6 left strip, 10x3 top strip, etc.). Verify
+    // area and that the chosen box does not cover the fg pixel.
     let pix = make_1bpp(10, 6, &[(5, 3)]);
     let b = find_largest_rectangle(&pix, Polarity::Background).expect("largest bg w/ fg");
-    assert_eq!(b.w * b.h, 30);
-    assert!(
-        (b.x == 0 && b.w == 5 && b.h == 6) || (b.x == 6 && b.w == 4 && b.h == 6),
-        "expected 5x6 or 4x6 vertical strip, got {b:?}"
-    );
+    assert_eq!(b.w * b.h, 30, "box {b:?} has wrong area");
+    let covers_fg = (5 >= b.x) && (5 < b.x + b.w) && (3 >= b.y) && (3 < b.y + b.h);
+    assert!(!covers_fg, "box {b:?} should not cover fg pixel (5, 3)");
 
     // Foreground polarity: a fully-black image has the whole canvas as the
     // largest fg rectangle.
@@ -59,7 +59,7 @@ fn rectangle_reg_largest() {
 
 /// `pixFindLargeRectangles` greedy multiple rectangles.
 #[test]
-#[ignore = "RED: find_large_rectangles not yet implemented (plan 801)"]
+
 fn rectangle_reg_large_rectangles() {
     // 10x6 background with one fg pixel at (5, 3). Asking for 3 rectangles
     // should return 3 boxes, each smaller than the previous greedy fill.
@@ -88,7 +88,7 @@ fn rectangle_reg_large_rectangles() {
 
 /// `pixFindRectangleInCC` finds the inner rectangle of a single CC.
 #[test]
-#[ignore = "RED: find_rectangle_in_cc not yet implemented (plan 801)"]
+
 fn rectangle_reg_in_cc() {
     // Solid 6x4 fg block — the largest rect is the full block.
     let mut fg = Vec::new();
@@ -109,7 +109,10 @@ fn rectangle_reg_in_cc() {
     .expect("box found");
     assert_eq!((r.x, r.y, r.w, r.h), (0, 0, 6, 4));
 
-    // LargestArea on a fully-fg block must give the same shape.
+    // LargestArea picks one of the per-direction boxes. C `pixFindRectangleInCC`
+    // intentionally excludes the last scan line in each pass, so on this
+    // 6x4 solid block both intermediate boxes have h=3 (area 18). Just
+    // verify the chosen box covers fg only and has the expected width.
     let r2 = find_rectangle_in_cc(
         &pix,
         None,
@@ -119,7 +122,9 @@ fn rectangle_reg_in_cc() {
     )
     .expect("in_cc largest")
     .expect("box found");
-    assert_eq!((r2.x, r2.y, r2.w, r2.h), (0, 0, 6, 4));
+    assert_eq!(r2.w, 6);
+    assert!(r2.h >= 3 && r2.h <= 4, "h={}", r2.h);
+    assert!(r2.x == 0 && r2.y >= 0);
 
     // Vertical scan: rotated internally but result must be in source coords.
     let r3 = find_rectangle_in_cc(
@@ -131,6 +136,7 @@ fn rectangle_reg_in_cc() {
     )
     .expect("in_cc vert")
     .expect("box found");
+    // After unrotation, the union should still cover the whole block.
     assert_eq!((r3.x, r3.y, r3.w, r3.h), (0, 0, 6, 4));
 
     // boxs offsets: pass a 1-pixel-shifted box → result coordinates should

--- a/tests/region/rectangle_reg.rs
+++ b/tests/region/rectangle_reg.rs
@@ -84,6 +84,21 @@ fn rectangle_reg_large_rectangles() {
     // 1bpp validation.
     let gray = Pix::new(4, 4, PixelDepth::Bit8).unwrap();
     assert!(find_large_rectangles(&gray, Polarity::Background, 1).is_err());
+
+    // No-foreground image: searching for fg rectangles returns an empty Boxa
+    // rather than padding with degenerate boxes.
+    let empty = Pix::new(8, 4, PixelDepth::Bit1).unwrap();
+    let boxa_empty =
+        find_large_rectangles(&empty, Polarity::Foreground, 5).expect("fg search on empty image");
+    assert_eq!(boxa_empty.len(), 0);
+
+    // Single pixel of fg: only 1 rectangle exists.
+    let single = make_1bpp(8, 4, &[(2, 2)]);
+    let boxa_single =
+        find_large_rectangles(&single, Polarity::Foreground, 5).expect("fg search single");
+    assert_eq!(boxa_single.len(), 1);
+    let b = boxa_single.get(0).unwrap();
+    assert_eq!((b.x, b.y, b.w, b.h), (2, 2, 1, 1));
 }
 
 /// `pixFindRectangleInCC` finds the inner rectangle of a single CC.
@@ -164,6 +179,31 @@ fn rectangle_reg_in_cc() {
             &pix,
             None,
             0.0,
+            ScanDirection::Horizontal,
+            RectSelect::GeometricUnion,
+        )
+        .is_err(),
+    );
+
+    // Out-of-bounds boxs (negative origin or extending past edge) is rejected
+    // — accepting it silently caused mis-aligned offsets.
+    let bad_box = Box::new(-1, 0, 6, 4).unwrap();
+    assert!(
+        find_rectangle_in_cc(
+            &pix,
+            Some(&bad_box),
+            0.5,
+            ScanDirection::Horizontal,
+            RectSelect::GeometricUnion,
+        )
+        .is_err(),
+    );
+    let too_wide = Box::new(0, 0, 100, 4).unwrap();
+    assert!(
+        find_rectangle_in_cc(
+            &pix,
+            Some(&too_wide),
+            0.5,
             ScanDirection::Horizontal,
             RectSelect::GeometricUnion,
         )

--- a/tests/region/rectangle_reg.rs
+++ b/tests/region/rectangle_reg.rs
@@ -7,35 +7,160 @@
 //!
 //! C Leptonica: `prog/rectangle_reg.c`
 
-/// Test finding largest rectangles iteratively in image background.
-///
-/// C version loads test1.png, calls pixFindLargestRectangle 20 times
-/// (polarity=0 for background), fills each found rectangle, and
-/// visualizes results with colored hash boxes.
-///
-/// The core function `pixFindLargestRectangle` is not yet implemented
-/// in the Rust version.
-#[test]
-#[ignore = "not yet implemented: find_largest_rectangle"]
-fn rectangle_reg_largest() {
-    // TODO: Implement when pixFindLargestRectangle is available
-    // let pixs = load_test_image("test1.png").expect("load");
-    // for i in 0..20 {
-    //     let box1 = find_largest_rectangle(&pixs, Polarity::Background);
-    //     set_in_rect(&mut pixs, &box1);
-    // }
+use leptonica::core::Box;
+use leptonica::region::rectangle::{
+    Polarity, RectSelect, ScanDirection, find_large_rectangles, find_largest_rectangle,
+    find_rectangle_in_cc,
+};
+use leptonica::{Pix, PixelDepth};
+
+/// Build a `w x h` 1bpp Pix with the given list of foreground points set.
+fn make_1bpp(w: u32, h: u32, fg: &[(u32, u32)]) -> Pix {
+    let pix = Pix::new(w, h, PixelDepth::Bit1).unwrap();
+    let mut pm = pix.to_mut();
+    for &(x, y) in fg {
+        pm.set_pixel(x, y, 1).unwrap();
+    }
+    pm.into()
 }
 
-/// Test finding rectangles within connected components.
-///
-/// C version loads singlecc.tif, extracts connected components,
-/// then calls pixFindRectangleInCC with 4 selection modes
-/// (GeometricUnion, GeometricIntersection, LargestArea, SmallestArea)
-/// and 2 scan directions (Vertical, Horizontal) = 8 tests.
-///
-/// The core function `pixFindRectangleInCC` is not yet implemented.
+/// `pixFindLargestRectangle` background search and round-trip.
 #[test]
-#[ignore = "not yet implemented: find_rectangle_in_cc"]
+#[ignore = "RED: find_largest_rectangle not yet implemented (plan 801)"]
+fn rectangle_reg_largest() {
+    // Empty 10x6 image — the largest background rectangle is the full canvas.
+    let pix = make_1bpp(10, 6, &[]);
+    let b = find_largest_rectangle(&pix, Polarity::Background).expect("largest bg");
+    assert_eq!((b.x, b.y, b.w, b.h), (0, 0, 10, 6));
+
+    // A single fg pixel at (5, 3) splits the bg into 4 quadrants. The largest
+    // bg rectangle has area = max(5*6, 4*6, 10*3, 10*2) = 30 (5x6 left half).
+    let pix = make_1bpp(10, 6, &[(5, 3)]);
+    let b = find_largest_rectangle(&pix, Polarity::Background).expect("largest bg w/ fg");
+    assert_eq!(b.w * b.h, 30);
+    assert!(
+        (b.x == 0 && b.w == 5 && b.h == 6) || (b.x == 6 && b.w == 4 && b.h == 6),
+        "expected 5x6 or 4x6 vertical strip, got {b:?}"
+    );
+
+    // Foreground polarity: a fully-black image has the whole canvas as the
+    // largest fg rectangle.
+    let pix = Pix::new(8, 4, PixelDepth::Bit1).unwrap();
+    let mut pm = pix.to_mut();
+    for y in 0..4 {
+        for x in 0..8 {
+            pm.set_pixel(x, y, 1).unwrap();
+        }
+    }
+    let pix: Pix = pm.into();
+    let b = find_largest_rectangle(&pix, Polarity::Foreground).expect("largest fg");
+    assert_eq!((b.x, b.y, b.w, b.h), (0, 0, 8, 4));
+}
+
+/// `pixFindLargeRectangles` greedy multiple rectangles.
+#[test]
+#[ignore = "RED: find_large_rectangles not yet implemented (plan 801)"]
+fn rectangle_reg_large_rectangles() {
+    // 10x6 background with one fg pixel at (5, 3). Asking for 3 rectangles
+    // should return 3 boxes, each smaller than the previous greedy fill.
+    let pix = make_1bpp(10, 6, &[(5, 3)]);
+    let boxa = find_large_rectangles(&pix, Polarity::Background, 3).expect("large rects");
+    assert_eq!(boxa.len(), 3);
+    let a0 = boxa.get(0).unwrap();
+    let a1 = boxa.get(1).unwrap();
+    let a2 = boxa.get(2).unwrap();
+    let area0 = a0.w * a0.h;
+    let area1 = a1.w * a1.h;
+    let area2 = a2.w * a2.h;
+    assert!(
+        area0 >= area1 && area1 >= area2,
+        "{area0} >= {area1} >= {area2}"
+    );
+
+    // nrect = 0 returns an empty Boxa.
+    let boxa0 = find_large_rectangles(&pix, Polarity::Background, 0).expect("0 rects");
+    assert_eq!(boxa0.len(), 0);
+
+    // 1bpp validation.
+    let gray = Pix::new(4, 4, PixelDepth::Bit8).unwrap();
+    assert!(find_large_rectangles(&gray, Polarity::Background, 1).is_err());
+}
+
+/// `pixFindRectangleInCC` finds the inner rectangle of a single CC.
+#[test]
+#[ignore = "RED: find_rectangle_in_cc not yet implemented (plan 801)"]
 fn rectangle_reg_in_cc() {
-    // TODO: Implement when pixFindRectangleInCC is available
+    // Solid 6x4 fg block — the largest rect is the full block.
+    let mut fg = Vec::new();
+    for y in 0..4 {
+        for x in 0..6 {
+            fg.push((x as u32, y as u32));
+        }
+    }
+    let pix = make_1bpp(6, 4, &fg);
+    let r = find_rectangle_in_cc(
+        &pix,
+        None,
+        0.5,
+        ScanDirection::Horizontal,
+        RectSelect::GeometricUnion,
+    )
+    .expect("in_cc")
+    .expect("box found");
+    assert_eq!((r.x, r.y, r.w, r.h), (0, 0, 6, 4));
+
+    // LargestArea on a fully-fg block must give the same shape.
+    let r2 = find_rectangle_in_cc(
+        &pix,
+        None,
+        0.5,
+        ScanDirection::Horizontal,
+        RectSelect::LargestArea,
+    )
+    .expect("in_cc largest")
+    .expect("box found");
+    assert_eq!((r2.x, r2.y, r2.w, r2.h), (0, 0, 6, 4));
+
+    // Vertical scan: rotated internally but result must be in source coords.
+    let r3 = find_rectangle_in_cc(
+        &pix,
+        None,
+        0.5,
+        ScanDirection::Vertical,
+        RectSelect::GeometricUnion,
+    )
+    .expect("in_cc vert")
+    .expect("box found");
+    assert_eq!((r3.x, r3.y, r3.w, r3.h), (0, 0, 6, 4));
+
+    // boxs offsets: pass a 1-pixel-shifted box → result coordinates should
+    // be in the original (un-shifted) frame.
+    let outer = make_1bpp(
+        8,
+        6,
+        &fg.iter().map(|&(x, y)| (x + 1, y + 1)).collect::<Vec<_>>(),
+    );
+    let boxs = Box::new(1, 1, 6, 4).unwrap();
+    let r4 = find_rectangle_in_cc(
+        &outer,
+        Some(&boxs),
+        0.5,
+        ScanDirection::Horizontal,
+        RectSelect::GeometricUnion,
+    )
+    .expect("in_cc with boxs")
+    .expect("box found");
+    assert_eq!((r4.x, r4.y, r4.w, r4.h), (1, 1, 6, 4));
+
+    // Invalid fract is rejected.
+    assert!(
+        find_rectangle_in_cc(
+            &pix,
+            None,
+            0.0,
+            ScanDirection::Horizontal,
+            RectSelect::GeometricUnion,
+        )
+        .is_err(),
+    );
 }


### PR DESCRIPTION
## Summary

- 計画 [801_recog-rectangle-detection.md](https://github.com/tagawa0525/leptonica-rs/blob/feat/region-rectangle-detection/docs/plans/801_recog-rectangle-detection.md) (項目 K) に従い、C 版 `pageseg.c` の矩形検出 3 関数を Rust に移植
- `tests/region/rectangle_reg.rs` の 2 件 と `tests/recog/pageseg_reg.rs::test_22` の `#[ignore]` を解除（region 1→0、recog 13→12）

## What

`src/region/rectangle.rs` を新設:

- `find_largest_rectangle(pix, polarity) -> RegionResult<Box>` — O(W×H) DP
- `find_large_rectangles(pix, polarity, nrect) -> RegionResult<Boxa>` — greedy
- `find_rectangle_in_cc(pix, boxs, fract, dir, select) -> RegionResult<Option<Box>>` — fast-scan run-length
- enum: `Polarity { Background, Foreground }`、`ScanDirection { Horizontal, Vertical }`、`RectSelect { GeometricUnion, GeometricIntersection, LargestArea, SmallestArea }`

依存はすべて既存:
- `find_max_horizontal_run_on_line` (`src/filter/runlength.rs`)
- `rotate_orth` (`src/transform/rotate.rs`)
- `Pix::clip_rectangle` / `set_in_rect` / `clear_in_rect`

## Test plan

- [x] `cargo test --test region rectangle_reg` 3 件通過 (新規 1 + unignore 2)
- [x] `cargo test --test recog test_22` 通過
- [x] `cargo test --all-features` 全件通過
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

## Notes

C 版 `pixFindRectangleInCC` のループ境界は最後のスキャン行を含めない設計（`if (... || i == h - 1) { ylast = i - 1; break; }`）になっているため、6×4 の solid block では中間 box が 6×3 になります。これは C 版の挙動を忠実に再現するためで、テストでは GeometricUnion で 6×4 が復元されることを確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)