### PR TITLE
docs(c-compat/004): Clear near edges 追加は不変と判明、SEL 生成差調査へ方針転換

### DIFF
--- a/docs/porting/c-compat-findings/004-hmt-impl-diff.md
+++ b/docs/porting/c-compat-findings/004-hmt-impl-diff.md
@@ -135,6 +135,80 @@ clear_pixels_in_rect(&mut out_mut, 0, h - yn, w, yn);
 
   すべて通ることを確認 (regression が無い)
 
+## 2026-05-20 更新: Identity は 005 で解消、Clear near edges は無効
+
+### Identity 1x1 (`fhmtauto_id.01.tif`): ✅ Ok 化
+
+PR #389 (TIFF 1bpp `PhotometricInterpretation` invert 修正, finding 005)
+によって **Identity 1x1 brick の 100% diff は解消**。最新の Phase 2
+レポート (`tests/c_compat_report.morph.txt`) で:
+
+```text
+[Ok] fhmtauto_id :: fhmtauto_id.01.tif :: matches fhmtauto_verify.07.tif = f29e3849aca2341e
+```
+
+→ 上記の「Identity 100% diff」仮説 (`hit_miss_transform` の bug) は誤りで、
+真因は TIFF reader の `BlackIsZero` 強制 invert (tiff crate の
+`WhiteIsZero` auto-invert と二重反転になっていた) だった。
+
+### Clear near edges 追加: ❌ 効果なし (Rust 出力 hash 不変)
+
+「Step 2: Clear near edges 実装」(上記) を実験的に `src/morph/binary.rs::
+hit_miss_transform` に追加して `cargo test --release --test morph`
+を実行した結果、**Rust 出力 hash は完全に不変** (例:
+`fhmtauto_hmt.02.tif = 622fa09c5fdc17bf` のまま) であり、fhmtauto_hmt 7
+件 (`sel_4_*` / `sel_8_*`) は依然 Mismatch のまま残った。
+
+理由:
+
+- C `pixHMT` の `Clear near edges` は **shift 元の `cx-j`/`cy-i` で
+
+  カバーされない領域** を明示的に 0 にする処理
+
+- Rust `shift_and_row` は word/bit 単位の shift 時に **左右端**
+
+  (`shift > 0` の `dst[0..word_shift] = 0` および `shift > 0` で `dst[
+  word_shift] &= src[0] >> bit_shift` の上位 bit) を AND-clear 済み
+
+- Rust `hit_miss_transform` は hit 行が `src_y < 0 || src_y >= h` のとき
+
+  **dst 行全体を 0 にクリア** (上下端)
+
+- → C `Clear near edges` と Rust 既存の word/bit-shift 境界処理が
+
+  **数学的に等価** で、追加しても出力に差が出ない
+
+### 結論: 残 7 件の root cause は別
+
+`hit_miss_transform` の Rust 実装は word/bit-shift 単位では C と一致して
+いるが、Phase 2 レポートで C と pixel-level hash 不一致が残る原因は、
+以下のいずれかにある (要追加調査):
+
+1. **`make_thin_sels` (`ThinSelSet::Set4cc1`/`Set8cc1`) の SEL 内容** が
+
+   C `selaAddHitMiss` (`reference/leptonica/src/morphapp.c`) が生成する
+   thinning sels と微妙に異なる
+
+2. C `pixHMT` の **first rasterop CLR/SET + その後 AND** ロジックと
+
+   Rust の **all-1 で開始して AND** ロジックが、特定 SEL 構成で異なる
+   結果になる (例: hit と miss が混在し、初期状態の影響が出るケース)
+
+3. Rust の `shift_and_row` / `shift_and_not_row` の MSB-first bit 順処理
+
+   に subtle なバグがあり、特定の `bit_shift` 値で C と差が出る
+
+### Next step (別 PR)
+
+- C `selaAddHitMiss` の SEL を dump し、Rust `make_thin_sels` と byte-
+
+  level で比較
+
+- 差があれば: Rust 側 SEL 生成を C 準拠に修正
+- 差がなければ: `hit_miss_transform` のロジックを `pixHMT` 完全準拠
+
+  (first rasterop CLR/SET 方式) に書き換えて再測定
+
 ## 関連
 
 - Phase 2.5 第一弾 ([001-jpeg-codec-diffs.md](001-jpeg-codec-diffs.md))

