### PR TITLE
docs(porting): Phase 2.5 第三弾 — brick morph の plain vs composite 不一致 (binmorph 7 件)

### DIFF
--- a/docs/plans/901_c-hash-compat.md
+++ b/docs/plans/901_c-hash-compat.md
@@ -173,7 +173,8 @@ Phase 2 のレポートを元に、不一致が出ている Rust テストを 1 
 
 - [c-compat-coverage.md](../porting/c-compat-coverage.md): Phase 2.5 移行前の完全性確認。⚠️ Phase 1 は **未完成** と判明。`prog/*_reg` 由来は 155 件取得済み (SKIP_REGS 4 件は出力なしで対象外、これは正しい) だが、`scripts/verify_*.c` 由来の C 中間結果 27 件が manifest_c.tsv に未取り込み (Phase 2 レポートで MissingC 27 件として現れる)。Rust 側回帰テスト数は 159/159 だが、機能カバー率は file 数とは別物 (dwamorph2/fmorphauto/morphseq でカバー漏れあり)。Phase 1.5 完全化 PR の実施が次のアクション
 - [001-jpeg-codec-diffs.md](../porting/c-compat-findings/001-jpeg-codec-diffs.md): Phase 2 のレポートで観測された 9 件の Mismatch (edge / convolve_blockconv_gray / colormorph) はすべて **JPEG codec 差** (仮説段階)。Rust 側修正対象外
-- [002-tiff-1bpp-write-limit.md](../porting/c-compat-findings/002-tiff-1bpp-write-limit.md): Phase 1.5 で顕在化した 15 件の 1bpp Mismatch (binmorph1/3、fhmtauto) は `src/io/tiff.rs` が 1bpp Pix を 8bpp に拡張して書き出すことが原因。`tiff` crate 0.11.3 に 1bpp encoder サポートがない。修正は別 PR (中規模、Rust manifest 再生成を伴う)
+- [002-tiff-1bpp-write-limit.md](../porting/c-compat-findings/002-tiff-1bpp-write-limit.md): Phase 1.5 で顕在化した 15 件の 1bpp Mismatch (binmorph1/3、fhmtauto) は `src/io/tiff.rs` が 1bpp Pix を 8bpp に拡張して書き出すことが原因。`tiff` crate 0.11.3 に 1bpp encoder サポートがない。修正は PR #383 で完了 (DirectoryEncoder の low-level API で 1bpp 直接書き出し)
+- [003-morph-brick-comp-vs-plain.md](../porting/c-compat-findings/003-morph-brick-comp-vs-plain.md): PR #383 後に残った 7 件の Mismatch (binmorph1/3) は Rust `dilate_brick` 等が composite decomposition を使う一方、`verify_binmorph.c` が plain `pixDilateBrick` を呼ぶことが原因。fhmtauto 8 件は別系統 (HMT 実装差、別 finding 予定)。修正は別 PR (推奨: verify_*.c を Comp 系に揃える Option A)
 
 ### Phase 3: 1モジュールでの検証ベースライン記録
 

