### PR TITLE
fix(region): cap ccbord trace loops to avoid OOM on feyn-fract.tif

### DIFF
--- a/docs/plans/701_region-ccbord-memory.md
+++ b/docs/plans/701_region-ccbord-memory.md
@@ -1,0 +1,85 @@
+# region/ccbord: feyn-fract.tif で OOM していた境界追跡の修正
+
+Status: IMPLEMENTED
+親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 J)
+
+## Context
+
+`tests/region/ccbord_reg.rs::ccbord_reg_feyn_fract` は
+"Rust ccbord has O(n_components × image_size) memory" との理由で
+`#[ignore]` されていた。31 起草時はメモリ計算量の問題と分類していたが、
+実際にテストを動かして backtrace を取ると別の原因が判明:
+
+```text
+memory allocation of 4294967296 bytes failed  (= 4 GB)
+stack backtrace:
+  ...
+  trace_hole_border
+  get_component_borders
+  get_all_borders
+  ccbord_reg_feyn_fract
+```
+
+`extract_component_image` は bbox-size の Pix しか確保しておらず、
+メモリ計算量は実際には O(Σ bbox_size_i)。OOM の真因は:
+
+- `trace_hole_border` の終了条件 `(px, py) == (start) && next == second`
+
+  が緩く、ill-formed な hole で標準 Moore-tracing 終了条件が発火しない
+
+- 結果としてループが無限に回り、`points: Vec<BorderPoint>` が
+
+  4 GB 以上を要求して OOM
+
+`trace_outer_border`（`get_outer_border` 内）にも同じ構造のループがあり、
+同様の暴走リスクを抱えていた。
+
+## 修正内容
+
+両ループに、border の周長上限である `4 * (W + H) + 16` を `points.len()`
+の上限として追加。これを超えたら `Err(RegionError::InvalidParameters(..))`
+で打ち切る。
+
+`get_component_borders` 内で `trace_hole_border` のエラーは既に
+`Err(_) => continue` で吸収されているため、hole 単位での失敗は
+コンポーネント全体を失敗にしない。`trace_outer_border` の失敗は
+`get_all_borders` の `match` で 1 コンポーネントだけ skip される。
+
+## 実装
+
+- `src/region/ccbord.rs::trace_hole_border`: 行 1230 付近にループ
+
+  上限チェックを追加
+
+- `src/region/ccbord.rs::get_outer_border` (= 行 923 付近の outer
+
+  tracer): 同じ上限チェックを追加
+
+## テスト
+
+- `tests/region/ccbord_reg.rs::ccbord_reg_feyn_fract` の `#[ignore]`
+
+  を解除（元の理由がもはや当てはまらない）
+
+- `cargo test --release` で feyn-fract.tif (1080×485, 1bpp の
+
+  text-heavy 画像) が OOM せず通過することを確認
+
+## ステータス
+
+- [x] OOM 原因の特定 (バックトレース)
+- [x] 上限チェックの追加
+- [x] `#[ignore]` 解除
+- [x] cargo test / clippy / fmt 通過
+- [ ] PR 作成・Copilot レビュー対応
+- [ ] /gh-pr-merge --merge
+- [ ] 031 全体計画書を IMPLEMENTED に更新
+
+## 残課題
+
+- ill-formed hole が発生する根本原因（Moore tracing の終了条件設計か
+
+  pixel-classification か）はこの PR では追跡していない。border 追跡が
+  早期に打ち切られた場合、その component の hole 情報は欠落する
+
+- 別 issue として「tracer の正しい終了条件」を将来再検討する余地あり

--- a/src/region/ccbord.rs
+++ b/src/region/ccbord.rs
@@ -975,7 +975,10 @@ pub fn get_outer_border(pix: &Pix, bounds: Option<&Box>) -> RegionResult<Border>
 
     let (mut px, mut py) = (spx, spy);
 
-    // Trace the border
+    // Trace the border. As with the hole tracer, cap the number of recorded
+    // points at a multiple of the perimeter bound to prevent runaway growth
+    // when the standard termination condition fails to fire.
+    let max_points = 4 * (bwidth as usize + bheight as usize) + 16;
     while let Some((next, new_qpos)) =
         find_next_border_pixel(&bordered, bwidth, bheight, px, py, qpos)
     {
@@ -985,6 +988,11 @@ pub fn get_outer_border(pix: &Pix, bounds: Option<&Box>) -> RegionResult<Border>
         }
 
         points.push(BorderPoint::new(next.x - 1, next.y - 1));
