### PR TITLE
ci: C 互換性レポートを Job Summary + artifact に出力 (plan 901 Phase 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,52 @@ jobs:
 
       - name: test
         run: cargo test --all-features
+
+      # plan 901 Phase 4: surface the C-compat report so reviewers can see
+      # at a glance how many Rust outputs match / mismatch / are unmapped
+      # against the C leptonica baseline, and download the raw per-binary
+      # reports for deeper inspection. See docs/porting/c-compat-status.md.
+      - name: Summarize C-compat report
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          if ! ls tests/c_compat_report.*.txt >/dev/null 2>&1; then
+            echo "_No C-compat report files found_" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## C compatibility report"
+            echo ""
+            echo "| 状態 | 件数 |"
+            echo "| --- | --: |"
+            for state in Ok Mismatch MissingC Unmapped; do
+              count=$(grep -h "^\[$state\]" tests/c_compat_report.*.txt 2>/dev/null | wc -l)
+              echo "| $state | $count |"
+            done
+            echo ""
+            echo "### test binary 別"
+            echo ""
+            echo "| binary | Ok | Mismatch | MissingC | Unmapped |"
+            echo "| --- | --: | --: | --: | --: |"
+            for f in tests/c_compat_report.*.txt; do
+              [ -f "$f" ] || continue
+              bin=$(basename "$f" | sed -e 's/^c_compat_report\.//' -e 's/\.txt$//')
+              ok=$(grep -c '^\[Ok\]' "$f" 2>/dev/null || true)
+              ms=$(grep -c '^\[Mismatch\]' "$f" 2>/dev/null || true)
+              mc=$(grep -c '^\[MissingC\]' "$f" 2>/dev/null || true)
+              un=$(grep -c '^\[Unmapped\]' "$f" 2>/dev/null || true)
+              echo "| $bin | ${ok:-0} | ${ms:-0} | ${mc:-0} | ${un:-0} |"
+            done
+            echo ""
+            echo "Raw reports are attached as the \`c-compat-report\` artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload C-compat report artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: c-compat-report
+          path: tests/c_compat_report.*.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
         if: always()
         shell: bash
         run: |
-          set -uo pipefail
+          # GitHub Actions' default bash shell runs with `set -e`. `grep -c`
+          # returns exit 1 when there are zero matches (e.g. an io-binary
+          # report with no `Mismatch` lines), which would abort the whole
+          # step before we finish writing the summary. Disable errexit here
+          # and rely on the `|| true` fallbacks below for individual greps.
+          set +e
           if ! ls tests/c_compat_report.*.txt >/dev/null 2>&1; then
             echo "_No C-compat report files found_" >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -123,10 +123,13 @@ PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
 
   実際に C と pair 可能なものを段階的に登録
 
-### Phase 4: CI 統合
+### Phase 4: CI 統合 (PR #391 で実装)
 
-- `tests/c_compat_report.*.txt` を GitHub Actions の artifact として保存
-- `Ok / Mismatch / MissingC / Unmapped` の集計を PR 本文に自動コメント
+- ✅ `tests/c_compat_report.*.txt` を GitHub Actions の artifact として保存
+  (retention: 14 日)
+- ✅ workflow の Job Summary に Ok / Mismatch / MissingC / Unmapped の
+  集計テーブル (全体 + binary 別) を出力
+- PR 本文への自動コメント投稿は将来の拡張対象
 
 ## 関連
 


### PR DESCRIPTION
## Summary

Phase 2 (PR #378) で導入した `tests/c_compat_report.<binary>.txt` を CI 上
で可視化する **plan 901 Phase 4** の実装 PR です。Rust 実装は変更ありません。

## What

`.github/workflows/ci.yml` に 2 step を追加 (test step の後):

1. **Summarize C-compat report** (`if: always`)
   - 全体集計テーブル (Ok / Mismatch / MissingC / Unmapped)
   - test binary 別テーブル (8 binary × 4 状態)
   - `GITHUB_STEP_SUMMARY` に Markdown 形式で出力 (PR の Checks タブで at-a-glance に確認可能)
2. **Upload C-compat report artifact** (`if: always`)
   - `tests/c_compat_report.*.txt` を 14 日間保持の artifact として保存
   - `actions/upload-artifact@v4` を pinned sha (`ea165f8d...`) で導入

`if: always()` で test step が fail しても集計を出すようにし、Mismatch が
増えたときの原因追跡を容易にしています。

加えて `docs/porting/c-compat-status.md` の Phase 4 セクションを「未実装」
から「PR #391 で実装、PR 自動コメントは将来拡張」に更新。

## 期待される Job Summary (現状)

```markdown
## C compatibility report

| 状態 | 件数 |
| --- | --: |
| Ok | 22 |
| Mismatch | 31 |
| MissingC | 0 |
| Unmapped | 520 |

### test binary 別

| binary | Ok | Mismatch | MissingC | Unmapped |
| --- | --: | --: | --: | --: |
| color | 0 | 0 | 0 | 114 |
| core | 0 | 0 | 0 | 35 |
| filter | 2 | 5 | 0 | 97 |
| io | 0 | 0 | 0 | 60 |
| morph | 20 | 26 | 0 | 9 |
| recog | 0 | 0 | 0 | 45 |
| region | 0 | 0 | 0 | 78 |
| transform | 0 | 0 | 0 | 82 |
```

## Test plan

- [x] workflow YAML 構文確認
- [x] `tests/c_compat_report.*.txt` がローカル `cargo test --all-features`
      実行後に 8 ファイル生成されることを確認 (Phase 2 で実装済み)
- [ ] CI 実行で artifact が upload され、Job Summary に集計が出ることを確認

## Impact

- CI 実行時間: 集計 step 数百 ms + artifact upload 数 KB ≒ 軽微
- レビュアーが Mismatch 数の変化を PR の Checks タブで即座に確認できるよう
  になる (次の Phase 2.5 残作業 PR の効果測定が容易に)

🤖 Generated with [Claude Code](https://claude.com/claude-code)