### PR TITLE
feat(recog): port pixDecideIfTable / pixAutoPhotoinvert

### DIFF
--- a/docs/plans/802_recog-table-photoinvert.md
+++ b/docs/plans/802_recog-table-photoinvert.md
@@ -1,0 +1,123 @@
+# recog/pageseg: 表判定・自動反転の移植
+
+Status: IN_PROGRESS
+親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 L)
+
+## Context
+
+C 版 `pageseg.c` の以下 2 関数が Rust に未移植。`tests/recog/pageseg_reg.rs`
+には 2 件の `#[ignore]` が残っている。
+
+| C 関数               | 行             | 役割                                                                                     |
+| -------------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| `pixDecideIfTable`   | pageseg.c:2172 | テーブル判定。横/縦の前景線数 + 縦の背景線数からスコア 0–4 を返す（>= 2 でテーブル判定） |
+| `pixAutoPhotoinvert` | pageseg.c:2923 | 反転テキスト領域を halftone mask + 形態学で検出し、領域内 fg ≥ 60% なら photoinvert する |
+
+Rust 既存依存（確認済み）:
+
+- `Pix::convert_to_1`、`Pix::invert`、`Pix::or`、`Pix::subtract`、
+
+  `Pix::clip_rectangle`、`Pix::foreground_fraction`、
+  `Pix::combine_masked`、`Pix::is_zero`
+
+- `morph_sequence` (`src/morph/sequence.rs`)
+- `dilate_brick` (`src/morph/binary.rs`)
+- `seedfill_binary`、`fill_holes_to_bounding_rect` (`src/region/seedfill.rs`)
+- `count_conn_comp`、`find_connected_components` (`src/region/conncomp.rs`)
+- `pix_select_by_size` (`src/region/select.rs`)
+- `deskew_both` (`src/recog/skew.rs`)
+- `rotate_90` (`src/transform/rotate.rs`)
+- `generate_halftone_mask` (`src/recog/pageseg.rs`、現在 private — `pub(crate)` に昇格)
+
+未実装依存:
+
+- `pix_prepare_1bpp` 相当: 任意 box clip → 任意 background normalize → 1bpp 化 を 1 回でやる pageseg.c のヘルパ。本タスク内で recog/pageseg の内部 helper として実装。
+
+## アルゴリズム概要
+
+### `decide_if_table(pix, box, orient) -> Result<i32>`
+
+1. 175 ppi で 1bpp 化 → halftone mask 検出。halftone があれば `score = 0` を返す
+2. 75 ppi で 1bpp 化 → 2x2 dilate
+3. `deskew_both` で水平/垂直 deskew
+4. `orient == Landscape` なら 90° 回転
+5. 4 つの形態学シーケンスで横/縦黒線、縦白線を抽出
+6. 連結成分数 `nhb`、`nvb`、`nvw` を数える
+7. スコア:
+   - `nhb > 1` で +1
+   - `nvb > 2` で +1
+   - `nvw > 3` で +1
+   - `nvw > 6` で +1
+8. score >= 2 ならテーブル
+
+### `auto_photoinvert(pix, thresh) -> Result<(Pix, Option<Pix>)>`
+
+1. `convert_to_1(thresh)` で 1bpp 化
+2. `generate_halftone_mask` で halftone 候補を抽出
+3. 形態学 `o15.15 + c25.25` でノイズ除去
+4. `fill_holes_to_bounding_rect` で穴埋め
+5. mask が空なら 1bpp 結果を返す
+6. 各連結成分について、領域内 fg ≥ 60% なら反転対象として保持、そうでなければ mask から消去
+7. 残った mask 領域に photoinvert を適用 (`pix_inverted = pix.invert()`、
+
+   `pix_combined = combine_masked(pix1, pix_inverted, mask)`)
+
+8. 1bpp 結果と `Option<mask>` を返す
+
+## 配置先・API 設計
+
+- ファイル: `src/recog/pageseg.rs` に追記
+- 公開 API:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageOrientation {
+    Portrait,  // C: L_PORTRAIT_MODE
+    Landscape, // C: L_LANDSCAPE_MODE
+}
+
+/// pixDecideIfTable 相当
+///
+/// Returns -1 if not determined (per C semantics), or 0..=4 score.
+pub fn decide_if_table(
+    pix: &Pix,
+    box_: Option<&Box>,
+    orient: PageOrientation,
+) -> RecogResult<i32>;
+
+/// pixAutoPhotoinvert 相当
+///
+/// Returns the post-processed 1bpp image and an optional mask of inverted
+/// regions.
+pub fn auto_photoinvert(
+    pix: &Pix,
+    thresh: u32,
+) -> RecogResult<(Pix, Option<Pix>)>;
+```
+
+`PageOrientation` は新規 enum として `recog/pageseg.rs` 内に定義。
+
+## TDD ステップ
+
+1. **RED**: 公開 API stub と `tests/recog/pageseg_reg.rs::test_23_30_decide_if_table` /
+
+   `test_31_36_auto_photoinvert` の `#[ignore]` を RED に書き換え。テストは
+   実画像 (table.* / invertedtext.tif など) が無い場合は内部合成で実行する
+   smoke 観点に絞る
+
+2. **GREEN**: 上記アルゴリズムを実装、`#[ignore]` 解除
+
+## ブランチ・PR
+
+- ブランチ: `feat/recog-table-photoinvert`
+- PR: `feat(recog): port pixDecideIfTable / pixAutoPhotoinvert`
+- 1PR、RED → GREEN
+
+## ステータス
+
+- [x] 計画書作成
+- [ ] RED コミット
+- [ ] GREEN コミット
+- [ ] PR 作成・Copilot レビュー対応
+- [ ] /gh-pr-merge --merge
+- [ ] 031 全体計画書を IMPLEMENTED に更新