--- a/docs/porting/c-compat-findings/004-hmt-impl-diff.md
+++ b/docs/porting/c-compat-findings/004-hmt-impl-diff.md
@@ -153,61 +153,31 @@ PR #389 (TIFF 1bpp `PhotometricInterpretation` invert 修正, finding 005)
 
 ### Clear near edges 追加: ❌ 効果なし (Rust 出力 hash 不変)
 
-「Step 2: Clear near edges 実装」(上記) を実験的に `src/morph/binary.rs::
-hit_miss_transform` に追加して `cargo test --release --test morph`
-を実行した結果、**Rust 出力 hash は完全に不変** (例:
-`fhmtauto_hmt.02.tif = 622fa09c5fdc17bf` のまま) であり、fhmtauto_hmt 7
-件 (`sel_4_*` / `sel_8_*`) は依然 Mismatch のまま残った。
+「Step 2: Clear near edges 実装」(上記) を実験的に Rust 実装
+(`src/morph/binary.rs::hit_miss_transform`) に追加して
+`cargo test --release --test morph` を実行した結果、**Rust 出力 hash は完全に不変** (例: `fhmtauto_hmt.02.tif = 622fa09c5fdc17bf` のまま)
+であり、fhmtauto_hmt 7 件 (`sel_4_*` / `sel_8_*`) は依然 Mismatch のまま残った。
 
 理由:
 
-- C `pixHMT` の `Clear near edges` は **shift 元の `cx-j`/`cy-i` で
-
-  カバーされない領域** を明示的に 0 にする処理
-
-- Rust `shift_and_row` は word/bit 単位の shift 時に **左右端**
-
-  (`shift > 0` の `dst[0..word_shift] = 0` および `shift > 0` で `dst[
-  word_shift] &= src[0] >> bit_shift` の上位 bit) を AND-clear 済み
-
-- Rust `hit_miss_transform` は hit 行が `src_y < 0 || src_y >= h` のとき
-
-  **dst 行全体を 0 にクリア** (上下端)
-
-- → C `Clear near edges` と Rust 既存の word/bit-shift 境界処理が
-
-  **数学的に等価** で、追加しても出力に差が出ない
+- C `pixHMT` の `Clear near edges` は **shift 元の `cx-j`/`cy-i` でカバーされない領域** を明示的に 0 にする処理
+- Rust `shift_and_row` は word/bit 単位の shift 時に **左右端** (`shift > 0` の `dst[0..word_shift] = 0` および `dst[word_shift] &= src[0] >> bit_shift` の上位 bit) を AND-clear 済み
+- Rust `hit_miss_transform` は hit 行が `src_y < 0 || src_y >= h` のとき **dst 行全体を 0 にクリア** (上下端)
+- → C `Clear near edges` と Rust 既存の word/bit-shift 境界処理が **数学的に等価** で、追加しても出力に差が出ない
 
 ### 結論: 残 7 件の root cause は別
 
-`hit_miss_transform` の Rust 実装は word/bit-shift 単位では C と一致して
-いるが、Phase 2 レポートで C と pixel-level hash 不一致が残る原因は、
-以下のいずれかにある (要追加調査):
+Rust 実装は word/bit-shift 単位では C と一致しているが、Phase 2 レポートで C と pixel-level hash 不一致が残る原因は、以下のいずれかにある (要追加調査):
 