+        if points.len() >= max_points {
+            return Err(RegionError::InvalidParameters(format!(
+                "outer border trace exceeded {max_points} points without closing"
+            )));
+        }
         px = next.x;
         py = next.y;
         qpos = new_qpos;
@@ -1256,7 +1264,12 @@ fn trace_hole_border(pix: &Pix, start: BorderPoint, _hole_bounds: &Box) -> Regio
 
     let (mut px, mut py) = (spx, spy);
 
-    // Trace the border
+    // Trace the border. The standard termination condition (back at the
+    // start with the same outgoing direction as on the first iteration) can
+    // fail for ill-formed holes and let the trace run away. Cap the number
+    // of points at a multiple of the perimeter bound `2*(W + H)` so we abort
+    // long before exhausting memory.
+    let max_points = 4 * (width as usize + height as usize) + 16;
     while let Some((next, new_qpos)) = find_next_border_pixel(pix, width, height, px, py, qpos) {
         // Check if we've completed the loop
         if px == fpx && py == fpy && next.x == spx && next.y == spy {
@@ -1264,6 +1277,11 @@ fn trace_hole_border(pix: &Pix, start: BorderPoint, _hole_bounds: &Box) -> Regio
         }
 
         points.push(next);
+        if points.len() >= max_points {
+            return Err(RegionError::InvalidParameters(format!(
+                "hole border trace exceeded {max_points} points without closing"
+            )));
+        }
         px = next.x;
         py = next.y;
         qpos = new_qpos;

--- a/src/region/ccbord.rs
+++ b/src/region/ccbord.rs
@@ -7,20 +7,15 @@
 //! - Outer borders are traced clockwise
 //! - Hole borders are traced counter-clockwise
 //!
-//! # Known Limitations
+//! # Robustness
 //!
-//! **Memory Efficiency Issue in `get_all_borders()`:**
-//! The current implementation has O(n_components * image_size) memory complexity.
-//! When processing images with many components (e.g., feyn-fract.tif), memory usage
-//! can exceed available RAM. This is due to the Vec-based component detection
-//! accumulating all components before processing, unlike the C reference implementation
-//! which processes components sequentially and releases memory immediately.
-//!
-//! **Workaround:** For large images with many components, consider:
-//! - Processing components iteratively rather than collecting all at once
-//! - Or breaking the image into smaller regions before calling `get_all_borders()`
-//!
-//! See `docs/plans/500_region-full-porting.md` Phase 5 for improvement plan.
+//! The Moore-tracing termination condition (back at the start with the
+//! same outgoing direction as on the first iteration) can fail to fire on
+//! ill-formed holes; both the outer and hole tracers therefore cap the
+//! number of recorded points at roughly the perimeter bound
+//! (`4 * (W + H) + 16`) and abort with `RegionError::InvalidParameters`
+//! when the cap is exceeded. Callers (`get_component_borders`,
+//! `get_all_borders`) skip just that border / component and continue.
 //!
 //! # Examples
 //!
@@ -977,8 +972,13 @@ pub fn get_outer_border(pix: &Pix, bounds: Option<&Box>) -> RegionResult<Border>
 
     // Trace the border. As with the hole tracer, cap the number of recorded
     // points at a multiple of the perimeter bound to prevent runaway growth
-    // when the standard termination condition fails to fire.
-    let max_points = 4 * (bwidth as usize + bheight as usize) + 16;
+    // when the standard termination condition fails to fire. Compute the cap
+    // in u64 then saturate-cast to usize so we cannot overflow on
+    // pathologically large images.
+    let max_points: usize = ((bwidth as u64 + bheight as u64)
+        .saturating_mul(4)
+        .saturating_add(16))
+    .min(usize::MAX as u64) as usize;
     while let Some((next, new_qpos)) =
         find_next_border_pixel(&bordered, bwidth, bheight, px, py, qpos)
     {
@@ -988,7 +988,7 @@ pub fn get_outer_border(pix: &Pix, bounds: Option<&Box>) -> RegionResult<Border>
         }
 
         points.push(BorderPoint::new(next.x - 1, next.y - 1));
-        if points.len() >= max_points {
+        if points.len() > max_points {
             return Err(RegionError::InvalidParameters(format!(
                 "outer border trace exceeded {max_points} points without closing"
             )));
@@ -1268,8 +1268,12 @@ fn trace_hole_border(pix: &Pix, start: BorderPoint, _hole_bounds: &Box) -> Regio
     // start with the same outgoing direction as on the first iteration) can
     // fail for ill-formed holes and let the trace run away. Cap the number
     // of points at a multiple of the perimeter bound `2*(W + H)` so we abort
-    // long before exhausting memory.
-    let max_points = 4 * (width as usize + height as usize) + 16;
+    // long before exhausting memory. Compute in u64 + saturating cast to
+    // avoid overflow on pathologically large images.
+    let max_points: usize = ((width as u64 + height as u64)
+        .saturating_mul(4)
+        .saturating_add(16))
+    .min(usize::MAX as u64) as usize;
     while let Some((next, new_qpos)) = find_next_border_pixel(pix, width, height, px, py, qpos) {
         // Check if we've completed the loop
         if px == fpx && py == fpy && next.x == spx && next.y == spy {
@@ -1277,7 +1281,7 @@ fn trace_hole_border(pix: &Pix, start: BorderPoint, _hole_bounds: &Box) -> Regio
         }
 
         points.push(next);
-        if points.len() >= max_points {
+        if points.len() > max_points {
             return Err(RegionError::InvalidParameters(format!(
                 "hole border trace exceeded {max_points} points without closing"
             )));

--- a/tests/region/ccbord_reg.rs
+++ b/tests/region/ccbord_reg.rs
@@ -118,9 +118,10 @@ fn run_ccbord_test(fname: &str, rp: &mut RegParams) {
 
 /// Border tracing test using feyn-fract.tif
 ///
-/// Currently cannot run due to O(n_components * image_size) memory in Rust implementation.
+/// Previously ignored with a misleading "O(n_components * image_size)" memory
+/// notice. The actual problem was an infinite loop in the Moore tracer that
+/// grew the points vector until allocation hit 4 GiB; capped in PR #323.
 #[test]
-
 fn ccbord_reg_feyn_fract() {
     let mut rp = RegParams::new("ccbord_feyn_fract");
     run_ccbord_test("feyn-fract.tif", &mut rp);

--- a/tests/region/ccbord_reg.rs
+++ b/tests/region/ccbord_reg.rs
@@ -120,7 +120,7 @@ fn run_ccbord_test(fname: &str, rp: &mut RegParams) {
 ///
 /// Currently cannot run due to O(n_components * image_size) memory in Rust implementation.
 #[test]
-#[ignore = "Rust ccbord has O(n_components * image_size) memory - causes OOM on feyn-fract.tif"]
+
 fn ccbord_reg_feyn_fract() {
     let mut rp = RegParams::new("ccbord_feyn_fract");
     run_ccbord_test("feyn-fract.tif", &mut rp);


### PR DESCRIPTION
## Summary

- 計画 [701_region-ccbord-memory.md](https://github.com/tagawa0525/leptonica-rs/blob/feat/region-ccbord-feyn-test/docs/plans/701_region-ccbord-memory.md) (項目 J、Group 3 初項) に従い、`tests/region/ccbord_reg.rs::ccbord_reg_feyn_fract` の OOM 問題を修正
- `#[ignore]` を解除（region ignored 既に 0 だったが、PR #321 の確認で 1 件残っていた `feyn-fract.tif` が解消）

## Investigation

`#[ignore]` のメッセージは "Rust ccbord has O(n_components × image_size) memory" となっていたが、release ビルドで実行 + バックトレース取得で別の真因が判明:

```text
memory allocation of 4294967296 bytes failed  (= 4 GiB)
stack backtrace:
  ...
  trace_hole_border
  get_component_borders
  get_all_borders
```

`extract_component_image` は bbox-size の Pix しか確保しておらず、メモリ計算量は実際には O(Σ bbox_size_i) で問題なし。OOM の真因は **`trace_hole_border` (および `get_outer_border` の同型ループ) の終了条件不発火による無限ループ**。`points: Vec<BorderPoint>` が 4 GiB に到達して abort していた。

## Fix

両ループに、画像周長上限 `4 * (W + H) + 16` を `points.len()` の上限として追加。これを超えたら `Err(RegionError::InvalidParameters(..))` で打ち切る。

- `get_component_borders` 内で `trace_hole_border` のエラーは既に `Err(_) => continue` で吸収済 → hole 単位での失敗はコンポーネント全体を失敗にしない
- `get_all_borders` の `match` で `Err` の component は skip → 1 component の失敗が画像全体を巻き込まない

## Test plan

- [x] `cargo test --release --test region ccbord_reg_feyn_fract` 通過
- [x] `cargo test --all-features` 全件通過 (region ignored 1→0)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

## Notes

ill-formed hole が発生する根本原因（Moore-tracing の終了条件設計）は別 issue で。border 追跡が早期に打ち切られた場合、その component の hole 情報は欠落します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)