--- a/docs/plans/802_recog-table-photoinvert.md
+++ b/docs/plans/802_recog-table-photoinvert.md
@@ -115,9 +115,9 @@ pub fn auto_photoinvert(
 
 ## ステータス
 
-- [x] 計画書作成
-- [ ] RED コミット
-- [ ] GREEN コミット
-- [ ] PR 作成・Copilot レビュー対応
+- [x] 計画書作成（20fd79c）
+- [x] RED コミット（a057fc4）
+- [x] GREEN コミット（08023a3）
+- [x] PR 作成・Copilot レビュー対応（PR #322）
 - [ ] /gh-pr-merge --merge
-- [ ] 031 全体計画書を IMPLEMENTED に更新
+- [ ] 031 全体計画書の表に PR #322 を反映

--- a/docs/plans/802_recog-table-photoinvert.md
+++ b/docs/plans/802_recog-table-photoinvert.md
@@ -1,6 +1,6 @@
 # recog/pageseg: 表判定・自動反転の移植
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 L)
 
 ## Context

--- a/src/recog/pageseg.rs
+++ b/src/recog/pageseg.rs
@@ -980,9 +980,11 @@ fn prepare_1bpp(pix: &Pix, box_: Option<&crate::core::Box>) -> RecogResult<Pix> 
 
 /// Decide whether `pix` likely contains a table.
 ///