--- a/docs/porting/c-compat-findings/003-morph-brick-comp-vs-plain.md
+++ b/docs/porting/c-compat-findings/003-morph-brick-comp-vs-plain.md
@@ -1,0 +1,177 @@
+# C互換性調査 #003: brick morph の plain vs composite semantics 不一致 (binmorph1/3 計 7 件)
+
+Phase 2.5 第二弾 (PR #383, TIFF 1bpp 直接書き出し) で depth stop が解消した
+あとに残った 7 件の `Mismatch` (`binmorph1.{09,10,11,12}.tif` と
+`binmorph3.{14,15,16}.tif`) の原因を調査した結果、**Rust の
+`dilate_brick` / `erode_brick` / `open_brick` / `close_brick` が
+"composite decomposition"** を採用しているのに対し、verify 用 C プログラム
+`scripts/verify_binmorph.c` が **plain separable な
+`pixDilateBrick` 等** を呼んでいることが原因と判明した。
+
+`fhmtauto` 系 8 件はまた別の論点 (Sel origin / 境界処理) で、本書では概略の
+切り分けまでに留め、詳細は後続の調査ノート (`004-hmt-impl-diff.md` を予定) に
+回す。
+
+## 観測
+
+Phase 2 レポートの該当 7 件:
+
+```text
+[Mismatch] binmorph1 :: binmorph1.09.tif :: rust=fb2e160b859512ae, c[binmorph1_verify.00.tif]=33b60cb6c754a60e
+[Mismatch] binmorph1 :: binmorph1.10.tif :: rust=171a1de4fa7c74bf, c[binmorph1_verify.01.tif]=b7f005730578dbee
+[Mismatch] binmorph1 :: binmorph1.11.tif :: rust=e99305c26e85c7af, c[binmorph1_verify.02.tif]=b7f005730578dbee
+[Mismatch] binmorph1 :: binmorph1.12.tif :: rust=e588e7c557e77cce, c[binmorph1_verify.03.tif]=4e03255827c5495e
+[Mismatch] binmorph3 :: binmorph3.14.tif :: rust=ceaf6053504e87ff, c[binmorph3_verify.00.tif]=ea95536789d31c6f
+[Mismatch] binmorph3 :: binmorph3.15.tif :: rust=ceaf6053504e87ff, c[binmorph3_verify.01.tif]=ea95536789d31c6f
+[Mismatch] binmorph3 :: binmorph3.16.tif :: rust=d1fc7996d523973e, c[binmorph3_verify.02.tif]=90603db276f02f1f
+```
+
+`compare_golden` の pixel-level 数値:
+
+| Test                 |    Diff/Total | MaxDiff |  %Diff |
+| -------------------- | ------------: | ------: | -----: |
+| `dilate_brick 21x15` | 129670/523800 |       1 | 24.76% |
+| `erode_brick 21x15`  | 112527/523800 |       1 | 21.48% |
+| `open_brick 21x15`   | 300049/523800 |       1 | 57.28% |
+| `close_brick 21x15`  | 284500/523800 |       1 | 54.31% |
+
+`max=1` は 1bpp の値域上限なので、これだけでは codec/アルゴリズムの区別は
+できないが、**差分ピクセル数が大きい** (20-57%) ため codec 差では説明不可能。
+
+## 根本原因
+
+C 版 leptonica は brick morph で 2 系統の API を提供する:
+
+- `pixDilateBrick(pixd, pixs, hsize, vsize)` — **plain separable**: 単純な
+
+  brick SEL を horizontal と vertical で 2 回適用 (`reference/leptonica/
+  src/morph.c:672`)
+
+- `pixDilateCompBrick(pixd, pixs, hsize, vsize)` — **composite separable**:
+
+  各次元を 2 つの factor (`selectComposableSels` で `f1 × f2 ≒ hsize`) に
+  分解し、合成 SEL の積で実装 (`reference/leptonica/src/morph.c:1213`)
+
+両者は **`hsize` が分解可能な場合は同じ結果** になるが、composite は SEL の
+origin / 端の扱いで微小な差が出る場合がある。とくに分解時に **「product of
+factors が `hsize` と一致しない」** ケース (上流 doc:
+`reference/leptonica/src/morph.c:1198-1210` の Notes 8) では結果が積分的に
+ズレる。
+
+Rust 側 `src/morph/binary.rs::dilate_brick` (338 行) は実装内で
+`dilate_1d_composite` を呼んでおり、**常に composite decomposition** を採用:
+
+```rust
+pub fn dilate_brick(pix: &Pix, width: u32, height: u32) -> MorphResult<Pix> {
+    if width == 1 && height == 1 {
+        return Ok(pix.clone());
+    }
+    // Separable: horizontal then vertical, each using composite decomposition.
+    let tmp: Pix = dilate_1d_composite(pix, width, true)?.into();
+    let mut result = dilate_1d_composite(&tmp, height, false)?;
+    clear_unused_bits(result.data_mut(), pix.width(), pix.wpl() as usize);
+    Ok(result.into())
+}
+```
+
+doc コメントに「Uses separable + composite decomposition for optimal
+performance」と書かれており、性能のために composite を選んでいるのは意図的。
+
+一方 `scripts/verify_binmorph.c` (48-51 行) は plain 系の C API を呼ぶ:
+
+```c
+PIX *dil = pixDilateBrick(NULL, pixs, 21, 15);   /* plain separable */
+PIX *ero = pixErodeBrick(NULL, pixs, 21, 15);
+PIX *opn = pixOpenBrick(NULL, pixs, 21, 15);
+PIX *cls = pixCloseBrick(NULL, pixs, 21, 15);
+```
+
+**Rust の `dilate_brick` は C の `pixDilateCompBrick` 相当、`verify` は C の
+`pixDilateBrick` (= plain) を期待している** → ハッシュが合わない。
+
+## 解決オプション (修正は別 PR で)
+
+### A. `scripts/verify_*.c` を Comp 系に修正 (推奨、影響範囲最小)
+
+- `pixDilateBrick` → `pixDilateCompBrick` 等に置換
+- `tests/golden_manifest_c.tsv` の `binmorph1_verify.*` / `binmorph3_verify.*`
+
+  7 件 hash を再生成
+
+- Rust 実装は変えない (Rust 側 manifest 不変)
+- 「Rust `dilate_brick` の semantics は `pixDilateCompBrick` 相当」と doc 明記
+
+### B. Rust 実装を plain separable に修正
+
+- `src/morph/binary.rs::dilate_brick` 等を `dilate(pix, brick_sel(W, H))` の
+
+  単純呼び出しに戻す
+
+- 既存の composite 実装を `dilate_comp_brick` のような別 API として残す
+- 性能トレードオフ: 大サイズの brick で composite の方が高速 (上流の C 慣習も
+
+  `pixOpenCompBrick` 等を別途用意)
+
+- Rust manifest が広範に変わる (`binmorph1` / `binmorph3` の `tests/golden_
+
+  manifest.tsv` 7 件、加えて呼び出し元のテストも要再生成)
+
+- インターフェース不変だが意味論が変わる **breaking change**
+
+### C. Rust に両方の API を提供 (C 慣習と揃える)
+
+- `dilate_brick` (plain) と `dilate_comp_brick` (composite) を別関数として
+
+  提供
+
+- 既存テストの呼び出し先を必要に応じて切り替え
+- 最も clean だが工数は B + α
+- C 版と naming / semantics が完全一致して長期的には筋がよい
+
+## 推奨
+
+短期で `Mismatch` を解消するには **Option A**:
+
+1. `scripts/verify_binmorph.c` の 4 関数を `pix*CompBrick` に置換
+2. `bash scripts/gen_c_manifest.sh` を再実行 (manifest_c.tsv に 7 件の
+
+   新 hash)
+
+3. Phase 2 レポートで `binmorph1` / `binmorph3` の Mismatch が `Ok` に
+
+   転換することを確認
+
+長期的には **Option C** が望ましく、別フェーズ (Phase 3 以降) で
+`docs/plans/` に新計画として整理する。
+
+## fhmtauto 8 件について
+
+`fhmtauto_hmt.{02,04,06,08,10,12,14}.tif` + `fhmtauto_id.01.tif` の 8 件は
+別系統 (HMT、Hit-Miss Transform)。`src/morph/binary.rs::hit_miss_transform`
+と C `pixHMT` の比較で:
+
+- `verify_fhmtauto.c` は `pixHMT(NULL, pixs, sel)` を呼ぶ (plain HMT、
+
+  composite なし)
+
+- Rust `hit_miss_transform` も Sel 直接 (composite なし)
+- なので brick とは別の根本原因がある
+
+仮説:
+
+- Sel の origin 解釈の差
+- 出力初期化方針の差 (Rust は全 1 から AND、C は別?)
+- 境界処理 (Rust は `clear_unused_bits` で src clone を変更、C は in-place で
+
+  違う処理)
+
+- HMT の hit / miss テーブルの初期値処理
+
+詳細は本書のスコープを超えるため、後続の `004-hmt-impl-diff.md` に
+まとめる予定。
+
+## 関連
+
+- Phase 2.5 第一弾 ([001-jpeg-codec-diffs.md](001-jpeg-codec-diffs.md)): JPEG codec 差
+- Phase 2.5 第二弾 ([002-tiff-1bpp-write-limit.md](002-tiff-1bpp-write-limit.md)): TIFF 1bpp write
+- 上流 leptonica の brick API 一覧: `reference/leptonica/src/morph.c:51-58`


### PR DESCRIPTION
## Summary

PR #383 (Phase 2.5 第二弾) で TIFF 1bpp 書き出しを修正した後に残った 7 件
の `Mismatch` (binmorph1 4 件 + binmorph3 3 件) の原因を切り分け、修正方針
を整理する **調査記録 PR** です。Rust 実装は変更ありません。

## 結論

Rust の `dilate_brick` / `erode_brick` / `open_brick` / `close_brick` は
**常に composite decomposition** を採用しており、C 版の
`pixDilateCompBrick` 等に相当する。一方 `scripts/verify_binmorph.c` は
**plain separable な `pixDilateBrick`** を呼んでいるため、hash が合わない。

| Test | Diff/Total | %Diff |
|------|-----------:|------:|
| dilate_brick 21x15 | 129,670/523,800 | 24.76% |
| erode_brick 21x15 | 112,527/523,800 | 21.48% |
| open_brick 21x15 | 300,049/523,800 | 57.28% |
| close_brick 21x15 | 284,500/523,800 | 54.31% |

C 版に存在する 2 系統:

- `pixDilateBrick` (plain) — `reference/leptonica/src/morph.c:672`
- `pixDilateCompBrick` (composite) — `reference/leptonica/src/morph.c:1213`

Rust 側 `src/morph/binary.rs::dilate_brick` の doc コメントにも「Uses
separable + composite decomposition for optimal performance」と明記されて
いる (意図的な選択)。

## 修正オプション

詳細は `docs/porting/c-compat-findings/003-morph-brick-comp-vs-plain.md`
を参照。

- **A (推奨、短期)**: `scripts/verify_*.c` を `pix*CompBrick` に置換し、
  `manifest_c.tsv` 7 件を再生成。Rust 実装不変
- **B**: Rust 実装を plain separable に修正、composite を `dilate_comp_brick`
  に切り出し。Rust manifest 広範に再生成 (breaking change)
- **C (長期)**: Rust に plain と composite の両 API を提供 (C 慣習と完全
  一致、最も clean だが工数大)

## fhmtauto 8 件は別系統

`fhmtauto_hmt.*` + `fhmtauto_id.*` の 8 件は HMT 実装差 (Sel origin / 境界
処理) で別調査。`004-hmt-impl-diff.md` を後続 PR で予定。

## What

- `docs/porting/c-compat-findings/003-morph-brick-comp-vs-plain.md` を新規追加
- `docs/plans/901_c-hash-compat.md` の Findings ログを更新 (002 完了マーク、
  003 追加)

## Test plan

- [x] `cargo run --release --example compare_golden -- --module binmorph1`
      で 24-57% の pixel diff を確認
- [x] `src/morph/binary.rs::dilate_brick` の doc コメントが composite 選択を
      明示していることを確認
- [x] `reference/leptonica/src/morph.c` の `pixDilateBrick` (line 672) と
      `pixDilateCompBrick` (line 1213) を読み比べて 2 系統あることを確認
- [x] `scripts/verify_binmorph.c` が `pixDilateBrick` (plain) を呼んで
      いることを確認
- [ ] CI (markdownlint) 通過確認

## Impact

Rust 実装は本 PR では変更なし。次の実装 PR で Option A を採用すれば
`binmorph1` / `binmorph3` の Mismatch 7 件が `Ok` に転換する見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)