### PR TITLE
fix(examples/gen_c_manifest): PDF/PS 等の非決定的形式を hash 化から除外

### DIFF
--- a/examples/gen_c_manifest.rs
+++ b/examples/gen_c_manifest.rs
@@ -86,6 +86,21 @@ mod logic {
         )
     }
 
+    /// `true` for extensions whose C-side output embeds non-determinism
+    /// (e.g. `CreationDate`, sequential object identifiers) and therefore
+    /// changes hash on every regeneration even when the actual rendered
+    /// content is the same. These are skipped entirely so they never end up
+    /// in `tests/golden_manifest_c.tsv` and never trigger spurious diffs
+    /// on `bash scripts/gen_c_manifest.sh` re-runs.
+    ///
+    /// The Rust side does not hit this issue because `RegParams::
+    /// write_pix_and_check` hashes the in-memory `Pix`, not the serialized
+    /// PDF/PS bytes — so Rust manifest entries for `*.pdf` / `*.ps` are
+    /// stable.
+    pub fn is_unstable_extension(ext: &str) -> bool {
+        matches!(ext.to_ascii_lowercase().as_str(), "pdf" | "ps")
+    }
+
     /// Reason a file could not be hashed. `unsupported` files are skipped
     /// without aborting the run because leptonica-rs simply does not implement
     /// the corresponding decoder yet (e.g. TIFF Fax3 / Huffman / RGBPalette);
@@ -265,6 +280,15 @@ fn main() {
             skipped += 1;
             continue;
         }