-/// Returns `Ok(-1)` when the analysis cannot be completed, `Ok(0..=4)` for the
-/// detection score otherwise. A score `>= 2` is the conventional table
-/// threshold (see C `pixDecideIfTable` notes).
+/// Returns `Ok(0..=4)` where higher values indicate stronger evidence of a
+/// table; `>= 2` is the conventional threshold (see C `pixDecideIfTable`
+/// notes). The C version uses `-1` as a sentinel for "undetermined" via an
+/// out-parameter; the Rust port instead surfaces failures as `Err` so the
+/// `Ok` value is always a valid score.
 ///
 /// C Leptonica equivalent: `pixDecideIfTable`.
 pub fn decide_if_table(
@@ -1024,20 +1026,11 @@ pub fn decide_if_table(
     let nvb = count_conn_comp(&pix_v, ConnectivityType::EightWay)?;
 
     // Vertical whitespace detection: invert to make whitespace foreground.
-    let h_lines = seedfill_binary_restricted(
-        &pix_h,
-        &pix1,
-        ConnectivityType::EightWay,
-        u32::MAX,
-        u32::MAX,
-    )?;
-    let v_lines = seedfill_binary_restricted(
-        &pix_v,
-        &pix1,
-        ConnectivityType::EightWay,
-        u32::MAX,
-        u32::MAX,
-    )?;
+    // (xmax, ymax) = (0, 0) is the unlimited fast-path in
+    // `seedfill_binary_restricted`; passing u32::MAX would force per-pixel
+    // distance checks for no benefit.
+    let h_lines = seedfill_binary_restricted(&pix_h, &pix1, ConnectivityType::EightWay, 0, 0)?;
+    let v_lines = seedfill_binary_restricted(&pix_v, &pix1, ConnectivityType::EightWay, 0, 0)?;
     let lines = h_lines.or(&v_lines)?;
     let no_lines = pix1.subtract(&lines)?;
     let cleaned = morph_sequence(&no_lines, "c4.1 + o8.1")?;

--- a/src/recog/pageseg.rs
+++ b/src/recog/pageseg.rs
@@ -955,6 +955,29 @@ pub enum PageOrientation {
     Landscape,
 }
 
+/// Helper: clip to `box_` if any, then ensure 1bpp.
+fn prepare_1bpp(pix: &Pix, box_: Option<&crate::core::Box>) -> RecogResult<Pix> {
+    let clipped = if let Some(b) = box_ {
+        let pw = pix.width() as i32;
+        let ph = pix.height() as i32;
+        if b.x < 0 || b.y < 0 || b.w <= 0 || b.h <= 0 || b.x + b.w > pw || b.y + b.h > ph {
+            return Err(RecogError::InvalidParameter(format!(
+                "box {:?} is out of bounds for {}x{} image",
+                b, pw, ph
+            )));
+        }
+        pix.clip_rectangle(b.x as u32, b.y as u32, b.w as u32, b.h as u32)
+            .map_err(RecogError::from)?
+    } else {
+        pix.clone()
+    };
+    if clipped.depth() == PixelDepth::Bit1 {
+        Ok(clipped)
+    } else {
+        ensure_binary_with_threshold(&clipped, 128)
+    }
+}
+
 /// Decide whether `pix` likely contains a table.
 ///
 /// Returns `Ok(-1)` when the analysis cannot be completed, `Ok(0..=4)` for the
@@ -963,11 +986,84 @@ pub enum PageOrientation {
 ///
 /// C Leptonica equivalent: `pixDecideIfTable`.
 pub fn decide_if_table(
-    _pix: &Pix,
-    _box_: Option<&crate::core::Box>,
-    _orient: PageOrientation,
+    pix: &Pix,
+    box_: Option<&crate::core::Box>,
+    orient: PageOrientation,
 ) -> RecogResult<i32> {
-    unimplemented!("decide_if_table: implemented in GREEN commit (plan 802)")
+    use crate::morph::{dilate_brick, sequence::morph_sequence};
+    use crate::region::conncomp::{ConnectivityType, count_conn_comp, find_connected_components};
+    use crate::region::seedfill::seedfill_binary_restricted;
+    use crate::transform::rotate::rotate_90;
+
+    // 1bpp + halftone detection: if a halftone region is present, the page
+    // likely contains an image rather than a table — return 0 immediately.
+    let pix_for_ht = prepare_1bpp(pix, box_)?;
+    let (halftone, _text) = generate_halftone_mask(&pix_for_ht)?;
+    if !halftone.is_zero() {
+        return Ok(0);
+    }
+
+    // Same 1bpp pix, dilated 2x2 to merge near-adjacent text strokes.
+    let pix1 = prepare_1bpp(pix, box_)?;
+    if pix1.is_zero() {
+        return Ok(0);
+    }
+    let pix2 = dilate_brick(&pix1, 2, 2)?;
+
+    // Deskew and optionally rotate for landscape pages.
+    let (pix3, _angle) = crate::recog::skew::deskew_both(&pix2)?;
+    let pix1 = match orient {
+        PageOrientation::Portrait => pix3,
+        PageOrientation::Landscape => rotate_90(&pix3, true)?,
+    };
+
+    // Horizontal/vertical foreground line detection.
+    let pix_h = morph_sequence(&pix1, "o100.1 + c1.4")?;
+    let pix_v = morph_sequence(&pix1, "o1.100 + c4.1")?;
+    let nhb = count_conn_comp(&pix_h, ConnectivityType::EightWay)?;
+    let nvb = count_conn_comp(&pix_v, ConnectivityType::EightWay)?;
+
+    // Vertical whitespace detection: invert to make whitespace foreground.
+    let h_lines = seedfill_binary_restricted(
+        &pix_h,
+        &pix1,
+        ConnectivityType::EightWay,
+        u32::MAX,
+        u32::MAX,
+    )?;
+    let v_lines = seedfill_binary_restricted(
+        &pix_v,
+        &pix1,
+        ConnectivityType::EightWay,
+        u32::MAX,
+        u32::MAX,
+    )?;
+    let lines = h_lines.or(&v_lines)?;
+    let no_lines = pix1.subtract(&lines)?;
+    let cleaned = morph_sequence(&no_lines, "c4.1 + o8.1")?;
+    let inverted = cleaned.invert();
+    let vws_mask = morph_sequence(&inverted, "r1 + o1.100")?;
+    // C: pixSelectBySize(pix8, 5, 0, 8, L_SELECT_WIDTH, L_SELECT_IF_GTE) — keep
+    // components whose bounding-box width is at least 5px. The Rust
+    // pix_select_by_size only offers IfBoth/IfEither, so filter via the
+    // connected-component list instead.
+    let vws_comps = find_connected_components(&vws_mask, ConnectivityType::EightWay)?;
+    let nvw = vws_comps.iter().filter(|c| c.bounds.w >= 5).count() as u32;
+
+    let mut score = 0;
+    if nhb > 1 {
+        score += 1;
+    }
+    if nvb > 2 {
+        score += 1;
+    }
+    if nvw > 3 {
+        score += 1;
+    }
+    if nvw > 6 {
+        score += 1;
+    }
+    Ok(score)
 }
 
 /// Detect inverted-text regions and re-invert them.
@@ -976,8 +1072,49 @@ pub fn decide_if_table(
 /// post-photoinvert binary image and the mask flags inverted regions.
 ///
 /// C Leptonica equivalent: `pixAutoPhotoinvert`.
-pub fn auto_photoinvert(_pix: &Pix, _thresh: u32) -> RecogResult<(Pix, Option<Pix>)> {
-    unimplemented!("auto_photoinvert: implemented in GREEN commit (plan 802)")
+pub fn auto_photoinvert(pix: &Pix, thresh: u32) -> RecogResult<(Pix, Option<Pix>)> {
+    use crate::morph::sequence::morph_sequence;
+    use crate::region::conncomp::{ConnectivityType, find_connected_components};
+    use crate::region::seedfill::fill_holes_to_bounding_rect;
+
+    let thresh = if thresh == 0 { 128 } else { thresh };
+    let pix1 = ensure_binary_with_threshold(pix, thresh)?;
+
+    // Identify candidate inverted-text regions via halftone-style mask.
+    let (ht, _text) = generate_halftone_mask(&pix1)?;
+    let denoised = morph_sequence(&ht, "o15.15 + c25.25")?;
+    let mut mask = fill_holes_to_bounding_rect(&denoised, 1, 0.5, 1.0)?;
+    if mask.is_zero() {
+        return Ok((pix1, None));
+    }
+
+    // Validate each component: the underlying region must be ≥ 60% fg in pix1
+    // (i.e. dark background with light text). Erase regions that do not meet
+    // the criterion from the mask.
+    let comps = find_connected_components(&mask, ConnectivityType::EightWay)?;
+    let mut mask_mut = mask.to_mut();
+    for cc in &comps {
+        let b = cc.bounds;
+        let region = pix1.clip_rectangle(b.x as u32, b.y as u32, b.w as u32, b.h as u32)?;
+        let frac = region.foreground_fraction()?;
+        if frac < 0.6 {
+            // Erase this component from the mask.
+            mask_mut.clear_in_rect(&b)?;
+        }
+    }
+    mask = mask_mut.into();
+
+    if mask.is_zero() {
+        return Ok((pix1, None));
+    }
+
+    // Photoinvert: combine inverted pix into pix1 over the mask.
+    let inverted = pix1.invert();
+    let mut combined_mut = pix1.to_mut();
+    combined_mut.combine_masked(&inverted, &mask)?;
+    let combined: Pix = combined_mut.into();
+
+    Ok((combined, Some(mask)))
 }
 
 // Old pixel-by-pixel implementations preserved for testing

--- a/src/recog/pageseg.rs
+++ b/src/recog/pageseg.rs
@@ -946,6 +946,40 @@ fn subtract_images(pix1: &Pix, pix2: &Pix) -> RecogResult<Pix> {
     Ok(result_mut.into())
 }
 
+/// Page orientation for [`decide_if_table`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageOrientation {
+    /// `L_PORTRAIT_MODE` — assume the image is upright.
+    Portrait,
+    /// `L_LANDSCAPE_MODE` — rotate 90° cw before analysing.
+    Landscape,
+}
+
+/// Decide whether `pix` likely contains a table.
+///
+/// Returns `Ok(-1)` when the analysis cannot be completed, `Ok(0..=4)` for the
+/// detection score otherwise. A score `>= 2` is the conventional table
+/// threshold (see C `pixDecideIfTable` notes).
+///
+/// C Leptonica equivalent: `pixDecideIfTable`.
+pub fn decide_if_table(
+    _pix: &Pix,
+    _box_: Option<&crate::core::Box>,
+    _orient: PageOrientation,
+) -> RecogResult<i32> {
+    unimplemented!("decide_if_table: implemented in GREEN commit (plan 802)")
+}
+
+/// Detect inverted-text regions and re-invert them.
+///
+/// Returns `(processed_1bpp, optional_mask)` where `processed_1bpp` is the
+/// post-photoinvert binary image and the mask flags inverted regions.
+///
+/// C Leptonica equivalent: `pixAutoPhotoinvert`.
+pub fn auto_photoinvert(_pix: &Pix, _thresh: u32) -> RecogResult<(Pix, Option<Pix>)> {
+    unimplemented!("auto_photoinvert: implemented in GREEN commit (plan 802)")
+}
+
 // Old pixel-by-pixel implementations preserved for testing
 #[cfg(test)]
 mod old_impl {

--- a/tests/recog/pageseg_reg.rs
+++ b/tests/recog/pageseg_reg.rs
@@ -747,7 +747,7 @@ fn test_22_find_large_rectangles() {
 /// Rust 版テストデータが揃わないため、`feyn-fract.tif`（テキスト中心、
 /// 表構造ほぼ無し）を非テーブル候補として、score < 2 を期待する smoke 形。
 #[test]
-#[ignore = "RED: decide_if_table not yet implemented (plan 802)"]
+
 fn test_23_30_decide_if_table() {
     use leptonica::recog::pageseg::{PageOrientation, decide_if_table};
 
@@ -773,7 +773,7 @@ fn test_23_30_decide_if_table() {
 /// Rust 版テストデータが揃わないため、smoke 観点（戻り値が 1bpp で寸法が
 /// 入力と一致する）で検証。
 #[test]
-#[ignore = "RED: auto_photoinvert not yet implemented (plan 802)"]
+
 fn test_31_36_auto_photoinvert() {
     use leptonica::recog::pageseg::auto_photoinvert;
 

--- a/tests/recog/pageseg_reg.rs
+++ b/tests/recog/pageseg_reg.rs
@@ -744,16 +744,24 @@ fn test_22_find_large_rectangles() {
 /// C版: pixDecideIfTable(pix1, NULL, L_PORTRAIT_MODE, &score, pixadb)
 ///       table.15.tif, table.27.tif, table.150.png, toc.99.tif で判定
 ///
-/// Rust未実装のためスキップ。
+/// Rust 版テストデータが揃わないため、`feyn-fract.tif`（テキスト中心、
+/// 表構造ほぼ無し）を非テーブル候補として、score < 2 を期待する smoke 形。
 #[test]
-#[ignore = "pixDecideIfTable() -- Rust未実装のためスキップ"]
+#[ignore = "RED: decide_if_table not yet implemented (plan 802)"]
 fn test_23_30_decide_if_table() {
-    // C版: pixDecideIfTable で score >= 2 ならテーブルと判定
-    // table.15.tif: テーブル (expect istable=1) -- Test 23
-    // table.27.tif: テーブル (expect istable=1) -- Test 25
-    // table.150.png: テーブル (expect istable=1) -- Test 27
-    // toc.99.tif: 目次 (not a table, expect istable=0) -- Test 29
-    eprintln!("pixDecideIfTable is not implemented in Rust");
+    use leptonica::recog::pageseg::{PageOrientation, decide_if_table};
+
+    let pix = load_test_image("feyn-fract.tif").expect("load feyn-fract.tif");
+    let score = decide_if_table(&pix, None, PageOrientation::Portrait).expect("decide_if_table");
+    // Plain text page: score should be in valid range and below table threshold.
+    assert!(
+        (-1..=4).contains(&score),
+        "score must be -1..=4, got {score}"
+    );
+    assert!(
+        score < 2,
+        "feyn-fract.tif is text, expected score < 2, got {score}"
+    );
 }
 
 /// Test 31-36: pixAutoPhotoinvert -- 自動テキスト反転
@@ -762,14 +770,18 @@ fn test_23_30_decide_if_table() {
 ///       zanotti-78.jpg の一部を反転し、自動検出して再反転
 ///       invertedtext.tif も同様にテスト
 ///
-/// Rust未実装のためスキップ。
+/// Rust 版テストデータが揃わないため、smoke 観点（戻り値が 1bpp で寸法が
+/// 入力と一致する）で検証。
 #[test]
-#[ignore = "pixAutoPhotoinvert() -- Rust未実装のためスキップ"]
+#[ignore = "RED: auto_photoinvert not yet implemented (plan 802)"]
 fn test_31_36_auto_photoinvert() {
-    // C版: pixAutoPhotoinvert で反転テキスト領域を検出して再反転
-    // zanotti-78.jpg: 一部を手動反転して自動検出テスト -- Test 31-33
-    // invertedtext.tif: 反転テキスト画像の自動検出テスト -- Test 34-36
-    eprintln!("pixAutoPhotoinvert is not implemented in Rust");
+    use leptonica::recog::pageseg::auto_photoinvert;
+
+    let pix = load_test_image("feyn-fract.tif").expect("load feyn-fract.tif");
+    let (out, _mask) = auto_photoinvert(&pix, 128).expect("auto_photoinvert");
+    assert_eq!(out.depth(), PixelDepth::Bit1, "result must be 1bpp");
+    assert_eq!(out.width(), pix.width(), "width preserved");
+    assert_eq!(out.height(), pix.height(), "height preserved");
 }
 
 // ============================================================================

--- a/tests/recog/pageseg_reg.rs
+++ b/tests/recog/pageseg_reg.rs
@@ -753,11 +753,9 @@ fn test_23_30_decide_if_table() {
 
     let pix = load_test_image("feyn-fract.tif").expect("load feyn-fract.tif");
     let score = decide_if_table(&pix, None, PageOrientation::Portrait).expect("decide_if_table");
-    // Plain text page: score should be in valid range and below table threshold.
-    assert!(
-        (-1..=4).contains(&score),
-        "score must be -1..=4, got {score}"
-    );
+    // Plain text page: score should be in the 0..=4 range and below the
+    // conventional table threshold.
+    assert!((0..=4).contains(&score), "score must be 0..=4, got {score}");
     assert!(
         score < 2,
         "feyn-fract.tif is text, expected score < 2, got {score}"


### PR DESCRIPTION
## Summary

- 計画 [802_recog-table-photoinvert.md](https://github.com/tagawa0525/leptonica-rs/blob/feat/recog-table-photoinvert/docs/plans/802_recog-table-photoinvert.md) (項目 L、Group 2 最終) に従い、C 版 `pageseg.c` の `pixDecideIfTable` と `pixAutoPhotoinvert` を Rust に移植
- `tests/recog/pageseg_reg.rs::test_23_30_decide_if_table` と `test_31_36_auto_photoinvert` の `#[ignore]` を解除（recog ignored 4 → 2）
- これで **Group 2 (項目 D/K/L)** が全て完了

## What

`src/recog/pageseg.rs`:
- `pub enum PageOrientation { Portrait, Landscape }`
- `decide_if_table(pix, box, orient) -> RecogResult<i32>`: halftone 検出 → 1bpp dilate → deskew → 形態学シーケンスで横/縦黒線・縦白線の連結成分数を計算 → C 版と同じ 4 条件 (`nhb>1`, `nvb>2`, `nvw>3`, `nvw>6`) でスコア 0..=4 を返す
- `auto_photoinvert(pix, thresh) -> RecogResult<(Pix, Option<Pix>)>`: halftone mask → `o15.15 + c25.25` でノイズ除去 → `fill_holes_to_bounding_rect` で穴埋め → 各連結成分の fg fraction が 0.6 未満なら mask から消去 → 残った mask 領域だけ photoinvert
- 内部 helper `prepare_1bpp(pix, box)` でオプション clip + 1bpp 化

## Notes

- `pixSelectBySize(L_SELECT_WIDTH)` (width のみで select) は Rust の `pix_select_by_size` API では表現できないため、`find_connected_components` で連結成分一覧を取得し `bounds.w >= 5` で直接フィルタ
- 解像度変換 (75/175 ppi スケーリング) は省略 — 入力 1bpp 文書を想定した smoke 実装
- テストデータが同梱されていないため、`feyn-fract.tif` を使った smoke 観点の検証

## Test plan

- [x] `cargo test --test recog test_23_30_decide_if_table` 通過
- [x] `cargo test --test recog test_31_36_auto_photoinvert` 通過
- [x] `cargo test --all-features` 全件通過 (recog ignored 4→2)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)