### PR TITLE
docs(porting): Phase 3 — C 互換性ベースライン記録 (Ok 22 / Mismatch 31)

### DIFF
--- a/docs/plans/901_c-hash-compat.md
+++ b/docs/plans/901_c-hash-compat.md
@@ -178,10 +178,10 @@ Phase 2 のレポートを元に、不一致が出ている Rust テストを 1 
 - [004-hmt-impl-diff.md](../porting/c-compat-findings/004-hmt-impl-diff.md): fhmtauto 系 8 件の Mismatch。7 件 (sel_4_*, sel_8_*) は C `pixHMT` の「Clear near edges」処理が Rust `hit_miss_transform` に無いことが疑わしい。8 件目 (Identity 1x1 brick, 100% diff) は theoretical には identity になるはずだが実機で all-1 出力に近い → 005 で真因解明
 - [005-tiff-1bpp-photometric-invert-bug.md](../porting/c-compat-findings/005-tiff-1bpp-photometric-invert-bug.md): **`src/io/tiff.rs` の 1bpp invert 条件が C `tiffio.c` と完全に逆**。BlackIsZero TIFF (`feyn-fract.tif` 等) を読むと内部表現が「逆 leptonica 慣習 (FG=0)」になる重大 bug。修正は数行だが影響広範 (24+ Rust テスト fail) で write 側との整合性も含めて見直しが必要。修正は別 PR で慎重に進める。binmorph/fhmtauto/cthin 系の Mismatch 15 件が一気に Ok 化する見込み
 
-### Phase 3: 1モジュールでの検証ベースライン記録
+### Phase 3: ベースライン記録
 
-1. `tests/io/` か `tests/morph/` を先行検証
-2. 一致率・主要な不一致パターンを `docs/porting/c-compat-status.md` (新規) にまとめる
+1. ✅ `docs/porting/c-compat-status.md` を新規作成 (PR 番号: 本 PR)。現在の Ok/Mismatch/MissingC/Unmapped 集計と Phase 2.5 findings (001-005) の解消状況を整理
+2. `scripts/golden_map.tsv` の Unmapped 520 件のうち実マップ可能なエントリを段階的に追加 (継続作業)
 3. インデックスズレが多いテストの一覧を作成 (golden_map.tsv の補完情報)
 
 Phase 3 完了条件: 主要モジュールで C 互換性のベースラインが得られている

--- a/docs/plans/901_c-hash-compat.md
+++ b/docs/plans/901_c-hash-compat.md
@@ -180,7 +180,7 @@ Phase 2 のレポートを元に、不一致が出ている Rust テストを 1 
 
 ### Phase 3: ベースライン記録
 