-1. **`make_thin_sels` (`ThinSelSet::Set4cc1`/`Set8cc1`) の SEL 内容** が
-
-   C `selaAddHitMiss` (`reference/leptonica/src/morphapp.c`) が生成する
-   thinning sels と微妙に異なる
-
-2. C `pixHMT` の **first rasterop CLR/SET + その後 AND** ロジックと
-
-   Rust の **all-1 で開始して AND** ロジックが、特定 SEL 構成で異なる
-   結果になる (例: hit と miss が混在し、初期状態の影響が出るケース)
-
-3. Rust の `shift_and_row` / `shift_and_not_row` の MSB-first bit 順処理
-
-   に subtle なバグがあり、特定の `bit_shift` 値で C と差が出る
+1. **`make_thin_sels` (`ThinSelSet::Set4cc1`/`Set8cc1`) の SEL 内容** が C `selaAddHitMiss` (`reference/leptonica/src/morphapp.c`) が生成する thinning sels と微妙に異なる
+2. C `pixHMT` の **first rasterop CLR/SET + その後 AND** ロジックと Rust の **all-1 で開始して AND** ロジックが、特定 SEL 構成で異なる結果になる (例: hit と miss が混在し、初期状態の影響が出るケース)
+3. Rust の `shift_and_row` / `shift_and_not_row` の MSB-first bit 順処理に subtle なバグがあり、特定の `bit_shift` 値で C と差が出る
 
 ### Next step (別 PR)
 
-- C `selaAddHitMiss` の SEL を dump し、Rust `make_thin_sels` と byte-
-
-  level で比較
-
+- C `selaAddHitMiss` の SEL を dump し、Rust `make_thin_sels` と byte-level で比較
 - 差があれば: Rust 側 SEL 生成を C 準拠に修正
-- 差がなければ: `hit_miss_transform` のロジックを `pixHMT` 完全準拠
-
-  (first rasterop CLR/SET 方式) に書き換えて再測定
+- 差がなければ: `hit_miss_transform` のロジックを `pixHMT` 完全準拠 (first rasterop CLR/SET 方式) に書き換えて再測定
 
 ## 関連
 

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -72,21 +72,21 @@ PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
 
 ### 修正対象 (Rust 実装の C 互換性改善): 10 件
 
