### PR TITLE
fix(tests): gate JP2K tests behind jp2k-format feature

### DIFF
--- a/tests/io/jp2kio_reg.rs
+++ b/tests/io/jp2kio_reg.rs
@@ -72,6 +72,7 @@ fn jp2kio_reg_roundtrip() {
 ///
 /// Requires pixReadJp2k with box parameter for ROI extraction.
 #[test]
+#[cfg(feature = "jp2k-format")]
 fn jp2kio_reg_cropped_read() {
     // Smoke: full JP2K decode tests require a bundled .jp2 fixture, which is
     // not available in-tree. We verify the error paths regardless.
@@ -100,6 +101,7 @@ fn jp2kio_reg_cropped_read() {
 /// `read_jp2k_scaled_mem(data, scale_denom)` backed by hayro-jpeg2000's
 /// `target_resolution` hint.
 #[test]
+#[cfg(feature = "jp2k-format")]
 fn jp2kio_reg_scaled_read() {
     use leptonica::io::jp2k::read_jp2k_scaled_mem;
     // Without sample data we can only verify error paths and the


### PR DESCRIPTION
## 概要

\`cargo test\` (デフォルト feature 構成) で次のコンパイルエラーが
発生していたため修正:

\`\`\`
error[E0432]: unresolved import \`leptonica::io::jp2k\`
   --> tests/io/jp2kio_reg.rs:80:24
\`\`\`

## 原因

\`tests/io/jp2kio_reg.rs\` 内の 2 つのテスト
(\`jp2kio_reg_cropped_read\` / \`jp2kio_reg_scaled_read\`) が
\`leptonica::io::jp2k\` モジュールを無条件に import していたが、
このモジュールは \`#[cfg(feature = \"jp2k-format\")]\` で gate
されているため、feature が無効な状態ではモジュール自体が存在せず、
テストバイナリが build できなかった。

## 変更点

両テストに \`#[cfg(feature = \"jp2k-format\")]\` を追加し、
feature が有効な時のみ build されるようにした。
他の JP2K テストは元から \`#[ignore]\` 付きで feature 非依存。

## テスト

- \`cargo test --test io\` (default features): pass
- \`cargo test --test io --all-features\`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)