-1. ✅ `docs/porting/c-compat-status.md` を新規作成 (PR 番号: 本 PR)。現在の Ok/Mismatch/MissingC/Unmapped 集計と Phase 2.5 findings (001-005) の解消状況を整理
+1. ✅ [`docs/porting/c-compat-status.md`](../porting/c-compat-status.md) を新規作成 (PR #390)。現在の Ok/Mismatch/MissingC/Unmapped 集計と Phase 2.5 findings (001-005) の解消状況を整理
 2. `scripts/golden_map.tsv` の Unmapped 520 件のうち実マップ可能なエントリを段階的に追加 (継続作業)
 3. インデックスズレが多いテストの一覧を作成 (golden_map.tsv の補完情報)
 

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -45,13 +45,13 @@ C 版 leptonica との互換性検証の **現在地** を整理する。`cargo 
 
 C 版と完全一致している領域:
 
-| カテゴリ                              | 件数 | 由来                                                           |
-| ------------------------------------- | ---: | -------------------------------------------------------------- |
-| `cthin1_thin` (4) + `cthin2_set` (11) |   15 | `pixThinConnected` / `pixThinConnectedBySet` (1bpp 細線化)     |
-| `compfilter_write_synthetic`          |    2 | `pixFillClosedBorders` 等 (合成画像)                           |
-| `binmorph1`                           |    3 | `pixDilate/Erode/Open*CompBrick(21,15)` (PR #389 で 4→1 Ok 化) |
-| `binmorph3`                           |    1 | `pixDilate*CompBrick(21,1)`                                    |
-| `fhmtauto_id`                         |    1 | Identity 1x1 HMT (PR #389 で解消)                              |
+| カテゴリ                              | 件数 | 由来                                                                          |
+| ------------------------------------- | ---: | ----------------------------------------------------------------------------- |
+| `cthin1_thin` (4) + `cthin2_set` (11) |   15 | `pixThinConnected` / `pixThinConnectedBySet` (1bpp 細線化)                    |
+| `compfilter_write_synthetic`          |    2 | `pixFillClosedBorders` 等 (合成画像)                                          |
+| `binmorph1`                           |    3 | `pixDilate/Erode/Open*CompBrick(21,15)` (PR #389 で Mismatch 4→1、3 件 Ok 化) |
+| `binmorph3`                           |    1 | `pixDilate*CompBrick(21,1)`                                                   |
+| `fhmtauto_id`                         |    1 | Identity 1x1 HMT (PR #389 で解消)                                             |
 
 PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
 

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -16,9 +16,9 @@ C 版 leptonica との互換性検証の **現在地** を整理する。`cargo 
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                      |
 | 📭 Unmapped | **520** | `scripts/golden_map.tsv` 未登録 (Phase 3+ で整理) |
 
-合計 573 entries が `tests/golden_manifest.tsv` 経由で C 比較対象。Rust
-manifest 全体は約 580 entries、加えて Rust 独自テスト 84 件 (C 版に
-対応なし)。
+合計 573 entries が C 比較対象。Rust manifest (`tests/golden_manifest.tsv`)
+全体は **580 entries** (582 行 - ヘッダ 2 行)。加えて Rust 独自テスト 84
+件 (C 版に対応なし)。
 
 ## test binary 別の内訳
 

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -1,0 +1,138 @@
+# C 互換性ベースライン (Phase 3)
+
+Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 (一連の PR #377〜#389) で確立した
+C 版 leptonica との互換性検証の **現在地** を整理する。`cargo test
+--all-features` 1 回で `tests/c_compat_report.*.txt` (8 個の test binary
+別ファイル) に集計が出力される仕組みは Phase 2 (PR #378) で導入済み。
+
+> **As of 2026-05-20** (PR #389 merge 後)。
+
+## 全体集計
+
+| 状態        |    件数 | 説明                                              |
+| ----------- | ------: | ------------------------------------------------- |
+| ✅ Ok       |  **22** | C 版と pixel-level 完全一致                       |
+| ⚠️ Mismatch |  **31** | C と Rust で hash 不一致 (内訳は後述)             |
+| ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                      |
+| 📭 Unmapped | **520** | `scripts/golden_map.tsv` 未登録 (Phase 3+ で整理) |
+
+合計 573 entries が `tests/golden_manifest.tsv` 経由で C 比較対象。Rust
+manifest 全体は約 580 entries、加えて Rust 独自テスト 84 件 (C 版に
+対応なし)。
+
+## test binary 別の内訳
+
+| Binary      |     Ok | Mismatch | MissingC | Unmapped |
+| ----------- | -----: | -------: | -------: | -------: |
+| `color`     |      0 |        0 |        0 |      114 |
+| `core`      |      0 |        0 |        0 |       35 |
+| `filter`    |      2 |        5 |        0 |       97 |
+| `io`        |      0 |        0 |        0 |       60 |
+| `morph`     | **20** |   **26** |        0 |        9 |
+| `recog`     |      0 |        0 |        0 |       45 |
+| `region`    |      0 |        0 |        0 |       78 |
+| `transform` |      0 |        0 |        0 |       82 |
+
+**morph** が現状最も Ok/Mismatch が集中している binary。これは:
+
+- 1bpp morph (binmorph, fhmtauto, ccthin) が C との pixel 一致を意図して
+
+  golden_map.tsv に登録されているため
+
+- Phase 2.5 で重点的に修正を進めた領域
+
+## Ok 22 件の内訳
+
+C 版と完全一致している領域:
+
+| カテゴリ                              | 件数 | 由来                                                           |
+| ------------------------------------- | ---: | -------------------------------------------------------------- |
+| `cthin1_thin` (4) + `cthin2_set` (11) |   15 | `pixThinConnected` / `pixThinConnectedBySet` (1bpp 細線化)     |
+| `compfilter_write_synthetic`          |    2 | `pixFillClosedBorders` 等 (合成画像)                           |
+| `binmorph1`                           |    3 | `pixDilate/Erode/Open*CompBrick(21,15)` (PR #389 で 4→1 Ok 化) |
+| `binmorph3`                           |    1 | `pixDilate*CompBrick(21,1)`                                    |
+| `fhmtauto_id`                         |    1 | Identity 1x1 HMT (PR #389 で解消)                              |
+
+PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
+
+## Mismatch 31 件の内訳
+
+### 修正対象外: 既知の JPEG codec 差 (21 件)
+
+| カテゴリ                                      | 件数 | 根拠                                                        |
+| --------------------------------------------- | ---: | ----------------------------------------------------------- |
+| `gmorph2_dilate_erode` + `gmorph2_open_close` |   12 | graymorph2 (8bpp JPEG quality=75)                           |
+| `edge`                                        |    4 | edge_reg (8bpp JPEG)                                        |
+| `colormorph`                                  |    4 | dilate_color/erode_color/open_color/close_color (8bpp JPEG) |
+| `convolve_blockconv_gray`                     |    1 | blockconv_gray (8bpp JPEG)                                  |
+
+すべて `docs/porting/c-compat-findings/001-jpeg-codec-diffs.md` で
+**JPEG codec 差** (libjpeg-turbo vs jpeg-decoder/jpeg-encoder) と仮説判定
+済み。Rust 実装のアルゴリズムは正しいと推定 (確定検証は別途)。
+
+### 修正対象 (Rust 実装の C 互換性改善): 10 件
+
+| カテゴリ                          | 件数 | finding                                                   | 修正方針                                                                                                                |
+| --------------------------------- | ---: | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `fhmtauto_hmt` (sel_4_*, sel_8_*) |    7 | [004](c-compat-findings/004-hmt-impl-diff.md)             | `hit_miss_transform` に C `pixHMT` の「Clear near edges」処理を追加 (`selFindMaxTranslations` 分の端 pixel を 0 クリア) |
+| `binmorph3` (sep/dir dilate)      |    2 | [003](c-compat-findings/003-morph-brick-comp-vs-plain.md) | `dilate_1d_composite` の factor 選択 / SEL origin / 境界処理を C `pixDilateCompBrick` 内部と pixel-level で突き合わせ   |
+| `binmorph1` (close 21x15)         |    1 | [003](c-compat-findings/003-morph-brick-comp-vs-plain.md) | 同上 (close は `pixCloseCompBrick` の padding 差)                                                                       |
+
+## 解消した発見の系譜 (Phase 2.5 の調査履歴)
+
+| Finding                                                                                       | 解消状況                                                           |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [001 JPEG codec diff](c-compat-findings/001-jpeg-codec-diffs.md)                              | 仮説段階 (修正対象外、21 件カバー)                                 |
+| [002 TIFF 1bpp write limit](c-compat-findings/002-tiff-1bpp-write-limit.md)                   | ✅ 実装完了 (PR #383)、bps=1 で書けるように                        |
+| [003 brick comp vs plain](c-compat-findings/003-morph-brick-comp-vs-plain.md)                 | 部分対応 (PR #385 で verify を Comp 化、`composite 細部差` 残課題) |
+| [004 HMT impl diff](c-compat-findings/004-hmt-impl-diff.md)                                   | 部分対応 (Identity は 005 真因で解消、Clear near edges は残課題)   |
+| [005 TIFF 1bpp photometric invert](c-compat-findings/005-tiff-1bpp-photometric-invert-bug.md) | ✅ 実装完了 (PR #389)、5 件 Ok 化                                  |
+
+## Unmapped 520 件について
+
+`scripts/golden_map.tsv` に C↔Rust の対応マッピングが登録されていない
+テスト。これは「Phase 1 / 1.5 で C 出力は取得済みだが、対応する Rust 出力
+との pairing 情報がない」状態。本書のスコープ外で、Phase 3+ (golden_map
+拡充フェーズ) で個別に拡張する。
+
+優先度の高い拡張候補 (現状 Unmapped が多い領域):
+
+- `color` (114), `transform` (82), `region` (78), `filter` (97), `io` (60)
+
+これらの大半は Rust 独自テスト (C に対応なし) も含むため、実質マッピング
+可能な件数はもっと少ない可能性。
+
+## 次のアクション
+
+### Phase 2.5 残作業 (Rust 修正対象 10 件)
+
+1. **004 finding 実装**: `src/morph/binary.rs::hit_miss_transform` に
+
+   Clear near edges 処理を追加 → fhmtauto_hmt 7 件解消見込み
+
+2. **003 finding 続き**: `src/morph/binary.rs::dilate_1d_composite` の
+
+   pixel-level audit → binmorph 3 件解消見込み
+
+両方完了で Mismatch 31 → 21 (JPEG codec 差のみが残る) になる見込み。
+
+### Phase 3 残作業 (本書整理 + golden_map 拡充)
+
+- 本書の継続更新 (Mismatch 数が変わるたびに表を refresh)
+- `scripts/golden_map.tsv` に未登録のテスト群 (Unmapped 520 件) のうち、
+
+  実際に C と pair 可能なものを段階的に登録
+
+### Phase 4: CI 統合
+
+- `tests/c_compat_report.*.txt` を GitHub Actions の artifact として保存
+- `Ok / Mismatch / MissingC / Unmapped` の集計を PR 本文に自動コメント
+
+## 関連
+
+- [plan 901: C版ハッシュとの互換性検証](../plans/901_c-hash-compat.md)
+- [Phase 1 完全性レポート](c-compat-coverage.md) (PR #380)
+- Phase 2.5 findings (001-005)
+- `examples/compare_golden.rs` (pixel-level 詳細比較ツール)
+- `examples/gen_c_manifest.rs` (C 出力からの hash 生成ツール)
+- `tests/common/c_compat.rs` (Phase 2 レポート機構)


### PR DESCRIPTION
## Summary

Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 (PR #377〜#389) で確立した C 互換性
検証の **現在地** を 1 つの doc に整理した **ベースライン記録 PR** です。
Rust 実装は変更ありません。

## What

- `docs/porting/c-compat-status.md` を新規追加 (as of 2026-05-20)
- `docs/plans/901_c-hash-compat.md` の Phase 3 セクションを実態に揃えて更新

## 現状

| 状態 | 件数 |
|------|---:|
| ✅ Ok | **22** |
| ⚠️ Mismatch | **31** |
| ⛔ MissingC | **0** (PR #381 で解消) |
| 📭 Unmapped | **520** |

### Mismatch 31 件の分類

- **修正対象外 (JPEG codec 差)**: 21 件 (gmorph2 12, edge 4, colormorph 4,
  convolve 1)
- **修正対象 (Rust 実装)**: **10 件** ← Phase 2.5 残作業の対象
  - fhmtauto_hmt 7 件 → 004 finding (Clear near edges 実装)
  - binmorph3 2 件 + binmorph1 1 件 → 003 finding (composite 細部)

## Findings の系譜

| Finding | 解消状況 |
|---------|----------|
| 001 JPEG codec diff | 仮説段階 (修正対象外、21 件カバー) |
| 002 TIFF 1bpp write limit | ✅ 完了 (PR #383) |
| 003 brick comp vs plain | 部分対応 (PR #385、composite 細部差残課題) |
| 004 HMT impl diff | 部分対応 (Identity は 005 で解消、Clear near edges 残課題) |
| 005 TIFF 1bpp photometric invert | ✅ 完了 (PR #389) |

## 次のアクション

1. **Phase 2.5 残作業**: 004 finding 実装 (fhmtauto_hmt 7 件) + 003 続き
   (binmorph 3 件) で **Mismatch 31 → 21 見込み**
2. **Phase 4 CI 統合**: `tests/c_compat_report.*.txt` の artifact 化

## Test plan

- [x] `cargo test --all-features` 全 binary pass、report 集計を物理確認
- [x] Findings 001-005 の参照リンク整合性確認
- [ ] CI (markdownlint) 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)