-| カテゴリ                          | 件数 | finding                                                   | 修正方針                                                                                                                |
-| --------------------------------- | ---: | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `fhmtauto_hmt` (sel_4_*, sel_8_*) |    7 | [004](c-compat-findings/004-hmt-impl-diff.md)             | `hit_miss_transform` に C `pixHMT` の「Clear near edges」処理を追加 (`selFindMaxTranslations` 分の端 pixel を 0 クリア) |
-| `binmorph3` (sep/dir dilate)      |    2 | [003](c-compat-findings/003-morph-brick-comp-vs-plain.md) | `dilate_1d_composite` の factor 選択 / SEL origin / 境界処理を C `pixDilateCompBrick` 内部と pixel-level で突き合わせ   |
-| `binmorph1` (close 21x15)         |    1 | [003](c-compat-findings/003-morph-brick-comp-vs-plain.md) | 同上 (close は `pixCloseCompBrick` の padding 差)                                                                       |
+| カテゴリ                          | 件数 | finding                                                   | 修正方針                                                                                                                                                                              |
+| --------------------------------- | ---: | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fhmtauto_hmt` (sel_4_*, sel_8_*) |    7 | [004](c-compat-findings/004-hmt-impl-diff.md)             | 2026-05-20 実験: Clear near edges 追加では効果なし (Rust 出力 hash 不変)。root cause は SEL 生成差または bit-shift 内部実装にあり、追加調査が必要 (004 finding 末尾「Next step」参照) |
+| `binmorph3` (sep/dir dilate)      |    2 | [003](c-compat-findings/003-morph-brick-comp-vs-plain.md) | `dilate_1d_composite` の factor 選択 / SEL origin / 境界処理を C `pixDilateCompBrick` 内部と pixel-level で突き合わせ                                                                 |
+| `binmorph1` (close 21x15)         |    1 | [003](c-compat-findings/003-morph-brick-comp-vs-plain.md) | 同上 (close は `pixCloseCompBrick` の padding 差)                                                                                                                                     |
 
 ## 解消した発見の系譜 (Phase 2.5 の調査履歴)
 
-| Finding                                                                                       | 解消状況                                                           |
-| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [001 JPEG codec diff](c-compat-findings/001-jpeg-codec-diffs.md)                              | 仮説段階 (修正対象外、21 件カバー)                                 |
-| [002 TIFF 1bpp write limit](c-compat-findings/002-tiff-1bpp-write-limit.md)                   | ✅ 実装完了 (PR #383)、bps=1 で書けるように                        |
-| [003 brick comp vs plain](c-compat-findings/003-morph-brick-comp-vs-plain.md)                 | 部分対応 (PR #385 で verify を Comp 化、`composite 細部差` 残課題) |
-| [004 HMT impl diff](c-compat-findings/004-hmt-impl-diff.md)                                   | 部分対応 (Identity は 005 真因で解消、Clear near edges は残課題)   |
-| [005 TIFF 1bpp photometric invert](c-compat-findings/005-tiff-1bpp-photometric-invert-bug.md) | ✅ 実装完了 (PR #389)、5 件 Ok 化                                  |
+| Finding                                                                                       | 解消状況                                                                                                            |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [001 JPEG codec diff](c-compat-findings/001-jpeg-codec-diffs.md)                              | 仮説段階 (修正対象外、21 件カバー)                                                                                  |
+| [002 TIFF 1bpp write limit](c-compat-findings/002-tiff-1bpp-write-limit.md)                   | ✅ 実装完了 (PR #383)、bps=1 で書けるように                                                                         |
+| [003 brick comp vs plain](c-compat-findings/003-morph-brick-comp-vs-plain.md)                 | 部分対応 (PR #385 で verify を Comp 化、`composite 細部差` 残課題)                                                  |
+| [004 HMT impl diff](c-compat-findings/004-hmt-impl-diff.md)                                   | 部分対応 (Identity は 005 真因で解消、`fhmtauto_hmt` 7 件は Clear near edges 追加でも不変と判明 → SEL 生成差調査へ) |
+| [005 TIFF 1bpp photometric invert](c-compat-findings/005-tiff-1bpp-photometric-invert-bug.md) | ✅ 実装完了 (PR #389)、5 件 Ok 化                                                                                   |
 
 ## Unmapped 520 件について
 
@@ -106,15 +106,19 @@ PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
 
 ### Phase 2.5 残作業 (Rust 修正対象 10 件)
 
-1. **004 finding 実装**: `src/morph/binary.rs::hit_miss_transform` に
+1. **004 finding 続き**: 2026-05-20 実験で Clear near edges 追加は不変
 
-   Clear near edges 処理を追加 → fhmtauto_hmt 7 件解消見込み
+   と判明。次は `make_thin_sels(Set4cc1/Set8cc1)` の SEL 内容を C
+   `selaAddHitMiss` と byte-level 比較し、SEL 生成差の有無を切り分け
+   → 切り分け後の方針で fhmtauto_hmt 7 件解消を目指す
 
 2. **003 finding 続き**: `src/morph/binary.rs::dilate_1d_composite` の
 
    pixel-level audit → binmorph 3 件解消見込み
 
 両方完了で Mismatch 31 → 21 (JPEG codec 差のみが残る) になる見込み。
+ただし 004 は当初想定より深い調査が必要なため、複数 PR に分割される
+可能性がある。
 
 ### Phase 3 残作業 (本書整理 + golden_map 拡充)
 
@@ -126,9 +130,13 @@ PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
 ### Phase 4: CI 統合 (PR #391 で実装)
 
 - ✅ `tests/c_compat_report.*.txt` を GitHub Actions の artifact として保存
+
   (retention: 14 日)
+
 - ✅ workflow の Job Summary に Ok / Mismatch / MissingC / Unmapped の
+
   集計テーブル (全体 + binary 別) を出力
+
 - PR 本文への自動コメント投稿は将来の拡張対象
 
 ## 関連

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -106,19 +106,10 @@ PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
 
 ### Phase 2.5 残作業 (Rust 修正対象 10 件)
 
-1. **004 finding 続き**: 2026-05-20 実験で Clear near edges 追加は不変
+1. **004 finding 続き**: 2026-05-20 実験で Clear near edges 追加は不変と判明。次は `make_thin_sels(Set4cc1/Set8cc1)` の SEL 内容を C `selaAddHitMiss` と byte-level 比較し、SEL 生成差の有無を切り分け → 切り分け後の方針で fhmtauto_hmt 7 件解消を目指す
+2. **003 finding 続き**: `src/morph/binary.rs::dilate_1d_composite` の pixel-level audit → binmorph 3 件解消見込み
 
-   と判明。次は `make_thin_sels(Set4cc1/Set8cc1)` の SEL 内容を C
-   `selaAddHitMiss` と byte-level 比較し、SEL 生成差の有無を切り分け
-   → 切り分け後の方針で fhmtauto_hmt 7 件解消を目指す
-
-2. **003 finding 続き**: `src/morph/binary.rs::dilate_1d_composite` の
-
-   pixel-level audit → binmorph 3 件解消見込み
-
-両方完了で Mismatch 31 → 21 (JPEG codec 差のみが残る) になる見込み。
-ただし 004 は当初想定より深い調査が必要なため、複数 PR に分割される
-可能性がある。
+両方完了で Mismatch 31 → 21 (JPEG codec 差のみが残る) になる見込み。ただし 004 は当初想定より深い調査が必要なため、複数 PR に分割される可能性がある。
 
 ### Phase 3 残作業 (本書整理 + golden_map 拡充)
 
@@ -129,14 +120,8 @@ PR #389 の TIFF invert bug 修正で **5 件追加で Ok 化**。
 
 ### Phase 4: CI 統合 (PR #391 で実装)
 
-- ✅ `tests/c_compat_report.*.txt` を GitHub Actions の artifact として保存
-
-  (retention: 14 日)
-
-- ✅ workflow の Job Summary に Ok / Mismatch / MissingC / Unmapped の
-
-  集計テーブル (全体 + binary 別) を出力
-
+- ✅ `tests/c_compat_report.*.txt` を GitHub Actions の artifact として保存 (retention: 14 日)
+- ✅ workflow の Job Summary に Ok / Mismatch / MissingC / Unmapped の集計テーブル (全体 + binary 別) を出力
 - PR 本文への自動コメント投稿は将来の拡張対象
 
 ## 関連


### PR DESCRIPTION
## Summary

Phase 2.5 finding 004 の修正方針「\`hit_miss_transform\` に Clear near
edges 処理を追加 → fhmtauto_hmt 7 件解消見込み」を 2026-05-20 に実験
した結果、**Rust 出力 hash が完全に不変** で 7 件依然 Mismatch のまま
残った。本 PR は実験結果と次のステップを finding 004 と c-compat-status
に記録する **docs only PR**。

## Why

後続調査者が同じ実験 (約 30 分の cargo test 実行 + 比較) を繰り返さない
ように、無効と判明した修正方針を文書化する。Identity 1x1 が PR #389
で解消済みなのも反映漏れだったので併せて更新。

## What

\`docs/porting/c-compat-findings/004-hmt-impl-diff.md\` に「2026-05-20
更新」セクション追加:

- Identity 1x1 (\`fhmtauto_id.01.tif\`) は PR #389 (finding 005) で既に Ok
- Clear near edges 追加実験: Rust 出力 hash 不変 (例: \`622fa09c5fdc17bf\`
  のまま)
- 解析: Rust \`shift_and_row\` の word/bit-shift 境界処理が C \`Clear near
  edges\` と数学的に等価
- 残 7 件 root cause 候補 3 つを列挙 + Next step (SEL byte-level 比較)

\`docs/porting/c-compat-status.md\` を整合更新:

- fhmtauto_hmt 行の修正方針を書き換え
- 系譜表の 004 行を更新
- 「次のアクション」を SEL byte-level 比較に書き換え
- Mismatch 31 → 21 の見込みは維持 (ただし 004 は複数 PR 分割の可能性
  あり)

## Impact

- docs only。Rust 実装変更なし
- Phase 2 レポート (\`tests/c_compat_report.morph.txt\`) 不変
- 現状: **Ok 22 / Mismatch 31 / MissingC 0 / Unmapped 520** (不変)

## Test plan

- [x] markdownlint 通過確認
- [ ] CI (fmt / clippy / test) 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)