### PR TITLE
feat(io/tiff): 1bpp Pix を 8bpp に拡張せず直接 bps=1 で書き出す (plan 901 Phase 2.5 第二弾)

### DIFF
--- a/src/io/tiff.rs
+++ b/src/io/tiff.rs
@@ -10,7 +10,7 @@ use tiff::ColorType;
 use tiff::decoder::{Decoder, DecodingResult};
 use tiff::encoder::colortype::{Gray8, Gray16, RGB8, RGBA8};
 use tiff::encoder::{Compression, TiffEncoder};
-use tiff::tags::PhotometricInterpretation;
+use tiff::tags::{CompressionMethod, PhotometricInterpretation, Tag};
 
 /// Read TIFF header metadata without decoding pixel data
 pub fn read_header_tiff(data: &[u8]) -> IoResult<ImageHeader> {
@@ -847,17 +847,59 @@ fn write_pix_to_encoder<W: Write + Seek>(mut encoder: TiffEncoder<W>, pix: &Pix)
 
     match pix.depth() {
         PixelDepth::Bit1 => {
-            // 1-bit binary - convert to 8-bit for simplicity
-            let mut data = vec![0u8; (width * height) as usize];
+            // 1bpp uncompressed TIFF via the `tiff` crate's low-level
+            // `DirectoryEncoder` API. `colortype::Gray8` (used previously)
+            // expanded each pixel to one byte and produced `bps=8` files,
+            // which is incompatible with C leptonica's 1bpp output and
+            // changes `pixel_content_hash`. See
+            // docs/porting/c-compat-findings/002-tiff-1bpp-write-limit.md.
+            let row_bytes = width.div_ceil(8) as usize;
+            let mut data = vec![0u8; row_bytes * height as usize];
             for y in 0..height {
+                let row_off = y as usize * row_bytes;
                 for x in 0..width {
                     let val = pix.get_pixel(x, y).unwrap_or(0);
-                    data[(y * width + x) as usize] = if val != 0 { 255 } else { 0 };
+                    if val != 0 {
+                        // TIFF default FillOrder=1: MSB of each byte is the
+                        // leftmost pixel.
+                        let byte_idx = row_off + (x / 8) as usize;
+                        let bit_idx = 7 - (x & 7);
+                        data[byte_idx] |= 1 << bit_idx;
+                    }
                 }
             }
-            encoder
-                .write_image::<Gray8>(width, height, &data)
+
+            let mut dir = encoder
+                .image_directory()
                 .map_err(|e| IoError::EncodeError(format!("TIFF write error: {}", e)))?;
+            let map = |e: tiff::TiffError| -> IoError {
+                IoError::EncodeError(format!("TIFF write error: {}", e))
+            };
+
+            dir.write_tag(Tag::ImageWidth, width).map_err(map)?;
+            dir.write_tag(Tag::ImageLength, height).map_err(map)?;
+            dir.write_tag(Tag::BitsPerSample, 1u16).map_err(map)?;
+            dir.write_tag(Tag::Compression, CompressionMethod::None.to_u16())
+                .map_err(map)?;
+            dir.write_tag(
+                Tag::PhotometricInterpretation,
+                // Leptonica's 1bpp convention: 0 = background (white),
+                // 1 = foreground (black). Match with WhiteIsZero so the
+                // pixel value semantics survive the round trip.
+                PhotometricInterpretation::WhiteIsZero.to_u16(),
+            )
+            .map_err(map)?;
+            dir.write_tag(Tag::SamplesPerPixel, 1u16).map_err(map)?;
+            dir.write_tag(Tag::RowsPerStrip, height).map_err(map)?;
+
+            let strip_byte_count = (row_bytes * height as usize) as u32;
+            let strip_offset = dir.write_data(&data[..]).map_err(map)?;
+            dir.write_tag(Tag::StripOffsets, &[strip_offset as u32][..])
+                .map_err(map)?;
+            dir.write_tag(Tag::StripByteCounts, &[strip_byte_count][..])
+                .map_err(map)?;
+
+            dir.finish().map_err(map)?;
         }
         PixelDepth::Bit2 | PixelDepth::Bit4 => {
             // 2-bit and 4-bit - convert to 8-bit

--- a/src/io/tiff.rs
+++ b/src/io/tiff.rs
@@ -841,65 +841,79 @@ pub fn write_tiff_multipage<W: Write + Seek>(
 }
 
 /// Write a Pix to a TiffEncoder (consumes the encoder)
+/// Write a 1bpp Pix as a true `bps=1` uncompressed TIFF directory using
+/// the `tiff` crate's low-level `DirectoryEncoder` API.
+///
+/// `colortype::Gray8` would expand each pixel to one byte and produce
+/// `bps=8` files, which is incompatible with C leptonica's 1bpp output
+/// and changes `pixel_content_hash`. See
+/// `docs/porting/c-compat-findings/002-tiff-1bpp-write-limit.md`.
+///
+/// Used by both the single-page (`write_pix_to_encoder`) and multipage
+/// (`write_pix_page_to_encoder`) writers so the two paths stay in lockstep.
+fn write_1bpp_pix_to_tiff<W: Write + Seek>(
+    encoder: &mut TiffEncoder<W>,
+    pix: &Pix,
+) -> IoResult<()> {
+    let width = pix.width();
+    let height = pix.height();
+    let row_bytes = width.div_ceil(8) as usize;
+    let mut data = vec![0u8; row_bytes * height as usize];
+    for y in 0..height {
+        let row_off = y as usize * row_bytes;
+        for x in 0..width {
+            let val = pix.get_pixel(x, y).unwrap_or(0);
+            if val != 0 {
+                // TIFF default FillOrder=1: MSB of each byte is the
+                // leftmost pixel.
+                let byte_idx = row_off + (x / 8) as usize;
+                let bit_idx = 7 - (x & 7);
+                data[byte_idx] |= 1 << bit_idx;
+            }
+        }
+    }
+
+    let mut dir = encoder
+        .image_directory()
+        .map_err(|e| IoError::EncodeError(format!("TIFF write error: {}", e)))?;
+    let map = |e: tiff::TiffError| -> IoError {
+        IoError::EncodeError(format!("TIFF write error: {}", e))
+    };
+
+    dir.write_tag(Tag::ImageWidth, width).map_err(map)?;
+    dir.write_tag(Tag::ImageLength, height).map_err(map)?;
+    dir.write_tag(Tag::BitsPerSample, 1u16).map_err(map)?;
+    dir.write_tag(Tag::Compression, CompressionMethod::None.to_u16())
+        .map_err(map)?;
+    dir.write_tag(
+        Tag::PhotometricInterpretation,
+        // Leptonica's 1bpp convention: 0 = background (white),
+        // 1 = foreground (black). Match with WhiteIsZero so the
+        // pixel value semantics survive the round trip.
+        PhotometricInterpretation::WhiteIsZero.to_u16(),
+    )
+    .map_err(map)?;
+    dir.write_tag(Tag::SamplesPerPixel, 1u16).map_err(map)?;
+    dir.write_tag(Tag::RowsPerStrip, height).map_err(map)?;
+
+    let strip_byte_count = (row_bytes * height as usize) as u32;
+    let strip_offset = dir.write_data(&data[..]).map_err(map)?;
+    dir.write_tag(Tag::StripOffsets, &[strip_offset as u32][..])
+        .map_err(map)?;
+    dir.write_tag(Tag::StripByteCounts, &[strip_byte_count][..])
+        .map_err(map)?;
+
+    dir.finish().map_err(map)?;
+    Ok(())
+}
+
 fn write_pix_to_encoder<W: Write + Seek>(mut encoder: TiffEncoder<W>, pix: &Pix) -> IoResult<()> {
     let width = pix.width();
     let height = pix.height();
 
     match pix.depth() {
         PixelDepth::Bit1 => {
-            // 1bpp uncompressed TIFF via the `tiff` crate's low-level
-            // `DirectoryEncoder` API. `colortype::Gray8` (used previously)
-            // expanded each pixel to one byte and produced `bps=8` files,
-            // which is incompatible with C leptonica's 1bpp output and
-            // changes `pixel_content_hash`. See
-            // docs/porting/c-compat-findings/002-tiff-1bpp-write-limit.md.
-            let row_bytes = width.div_ceil(8) as usize;
-            let mut data = vec![0u8; row_bytes * height as usize];
-            for y in 0..height {
-                let row_off = y as usize * row_bytes;
-                for x in 0..width {
-                    let val = pix.get_pixel(x, y).unwrap_or(0);
-                    if val != 0 {
-                        // TIFF default FillOrder=1: MSB of each byte is the
-                        // leftmost pixel.
-                        let byte_idx = row_off + (x / 8) as usize;
-                        let bit_idx = 7 - (x & 7);
-                        data[byte_idx] |= 1 << bit_idx;
-                    }
-                }
-            }
-
-            let mut dir = encoder
-                .image_directory()
-                .map_err(|e| IoError::EncodeError(format!("TIFF write error: {}", e)))?;
-            let map = |e: tiff::TiffError| -> IoError {
-                IoError::EncodeError(format!("TIFF write error: {}", e))
-            };
-
-            dir.write_tag(Tag::ImageWidth, width).map_err(map)?;
-            dir.write_tag(Tag::ImageLength, height).map_err(map)?;
-            dir.write_tag(Tag::BitsPerSample, 1u16).map_err(map)?;
-            dir.write_tag(Tag::Compression, CompressionMethod::None.to_u16())
-                .map_err(map)?;
-            dir.write_tag(
-                Tag::PhotometricInterpretation,
-                // Leptonica's 1bpp convention: 0 = background (white),
-                // 1 = foreground (black). Match with WhiteIsZero so the
-                // pixel value semantics survive the round trip.
-                PhotometricInterpretation::WhiteIsZero.to_u16(),
-            )
-            .map_err(map)?;
-            dir.write_tag(Tag::SamplesPerPixel, 1u16).map_err(map)?;
-            dir.write_tag(Tag::RowsPerStrip, height).map_err(map)?;
-
-            let strip_byte_count = (row_bytes * height as usize) as u32;
-            let strip_offset = dir.write_data(&data[..]).map_err(map)?;
-            dir.write_tag(Tag::StripOffsets, &[strip_offset as u32][..])
-                .map_err(map)?;
-            dir.write_tag(Tag::StripByteCounts, &[strip_byte_count][..])
-                .map_err(map)?;
-
-            dir.finish().map_err(map)?;
+            write_1bpp_pix_to_tiff(&mut encoder, pix)?;
         }
         PixelDepth::Bit2 | PixelDepth::Bit4 => {
             // 2-bit and 4-bit - convert to 8-bit
@@ -989,16 +1003,7 @@ fn write_pix_page_to_encoder<W: Write + Seek>(
 
     match pix.depth() {
         PixelDepth::Bit1 => {
-            let mut data = vec![0u8; (width * height) as usize];
-            for y in 0..height {
-                for x in 0..width {
-                    let val = pix.get_pixel(x, y).unwrap_or(0);
-                    data[(y * width + x) as usize] = if val != 0 { 255 } else { 0 };
-                }
-            }
-            encoder
-                .write_image::<Gray8>(width, height, &data)
-                .map_err(|e| IoError::EncodeError(format!("TIFF write error: {}", e)))?;
+            write_1bpp_pix_to_tiff(encoder, pix)?;
         }
         PixelDepth::Bit2 | PixelDepth::Bit4 => {
             let max_val = pix.depth().max_value();

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -402,7 +402,7 @@ iomisc_regen_gray_cmap.02.png	dfa56890470eeff7
 iomisc_regen_gray_cmap.04.png	25d12b85fa3e168b
 iomisc_regen_rgb_cmap.02.png	22c5e6237b6b0968
 iomisc_regen_rgb_cmap.05.png	42ab7323ea5e8762
-iomisc_tiff.02.png	0955a39abd55c407
+iomisc_tiff.02.png	e128cfedc914d07e
 italic_morph.03.tif	baa01f4969967fc3
 italic_wordmask.04.tif	c46a8aac9c1f37c2
 jbclass_corr.05.tif	842e5123f700fef3
@@ -451,7 +451,7 @@ pdfio1_multipage.01.pdf	2d5976d4f5a4ccda
 pixadisp_1bpp.03.tif	2ea186f22409f445
 pixadisp_scaled.05.png	ef85e68082995f77
 pixadisp_tiled.05.tif	f820e040504ec64b
-pixcomp_rt.04.tif	0955a39abd55c407
+pixcomp_rt.04.tif	e128cfedc914d07e
 pixcomp_rt.06.png	25d12b85fa3e168b
 pixcomp_rt.08.png	25d12b85fa3e168b
 pmask_32.03.png	796cccba9aa4c5e6

--- a/tests/io/main.rs
+++ b/tests/io/main.rs
@@ -27,6 +27,8 @@ mod psioseg_reg;
 #[cfg(feature = "pdf-format")]
 mod rotateorth_files_to_pdf_reg;
 mod spixio_reg;
+#[cfg(feature = "tiff-format")]
+mod tiff_1bpp_reg;
 #[cfg(feature = "webp-format")]
 mod webpanimio_reg;
 #[cfg(feature = "webp-format")]

--- a/tests/io/tiff_1bpp_reg.rs
+++ b/tests/io/tiff_1bpp_reg.rs
@@ -27,7 +27,6 @@ fn tmp_path(stem: &str) -> String {
 }
 
 #[test]
-
 fn round_trip_preserves_bit1_depth_byte_aligned_width() {
     // 16 は 8 の倍数なので末尾 padding なし
     let pix = make_1bpp_checkerboard(16, 8);
@@ -56,7 +55,6 @@ fn round_trip_preserves_bit1_depth_byte_aligned_width() {
 }
 
 #[test]
-
 fn round_trip_preserves_bit1_depth_non_byte_aligned_width() {
     // 17 は 8 の倍数ではないので末尾 padding bits がある (各行末で 7 bits 余る)
     // これらの padding bits が pixel data として読み戻されないことを確認
@@ -82,7 +80,6 @@ fn round_trip_preserves_bit1_depth_non_byte_aligned_width() {
 }
 
 #[test]
-
 fn round_trip_preserves_all_white_and_all_black_1bpp() {
     for (label, fill) in [("white", 0u32), ("black", 1u32)] {
         let pix = Pix::new(24, 6, PixelDepth::Bit1).unwrap();

--- a/tests/io/tiff_1bpp_reg.rs
+++ b/tests/io/tiff_1bpp_reg.rs
@@ -1,0 +1,113 @@
+//! Regression tests for 1bpp TIFF write/read round-trip.
+//!
+//! plan 901 Phase 2.5 第二弾の対象 (docs/porting/c-compat-findings/
+//! 002-tiff-1bpp-write-limit.md)。`src/io/tiff.rs::write_pix_to_encoder` の
+//! `PixelDepth::Bit1` ブランチが「convert to 8-bit for simplicity」と
+//! 8bpp に拡張して書き出していたため、binmorph1/3/fhmtauto の C 互換性
+//! チェックで 15 件の Mismatch が発生していた。本ファイルは 1bpp 出力が
+//! 1bpp として保たれることをロックダウンする。
+
+use leptonica::core::{Pix, PixelDepth};
+use leptonica::io::{ImageFormat, read_image, write_image};
+
+fn make_1bpp_checkerboard(width: u32, height: u32) -> Pix {
+    let pix = Pix::new(width, height, PixelDepth::Bit1).unwrap();
+    let mut pix_mut = pix.try_into_mut().unwrap();
+    for y in 0..height {
+        for x in 0..width {
+            let v = if (x + y) % 2 == 0 { 1 } else { 0 };
+            pix_mut.set_pixel_unchecked(x, y, v);
+        }
+    }
+    pix_mut.into()
+}
+
+fn tmp_path(stem: &str) -> String {
+    format!("/tmp/leptonica_rs_test_tiff_1bpp_{}.tif", stem)
+}
+
+#[test]
+#[ignore = "not yet implemented"]
+fn round_trip_preserves_bit1_depth_byte_aligned_width() {
+    // 16 は 8 の倍数なので末尾 padding なし
+    let pix = make_1bpp_checkerboard(16, 8);
+    let path = tmp_path("byte_aligned");
+    write_image(&pix, &path, ImageFormat::Tiff).expect("write tiff");
+    let pix2 = read_image(&path).expect("read tiff");
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        pix2.depth(),
+        PixelDepth::Bit1,
+        "1bpp Pix を書き出して読み戻したら depth が Bit1 のままである必要がある"
+    );
+    assert_eq!(pix2.width(), pix.width());
+    assert_eq!(pix2.height(), pix.height());
+
+    for y in 0..pix.height() {
+        for x in 0..pix.width() {
+            assert_eq!(
+                pix.get_pixel(x, y).unwrap_or(0),
+                pix2.get_pixel(x, y).unwrap_or(0),
+                "pixel mismatch at ({x}, {y})"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "not yet implemented"]
+fn round_trip_preserves_bit1_depth_non_byte_aligned_width() {
+    // 17 は 8 の倍数ではないので末尾 padding bits がある (各行末で 7 bits 余る)
+    // これらの padding bits が pixel data として読み戻されないことを確認
+    let pix = make_1bpp_checkerboard(17, 5);
+    let path = tmp_path("non_byte_aligned");
+    write_image(&pix, &path, ImageFormat::Tiff).expect("write tiff");
+    let pix2 = read_image(&path).expect("read tiff");
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(pix2.depth(), PixelDepth::Bit1);
+    assert_eq!(pix2.width(), 17);
+    assert_eq!(pix2.height(), 5);
+
+    for y in 0..5 {
+        for x in 0..17 {
+            assert_eq!(
+                pix.get_pixel(x, y).unwrap_or(0),
+                pix2.get_pixel(x, y).unwrap_or(0),
+                "pixel mismatch at ({x}, {y})"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "not yet implemented"]
+fn round_trip_preserves_all_white_and_all_black_1bpp() {
+    for (label, fill) in [("white", 0u32), ("black", 1u32)] {
+        let pix = Pix::new(24, 6, PixelDepth::Bit1).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        for y in 0..6 {
+            for x in 0..24 {
+                pm.set_pixel_unchecked(x, y, fill);
+            }
+        }
+        let pix: Pix = pm.into();
+
+        let path = tmp_path(label);
+        write_image(&pix, &path, ImageFormat::Tiff).expect("write tiff");
+        let pix2 = read_image(&path).expect("read tiff");
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(pix2.depth(), PixelDepth::Bit1, "{label}: depth Bit1");
+        for y in 0..6 {
+            for x in 0..24 {
+                assert_eq!(
+                    pix2.get_pixel(x, y).unwrap_or(0),
+                    fill,
+                    "{label}: pixel ({x},{y}) should be {fill}"
+                );
+            }
+        }
+    }
+}

--- a/tests/io/tiff_1bpp_reg.rs
+++ b/tests/io/tiff_1bpp_reg.rs
@@ -27,7 +27,7 @@ fn tmp_path(stem: &str) -> String {
 }
 
 #[test]
-#[ignore = "not yet implemented"]
+
 fn round_trip_preserves_bit1_depth_byte_aligned_width() {
     // 16 は 8 の倍数なので末尾 padding なし
     let pix = make_1bpp_checkerboard(16, 8);
@@ -56,7 +56,7 @@ fn round_trip_preserves_bit1_depth_byte_aligned_width() {
 }
 
 #[test]
-#[ignore = "not yet implemented"]
+
 fn round_trip_preserves_bit1_depth_non_byte_aligned_width() {
     // 17 は 8 の倍数ではないので末尾 padding bits がある (各行末で 7 bits 余る)
     // これらの padding bits が pixel data として読み戻されないことを確認
@@ -82,7 +82,7 @@ fn round_trip_preserves_bit1_depth_non_byte_aligned_width() {
 }
 
 #[test]
-#[ignore = "not yet implemented"]
+
 fn round_trip_preserves_all_white_and_all_black_1bpp() {
     for (label, fill) in [("white", 0u32), ("black", 1u32)] {
         let pix = Pix::new(24, 6, PixelDepth::Bit1).unwrap();


### PR DESCRIPTION
## Summary

`docs/porting/c-compat-findings/002-tiff-1bpp-write-limit.md` (PR #382) で
要件定義した **Option A** を実装。`src/io/tiff.rs::write_pix_to_encoder`
の `PixelDepth::Bit1` ブランチを **1bpp 直接書き出し**に修正します。

## What

- `tiff::encoder::DirectoryEncoder` の low-level API (`write_tag` /
  `write_data`) を使って 1bpp uncompressed TIFF を直接出力
- 必要な TIFF タグを手動指定: `ImageWidth` / `ImageLength` /
  `BitsPerSample=1` / `Compression=None` / `PhotometricInterpretation=
  WhiteIsZero` / `SamplesPerPixel=1` / `RowsPerStrip` / `StripOffsets` /
  `StripByteCounts`
- `PhotometricInterpretation=WhiteIsZero` は leptonica の 1bpp 慣習 (0=BG=
  white, 1=FG=black) と整合
- pixel は MSB-first packed bits (row 当たり `width.div_ceil(8)` bytes)

## Commit 構成 (TDD)

1. `test(io/tiff_1bpp)` — RED (3 テスト `#[ignore = "not yet implemented"]`、
   byte-aligned width 16 / non-byte-aligned width 17 / all-white-and-black)
2. `feat(io/tiff)` — GREEN (Bit1 ブランチ書き換え + `#[ignore]` 除去、
   3 テスト pass)
3. `chore(tests)` — `pixcomp_rt.04.tif` と `iomisc_tiff.02.png` の hash
   再生成 (round-trip テストの pix depth が Bit8 → Bit1 に変わった整合)

## 検証結果

- `cargo fmt --all -- --check` 通過
- `cargo clippy --all-features --all-targets -- -D warnings` 通過
- `cargo test --all-features` 全 binaries で 0 failed (`tests/io/tiff_1bpp_reg`
  3/3 pass、`pixcomp_reg` / `iomisc_reg` 含む全 round-trip pass)
- `file(1)` で `tests/regout/binmorph1.09.tif` が `bps=1 compression=none
  PhotometricInterpretation=WhiteIsZero` に変わったことを物理確認
  (修正前は `bps=8 compression=none`)

## 残課題 (Phase 2.5 第三弾、別 PR で)

本修正で `compare_golden` が DEPTH stop に進めなくなり、ピクセル比較が可能
になった結果、新たな不一致が顕在化:

```text
binmorph1/binmorph1_verify[C:00↔R:09] dilate_brick 21x15  129670/523800  max=1  24.76% DIFF(alg)
binmorph1/binmorph1_verify[C:01↔R:10] erode_brick 21x15  112527/523800  max=1  21.48% DIFF(alg)
binmorph1/binmorph1_verify[C:02↔R:11] open_brick 21x15   300049/523800  max=1  57.28% DIFF(alg)
binmorph1/binmorph1_verify[C:03↔R:12] close_brick 21x15  284500/523800  max=1  54.31% DIFF(alg)
```

24-57% の pixel diff は depth 違いでは説明できない (1bpp の値域なので
max=1 は値域上限)。Rust 側 `dilate_brick` / `erode_brick` / `open_brick` /
`close_brick` の morph 実装が C 版 `pixDilate/Erode/Open/CloseBrick` と
pixel-level で異なる。同様の差が `binmorph3` / `fhmtauto` でも観測。

これらは本 PR のスコープ外。次の Phase 2.5 第三弾 (`src/morph/brick.rs`
等の Rust morph 実装調査) で個別 PR 化します。

## Test plan

- [x] `cargo test --test io tiff_1bpp` — 3/3 pass
- [x] `cargo test --all-features` — 全 binary pass
- [x] `file tests/regout/binmorph1.09.tif` で bps=1 を物理確認
- [x] `cargo run --release --example compare_golden -- --module binmorph1`
      で「DEPTH stop」が消え、pixel 比較に進めることを確認
- [ ] CI 通過確認

## Impact

- ✅ Phase 2.5 第二弾の判明していた問題 (TIFF write の depth 拡張) を解消
- ⚠️ 新たに見えた問題 (Rust morph アルゴリズム差) は Phase 2.5 第三弾の
  別 PR で対処
- 既存 manifest への影響は round-trip テスト 2 件のみ (`pixcomp_rt.04.tif` /
  `iomisc_tiff.02.png`)。in-memory Pix から hash を取る他のテスト
  (`binmorph1` / `fhmtauto` / `cthin1` 等) は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)