+        // Skip formats that embed non-deterministic metadata (PDF
+        // CreationDate, PS object ids, etc.) so the manifest stays stable
+        // across `bash scripts/gen_c_manifest.sh` re-runs. See the
+        // is_unstable_extension doc for why Rust side is unaffected.
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if logic::is_unstable_extension(ext) {
+            skipped += 1;
+            continue;
+        }
         match logic::hash_file(&path) {
             Ok(h) => {
                 entries.insert(name, h);
@@ -320,6 +344,16 @@ mod tests {
         assert_eq!(data_content_hash(b"foo"), data_content_hash(b"foo"));
         assert_ne!(data_content_hash(b"foo"), data_content_hash(b"bar"));
         assert_ne!(data_content_hash(b"foo"), data_content_hash(b"foo\0"));
+    }
+
+    #[test]
+    fn unstable_extensions_recognised() {
+        for ext in ["pdf", "PDF", "ps", "PS"] {
+            assert!(is_unstable_extension(ext), "{ext} should be unstable");
+        }
+        for ext in ["png", "tif", "jpg", "txt", "ba", ""] {
+            assert!(!is_unstable_extension(ext), "{ext} should NOT be unstable");
+        }
     }
 
     #[test]

--- a/tests/golden_manifest_c.tsv
+++ b/tests/golden_manifest_c.tsv
@@ -273,7 +273,6 @@ binmorph6.05.png	b7f005730578dbee
 binmorph6.06.png	ed2378ed256a8026
 blackwhite.00.png	fb9543cbb81f1b0c
 blackwhite.01.png	b7babbf0b12293cc
-blend.pdf	22054b0b21e68080
 blend1.00.jpg	d25ef5b7528aa9d3
 blend1.01.jpg	811930575350d66b
 blend1.02.jpg	6784492b212a704d
@@ -707,7 +706,6 @@ compare.08.jpg	0ead766c63460b62
 compare.09.tif	fb3fc1755aec9a37
 compare.11.jpg	70e82b1d003136f6
 compare.12.tif	38ddb24b298c7f76
-compare.pdf	e61b635f3185401f
 compfilter.00.png	776f015732796ef4
 compfilter.01.png	32bbb5fff34c2454
 compfilter.31.png	3fc0111ee4296a1a
@@ -767,7 +765,6 @@ convolve.12.jpg	a9b8b7eef401b147
 convolve.13.jpg	f8f9c41edea63600
 convolve.14.jpg	91d660b752bc379e
 convolve.15.jpg	8d16597917a4e1a5
-correl.pdf	cbfba652ac050b91
 correl_5.png	ed418e487c30f43d
 crop.00.png	8853dafc907ca23c
 crop.01.png	fba6f8278d4e3eda
@@ -1377,7 +1374,6 @@ newspaper.09.tif	ed5159c3e38ac54b
 newspaper.10.png	80973652156f94e6
 newspaper.11.png	1687ac003fe74482
 newspaper.12.png	c594c4ef90c4b090
-newspaper.pdf	6d074d99d04dfea5
 numa2.00.png	81ca3c8ea6b59883
 numa2.03.png	2d1fe43567bd06ef
 numa2.10.png	8d93c0e3882212eb
@@ -1418,7 +1414,6 @@ pageseg.17.png	55799c27ee258006
 pageseg.18.png	1c437a12b42b32ef
 pageseg.19.png	e1b3838402297a5e
 pageseg.20.ba	b515cbc633485f75
-pageseg.21.pdf	ff60f410199fe857
 pageseg.22.png	ceb5b3a350c7014b
 pageseg.24.png	73e39578582717d9
 pageseg.26.png	001bcbe3de2672f0
@@ -1481,7 +1476,6 @@ paintmask.18.png	bb046f9937faa18a
 paintmask.19.png	e8bd6b5ba0733f0a
 paintmask.20.png	a0ec3f49705c429a
 paintmask.21.png	450593fb6e06121a
-pdfseg.7.pdf	d1db90dc5ee7169b
 pixa2-1.jpg	d0bad2f553ee185a
 pixa2-2.jpg	29c11ca0634d1af6
 pixa2-3.jpg	4adce8133b064826
@@ -1505,8 +1499,6 @@ pixcomp.04.jpg	4cc9e2d12eeb8038
 pixcomp.05.jpg	b2468932b8121aa9
 pixcomp.06.jpg	b844630b12aba742
 pixcomp.10.jpg	1584a368958731c7
-pixcomp.14.pdf	adaf5f34464c1e83
-pixcomp.15.pdf	aa5686642c746a44
 pixkern.png	1b68f34d0bc68ca6
 pixmem.12.png	0fd0a92eca260229
 pixs.10.spix	2accd0c9f3f2fa04
@@ -1553,24 +1545,13 @@ projective.30.jpg	0dfff0f65c1c1435
 projective.31.jpg	3b6a6197147f984e
 projective.32.jpg	62773181b431f54f
 projective.33.jpg	8f4900d057726a3a
-psio0.ps	82a0e85a8f66022b
-psio1.ps	27d031c01006f53f
-psio10.ps	b85fc44cedfb55fb
 psio2.jpg	949dc17f480620df
-psio3.ps	8dbf1f7bc700d812
-psio4.ps	6fbbab1a2c34f7ad
 psio5.jpg	82dcf510cfa9c46f
-psio5.ps	67377e022dca65c3
-psio6.ps	93436a37822a3002
-psio7.ps	19813ca77651a628
-psio8.ps	ab9ad5d8a52aae49
-psio9.ps	0615781884c3e055
 psioseg.00.jpg	c4d8a0e50edc6f51
 psioseg.01.jpg	714d60f571bb5cf4
 psioseg.02.jpg	1166bcf140330408
 psioseg.03.png	ace1c81e41968b85
 psioseg.04.png	040e83667327dac9
-psioseg.5.ps	204fa8467c7631cc
 pta.07.png	9950b2114a962a88
 pta.08.png	3e158421f59a6d68
 pta.09.png	4b0b56495eb194a8


### PR DESCRIPTION
## Summary

bash scripts/gen_c_manifest.sh のフルランで C 版 pdfio_reg / psioseg_reg 等が
PDF/PS を生成すると、embed されている **CreationDate / object identifier**
が毎回異なるため、出力の hash が毎回変わる問題を根本対処します。これまで
PR ごとに blend.pdf / newspaper.pdf 等の手動 revert を繰り返していた技術的
負債を解消します。

## Why

Rust 側 manifest (`tests/golden_manifest.tsv`) は `RegParams::write_pix_and_check`
が **in-memory `Pix`** を hash 化するため安定 (PDF を file に書いても hash
は変わらない)。

一方 C 側 manifest (`tests/golden_manifest_c.tsv`) は `examples/gen_c_manifest`
が **raw bytes** を hash 化するため、PDF 内部の timestamp drift で hash が
毎回変わる。

これまでの PR (#381, #383, #385) で blend.pdf / newspaper.pdf hash の
手動 revert が 3 回発生していた。

## What

- `examples/gen_c_manifest.rs::logic::is_unstable_extension()` を新規追加。
  `"pdf"` / `"ps"` をマーク
- `main` の dir walk loop で該当拡張子のファイルを skip (manifest entry を
  作らない)
- 単体テスト `unstable_extensions_recognised` を追加 (大文字小文字、安定
  形式の non-match を確認)
- `tests/golden_manifest_c.tsv` から PDF/PS 19 entries が消える
  (1898 → **1879**)

## 影響範囲

PDF/PS は `scripts/golden_map.tsv` に対応マッピングがなく、Phase 2 レポート
では **すべて `Unmapped`** 扱いだった。よって本変更で Phase 2 の compat
比較 (Mismatch/Ok 集計) には **一切影響しない**:

| カテゴリ | Before | After |
|----------|---:|---:|
| Ok | 17 | 17 |
| Mismatch | 36 | 36 |
| MissingC | 0 | 0 |
| Unmapped | 520 | 501 (-19 = 削除された PDF/PS) |

Rust 側 PDF テスト (`pdfio1_*`) の manifest entry は `tests/golden_manifest.tsv`
に 8 件残り、in-memory Pix hash で安定継続。

## Test plan

- [x] `cargo test --example gen_c_manifest --features all-formats` 6/6 pass
- [x] `bash scripts/gen_c_manifest.sh` フルランで 19 skipped がログに出る
- [x] `cargo test --all-features` 全 binary pass
- [x] `grep -cE '\.(pdf|ps)$' tests/golden_manifest_c.tsv` = 0
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)