### PR TITLE
feat(io): add scaled / cropped JP2K read using hayro target_resolution

### DIFF
--- a/docs/plans/203_io-jp2k-write.md
+++ b/docs/plans/203_io-jp2k-write.md
@@ -91,11 +91,10 @@ pub fn read_jp2k_cropped_mem(data: &[u8], box_: &Box) -> IoResult<Pix>;
 
 ## ステータス
 
-- [x] 計画書作成
+- [x] 計画書作成 (9e78e04)
 - [x] hayro-jpeg2000 API 調査 (decoder-only、target_resolution あり)
 - [x] 純 Rust encoder の不在を確認
-- [ ] RED コミット (stub + テスト)
-- [ ] GREEN コミット (実装)
-- [ ] PR 作成・Copilot レビュー対応
+- [x] 実装 + テスト (282f9e2): scaled/cropped read 4 関数、io ignored 6→4
+- [x] PR 作成・Copilot レビュー対応 (PR #325)
 - [ ] /gh-pr-merge --merge
 - [ ] 031 全体計画書を「項目 F: 部分実装、書き込みは保留」に更新

--- a/docs/plans/203_io-jp2k-write.md
+++ b/docs/plans/203_io-jp2k-write.md
@@ -1,0 +1,101 @@
+# io/jp2k: 書き込み + 高度読み込み（部分実装）
+
+Status: IN_PROGRESS
+親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 F)
+
+## Context
+
+C 版 `jp2kio.c` の以下が Rust に未移植。`tests/io/jp2kio_reg.rs` には 6 件の
+`#[ignore]` が残っている。
+
+| C 関数                                                    | 役割                         | Rust 実装可能性                |
+| --------------------------------------------------------- | ---------------------------- | ------------------------------ |
+| `pixWriteJp2k` / `pixWriteStreamJp2k` / `pixWriteMemJp2k` | JP2K 書き込み                | ❌ 純 Rust 不可                |
+| `pixReadJp2k` (reduction 引数)                            | 縮小読み込み (1/2, 1/4, ...) | ✅ hayro `target_resolution`   |
+| `pixReadJp2k` (box 引数)                                  | 範囲指定 cropped 読み込み    | ⚠ scale + clip で代替          |
+| `pixReadStreamJp2k` (J2K codec)                           | raw J2K codestream 読み込み  | ✅ hayro が両 codec をサポート |
+
+## 調査結果
+
+### hayro-jpeg2000 0.3.4 の機能
+
+[docs.rs](https://docs.rs/hayro-jpeg2000/0.3.4/) を確認した結果:
+
+- **デコーダ専用**（encoder なし）
+- `DecodeSettings { resolve_palette_indices, strict, target_resolution: Option<(u32, u32)> }` で
+
+  ターゲット解像度ヒントが指定可能
+
+- `Image::new(&data, &DecodeSettings)` → `decode()` で RGBA バイト列を取得
+- raw J2C codestream / JP2 box 形式の両方をサポート
+
+### 純 Rust JP2K エンコーダの状況 (2026-05 時点)
+
+- `hayro-jpeg2000` は decoder-only (本クレートが作られた pdf-writer 用途では reading のみ必要)
+- crates.io 検索で見つかる `jpeg2k` は libopenjp2 (C library) への bindings
+- 純 Rust の JP2K encoder crate は事実上存在しない
+- JP2K エンコーダは wavelet + arithmetic coding で実装規模が極めて大きい
+
+## 採用方針
+
+**部分実装 + 保留**:
+
+### 実装する (本タスク)
+
+- **`read_jp2k_scaled(reader, scale_denom)`**: hayro の `target_resolution`
+
+  を使い、原寸の `1/scale_denom` の解像度で読み込む。`scale_denom` は 1/2/4/8/16
+  をサポート（C 版の `reduction` 引数に相当）
+
+- **`read_jp2k_cropped(reader, box_)`**: 全画像をデコードした後に `Pix::clip_rectangle`
+
+  で box にクリップする方式で実装（hayro 単独では cropped デコード不可のため、
+  performance trade-off を doc に明記）
+
+### 保留 (別 issue)
+
+- **JP2K 書き込み (`pixWriteJp2k` 系)**: `jpeg2k` 等 C-binding crate 追加が必要。
+
+  ビルド複雑度・cross-compile 影響が大きいため別 issue にする
+
+- **J2K codec variant**: hayro は両 codec をサポートするため、書き込みが入った時点で
+
+  併せて実装する
+
+## 配置先・API 設計
+
+```rust
+// 新規追加
+pub fn read_jp2k_scaled<R: Read + Seek>(reader: R, scale_denom: u32) -> IoResult<Pix>;
+pub fn read_jp2k_scaled_mem(data: &[u8], scale_denom: u32) -> IoResult<Pix>;
+pub fn read_jp2k_cropped<R: Read + Seek>(reader: R, box_: &Box) -> IoResult<Pix>;
+pub fn read_jp2k_cropped_mem(data: &[u8], box_: &Box) -> IoResult<Pix>;
+```
+
+## TDD ステップ
+
+1. **RED**: `tests/io/jp2kio_reg.rs::jp2kio_reg_scaled_read` と
+
+   `jp2kio_reg_cropped_read` の `#[ignore]` を RED に書き換え。stub を公開
+
+2. **GREEN**: hayro の `DecodeSettings.target_resolution` を使って実装
+
+書き込み系 (`jp2kio_reg_write`、`jp2kio_reg_j2k_codec`) と "no JP2K test image bundled"
+の `#[ignore]` 2 件はそのまま残す。
+
+## ブランチ・PR
+
+- ブランチ: `feat/io-jp2k-scaled-read`
+- PR: `feat(io): add scaled / cropped JP2K read using hayro target_resolution`
+- 1PR、RED → GREEN
+
+## ステータス
+
+- [x] 計画書作成
+- [x] hayro-jpeg2000 API 調査 (decoder-only、target_resolution あり)
+- [x] 純 Rust encoder の不在を確認
+- [ ] RED コミット (stub + テスト)
+- [ ] GREEN コミット (実装)
+- [ ] PR 作成・Copilot レビュー対応
+- [ ] /gh-pr-merge --merge
+- [ ] 031 全体計画書を「項目 F: 部分実装、書き込みは保留」に更新

--- a/docs/plans/203_io-jp2k-write.md
+++ b/docs/plans/203_io-jp2k-write.md
@@ -1,6 +1,6 @@
 # io/jp2k: 書き込み + 高度読み込み（部分実装）
 
-Status: IN_PROGRESS
+Status: IMPLEMENTED
 親計画: [031_gap-fill-overall.md](031_gap-fill-overall.md) (項目 F)
 
 ## Context

--- a/src/io/jp2k.rs
+++ b/src/io/jp2k.rs
@@ -79,12 +79,14 @@ pub fn read_jp2k<R: Read + Seek>(mut reader: R) -> IoResult<Pix> {
 
 /// Read a JPEG 2000 image from memory
 pub fn read_jp2k_mem(data: &[u8]) -> IoResult<Pix> {
-    // Create decoder with default settings
     let settings = DecodeSettings::default();
-
     let image = Image::new(data, &settings)
         .map_err(|e| IoError::DecodeError(format!("JP2K parse error: {}", e)))?;
+    decode_image_to_pix(image)
+}
 
+/// Convert a hayro `Image` into a [`Pix`], dispatching on color space.
+fn decode_image_to_pix(image: Image<'_>) -> IoResult<Pix> {
     // Get image properties from the Image struct (before decoding)
     let width = image.width();
     let height = image.height();
@@ -377,6 +379,77 @@ pub fn write_jp2k<W: std::io::Write>(
     Err(IoError::UnsupportedFormat(
         "JP2K writing not yet supported: no pure-Rust encoder available".to_string(),
     ))
+}
+
+/// Read a JPEG 2000 image from memory at a reduced resolution.
+///
+/// `scale_denom` is the reciprocal of the scaling factor, e.g. `2` requests
+/// half-size and `4` requests quarter-size. `scale_denom == 0` is rejected.
+/// `scale_denom == 1` is equivalent to [`read_jp2k_mem`].
+///
+/// Implementation: passes `target_resolution` to hayro-jpeg2000's
+/// `DecodeSettings`. The hint is honoured when the codec's wavelet pyramid
+/// allows it (typically powers of two); for other denominators the decoder
+/// may return a slightly different size.
+///
+/// C Leptonica equivalent: `pixReadMemJp2k(data, size, reduction, ...)` with
+/// `box == NULL`.
+pub fn read_jp2k_scaled_mem(data: &[u8], scale_denom: u32) -> IoResult<Pix> {
+    if scale_denom == 0 {
+        return Err(IoError::DecodeError("scale_denom must be >= 1".to_string()));
+    }
+
+    // Probe the original dimensions to compute the target resolution.
+    let header_settings = DecodeSettings::default();
+    let probe = Image::new(data, &header_settings)
+        .map_err(|e| IoError::DecodeError(format!("JP2K parse error: {}", e)))?;
+    let target_w = (probe.width() / scale_denom).max(1);
+    let target_h = (probe.height() / scale_denom).max(1);
+    drop(probe);
+
+    let settings = DecodeSettings {
+        target_resolution: Some((target_w, target_h)),
+        ..DecodeSettings::default()
+    };
+    let image = Image::new(data, &settings)
+        .map_err(|e| IoError::DecodeError(format!("JP2K parse error: {}", e)))?;
+
+    decode_image_to_pix(image)
+}
+
+/// Read a JPEG 2000 image from a stream at a reduced resolution.
+pub fn read_jp2k_scaled<R: Read + Seek>(mut reader: R, scale_denom: u32) -> IoResult<Pix> {
+    let mut data = Vec::new();
+    reader
+        .read_to_end(&mut data)
+        .map_err(|e| IoError::DecodeError(format!("Failed to read JP2K data: {}", e)))?;
+    read_jp2k_scaled_mem(&data, scale_denom)
+}
+
+/// Read a JPEG 2000 image from memory and crop to `box_`.
+///
+/// hayro-jpeg2000 does not currently expose a tile-based partial decoder, so
+/// this implementation decodes the whole image then clips with
+/// [`Pix::clip_rectangle`]. For very large images this is wasteful — consider
+/// adding a tile-aware decoder when one becomes available.
+///
+/// C Leptonica equivalent: `pixReadMemJp2k(data, size, 1, &box, ...)`.
+pub fn read_jp2k_cropped_mem(data: &[u8], box_: &crate::core::Box) -> IoResult<Pix> {
+    let pix = read_jp2k_mem(data)?;
+    if box_.x < 0 || box_.y < 0 || box_.w <= 0 || box_.h <= 0 {
+        return Err(IoError::DecodeError(format!("invalid crop box {:?}", box_)));
+    }
+    pix.clip_rectangle(box_.x as u32, box_.y as u32, box_.w as u32, box_.h as u32)
+        .map_err(|e| IoError::DecodeError(format!("clip_rectangle failed: {e}")))
+}
+
+/// Read a JPEG 2000 image from a stream and crop to `box_`.
+pub fn read_jp2k_cropped<R: Read + Seek>(mut reader: R, box_: &crate::core::Box) -> IoResult<Pix> {
+    let mut data = Vec::new();
+    reader
+        .read_to_end(&mut data)
+        .map_err(|e| IoError::DecodeError(format!("Failed to read JP2K data: {}", e)))?;
+    read_jp2k_cropped_mem(&data, box_)
 }
 
 #[cfg(test)]

--- a/src/io/jp2k.rs
+++ b/src/io/jp2k.rs
@@ -396,7 +396,7 @@ pub fn write_jp2k<W: std::io::Write>(
 /// `box == NULL`.
 pub fn read_jp2k_scaled_mem(data: &[u8], scale_denom: u32) -> IoResult<Pix> {
     if scale_denom == 0 {
-        return Err(IoError::DecodeError("scale_denom must be >= 1".to_string()));
+        return Err(IoError::InvalidData("scale_denom must be >= 1".to_string()));
     }
 
     // Probe the original dimensions to compute the target resolution.
@@ -420,9 +420,7 @@ pub fn read_jp2k_scaled_mem(data: &[u8], scale_denom: u32) -> IoResult<Pix> {
 /// Read a JPEG 2000 image from a stream at a reduced resolution.
 pub fn read_jp2k_scaled<R: Read + Seek>(mut reader: R, scale_denom: u32) -> IoResult<Pix> {
     let mut data = Vec::new();
-    reader
-        .read_to_end(&mut data)
-        .map_err(|e| IoError::DecodeError(format!("Failed to read JP2K data: {}", e)))?;
+    reader.read_to_end(&mut data)?;
     read_jp2k_scaled_mem(&data, scale_denom)
 }
 
@@ -435,10 +433,12 @@ pub fn read_jp2k_scaled<R: Read + Seek>(mut reader: R, scale_denom: u32) -> IoRe
 ///
 /// C Leptonica equivalent: `pixReadMemJp2k(data, size, 1, &box, ...)`.
 pub fn read_jp2k_cropped_mem(data: &[u8], box_: &crate::core::Box) -> IoResult<Pix> {
-    let pix = read_jp2k_mem(data)?;
+    // Validate the crop box first so degenerate parameters are rejected
+    // before we spend time parsing/decoding the JP2K stream.
     if box_.x < 0 || box_.y < 0 || box_.w <= 0 || box_.h <= 0 {
-        return Err(IoError::DecodeError(format!("invalid crop box {:?}", box_)));
+        return Err(IoError::InvalidData(format!("invalid crop box {:?}", box_)));
     }
+    let pix = read_jp2k_mem(data)?;
     pix.clip_rectangle(box_.x as u32, box_.y as u32, box_.w as u32, box_.h as u32)
         .map_err(|e| IoError::DecodeError(format!("clip_rectangle failed: {e}")))
 }
@@ -446,9 +446,7 @@ pub fn read_jp2k_cropped_mem(data: &[u8], box_: &crate::core::Box) -> IoResult<P
 /// Read a JPEG 2000 image from a stream and crop to `box_`.
 pub fn read_jp2k_cropped<R: Read + Seek>(mut reader: R, box_: &crate::core::Box) -> IoResult<Pix> {
     let mut data = Vec::new();
-    reader
-        .read_to_end(&mut data)
-        .map_err(|e| IoError::DecodeError(format!("Failed to read JP2K data: {}", e)))?;
+    reader.read_to_end(&mut data)?;
     read_jp2k_cropped_mem(&data, box_)
 }
 

--- a/tests/io/jp2kio_reg.rs
+++ b/tests/io/jp2kio_reg.rs
@@ -76,18 +76,22 @@ fn jp2kio_reg_cropped_read() {
     // Smoke: full JP2K decode tests require a bundled .jp2 fixture, which is
     // not available in-tree. We verify the error paths regardless.
     use leptonica::core::Box;
+    use leptonica::io::IoError;
     use leptonica::io::jp2k::read_jp2k_cropped_mem;
+
     let bad: &[u8] = b"not a jpeg 2000 file";
     let any_box = Box::new(0, 0, 1, 1).unwrap();
     assert!(read_jp2k_cropped_mem(bad, &any_box).is_err());
 
-    // Negative or zero-extent boxes are rejected even with valid data — we
-    // can't construct valid data here, but we exercise the parameter-check
-    // branch by passing a degenerate box; the function should error before
-    // touching the bytes for clearly invalid box parameters in any future
-    // pre-decode validation, but for now any error is acceptable.
+    // Degenerate box is rejected before the JP2K parser is touched, so the
+    // error must be `InvalidData`. We even pass empty bytes to make sure the
+    // box check fires first.
     let bad_box = Box::new(0, 0, 0, 0).unwrap();
-    assert!(read_jp2k_cropped_mem(bad, &bad_box).is_err());
+    let err = read_jp2k_cropped_mem(b"", &bad_box).unwrap_err();
+    assert!(
+        matches!(err, IoError::InvalidData(_)),
+        "expected InvalidData for degenerate box, got {err:?}",
+    );
 }
 
 /// Test JP2K scaled read at different reductions (C checks 8-11).

--- a/tests/io/jp2kio_reg.rs
+++ b/tests/io/jp2kio_reg.rs
@@ -72,23 +72,38 @@ fn jp2kio_reg_roundtrip() {
 ///
 /// Requires pixReadJp2k with box parameter for ROI extraction.
 #[test]
-#[ignore = "not yet implemented: JP2K cropped read not available"]
 fn jp2kio_reg_cropped_read() {
-    // C version:
-    // 1. pixReadJp2k(fname, reduction, box) with bounding box
-    // 2. Verify cropped dimensions
-    // 3. Multiple crop regions
+    // Smoke: full JP2K decode tests require a bundled .jp2 fixture, which is
+    // not available in-tree. We verify the error paths regardless.
+    use leptonica::core::Box;
+    use leptonica::io::jp2k::read_jp2k_cropped_mem;
+    let bad: &[u8] = b"not a jpeg 2000 file";
+    let any_box = Box::new(0, 0, 1, 1).unwrap();
+    assert!(read_jp2k_cropped_mem(bad, &any_box).is_err());
+
+    // Negative or zero-extent boxes are rejected even with valid data — we
+    // can't construct valid data here, but we exercise the parameter-check
+    // branch by passing a degenerate box; the function should error before
+    // touching the bytes for clearly invalid box parameters in any future
+    // pre-decode validation, but for now any error is acceptable.
+    let bad_box = Box::new(0, 0, 0, 0).unwrap();
+    assert!(read_jp2k_cropped_mem(bad, &bad_box).is_err());
 }
 
 /// Test JP2K scaled read at different reductions (C checks 8-11).
 ///
-/// Requires pixReadJp2k with reduction factor parameter.
+/// Requires `pixReadJp2k` with reduction factor parameter — Rust port uses
+/// `read_jp2k_scaled_mem(data, scale_denom)` backed by hayro-jpeg2000's
+/// `target_resolution` hint.
 #[test]
-#[ignore = "not yet implemented: JP2K scaled read not available"]
 fn jp2kio_reg_scaled_read() {
-    // C version:
-    // 1. pixReadJp2k(fname, 2, NULL) for 2x reduction
-    // 2. Verify reduced dimensions
+    use leptonica::io::jp2k::read_jp2k_scaled_mem;
+    // Without sample data we can only verify error paths and the
+    // scale_denom == 0 contract.
+    let bad: &[u8] = b"not a jpeg 2000 file";
+    assert!(read_jp2k_scaled_mem(bad, 2).is_err());
+    // scale_denom == 0 is rejected before parsing.
+    assert!(read_jp2k_scaled_mem(b"", 0).is_err());
 }
 
 /// Test J2K codec variant (C check 16).


### PR DESCRIPTION
## Summary

- 計画 [203_io-jp2k-write.md](https://github.com/tagawa0525/leptonica-rs/blob/feat/io-jp2k-scaled-read/docs/plans/203_io-jp2k-write.md) (項目 F、Group 3) の部分実装
- C 版 `pixReadJp2k(reduction, box)` の Rust 移植（書き込み系は純 Rust encoder 不在のため引き続き保留）
- io ignored 6 → 4

## What

`src/io/jp2k.rs`:
- `read_jp2k_scaled_mem(data, scale_denom: u32)` — hayro の `DecodeSettings.target_resolution` に `(orig_w / scale_denom, orig_h / scale_denom)` を渡して縮小デコード
- `read_jp2k_scaled<R>(reader, scale_denom)` — `Read + Seek` wrapper
- `read_jp2k_cropped_mem(data, box)` — 全画像デコード後に `Pix::clip_rectangle` でクリップ（hayro が tile 単位の partial decode を提供しないため、performance trade-off を doc に明記）
- `read_jp2k_cropped<R>(reader, box)` — 同上の wrapper
- 既存 `read_jp2k_mem` の color-space ディスパッチを `decode_image_to_pix(image)` に抽出して再利用

`tests/io/jp2kio_reg.rs`:
- `jp2kio_reg_scaled_read` / `jp2kio_reg_cropped_read` の `#[ignore]` を解除し、不正データ / `scale_denom == 0` の error path を smoke 形でアサート
- 有効デコード経路の検証は将来 JP2K fixture を追加した時点で別 PR で

## Investigation

- **hayro-jpeg2000 0.3.4 はデコーダ専用** (encoder なし)
- DecodeSettings.target_resolution で scaled read 可能、cropped は scale + clip で代替
- 純 Rust JP2K encoder は事実上存在しない（[`jpeg2k`](https://crates.io/crates/jpeg2k) は libopenjp2 binding）→ 書き込みは別 issue
- 詳細: `docs/plans/203_io-jp2k-write.md`

## Test plan

- [x] `cargo test --all-features --test io jp2kio` で smoke 2 件通過
- [x] `cargo test --all-features` 全件通過 (io ignored 6→4)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)