### PR TITLE
docs(c-compat): Phase 2.5 完全終了 — 修正対象 10/10 件すべて Ok 化

### DIFF
--- a/docs/porting/c-compat-findings/003-morph-brick-comp-vs-plain.md
+++ b/docs/porting/c-compat-findings/003-morph-brick-comp-vs-plain.md
@@ -265,38 +265,46 @@ close_brick` を C `pixDilate/Erode/Open/CloseCompBrick`
 
 ### 結果
 
-| Test                             | 旧 hash (Rust) | 新 hash (Rust) | C hash    | 状態           |
-| -------------------------------- | -------------- | -------------- | --------- | -------------- |
-| `binmorph1.12 close(21, 15)`     | 4e0325...      | 9720f6...      | 9720f6... | ✅ **Ok 化**   |
-| `binmorph3.14 dilate(11, 7) sep` | ea9553...      | 2a6524...      | 7285e6... | ⚠️ Mismatch 残 |
-| `binmorph3.15 dilate(11, 7) dir` | ea9553...      | 2a6524...      | 7285e6... | ⚠️ Mismatch 残 |
+| Test                             | 旧 hash (Rust) | 新 hash (Rust) | C hash    | 状態         |
+| -------------------------------- | -------------- | -------------- | --------- | ------------ |
+| `binmorph1.12 close(21, 15)`     | 4e0325...      | 9720f6...      | 9720f6... | ✅ **Ok 化** |
+| `binmorph3.14 dilate(11, 7) sep` | ea9553...      | 2a6524...      | 7285e6... | (PR #400 へ) |
+| `binmorph3.15 dilate(11, 7) dir` | ea9553...      | 2a6524...      | 7285e6... | (PR #400 へ) |
 
 完全分解できる `close(21, 15)` (= `(7, 3) × (5, 3)`) は **完全一致**。
 prime 11 を含む `dilate(11, 7)` (= `(4, 3) × (7, 1)` で size 12) は
-**依然不一致**。
+PR #398 時点で不一致が残ったが、PR #400 で root cause を特定し解消した
+(下節「PR #400 結果」)。
 
-### 残 root cause (要追加調査)
+## PR #400 結果 (2026-05-20)
 
-PR #398 で SEL pair (brick(4), comb(4, 3)) + border 32 + 4-step
-構造を C と完全に揃えたが、`binmorph3.14/15` (dilate 11x7) は不一致
-のまま。原因は Rust 基本 `dilate(pix, sel)` (= `dilate_rasterop` の
-word/bit shift OR ループ) と C `pixDilate` (= `pixRasterop` with
-`PIX_SRC | PIX_DST`) の **subtle な内部差** にあると推定。
+PR #398 で SEL pair・border・4-step 構造を C と完全に揃えたあとも残った
+`binmorph3.14/15` の root cause が `dilate_rasterop` の **hit-offset
+方向反転** にあることが判明した。
 
-### Next step (別 PR)
+数学的には:
 
-1. C `pixAddBorder(pix, 32, 0)` の出力 hash と Rust `add_border(pix,
+- dilation: `B ⊕ A = ∪ (B + a)` = `dst(x) |= src(x - a) for a ∈ A`
+- erosion : `B ⊖ A = ∩ (B - a)` = `dst(x) &= src(x + a) for a ∈ A`
 
-   32, 32, 32, 32)` の出力 hash が一致するか確認 (border 構築 step
-   の検証)
+Rust 旧 `dilate_rasterop` は `src_y = y + dy, shift = -dx` で **`erode`
+と同じ sign** を使っており、これは erosion 側では正しいが dilation に
+流用したため `B ⊕ A^` (A^ = A の原点反射) を計算していた。対称 SEL
+(cx = w/2 で w odd) では A = A^ で結果同じだが、binmorph3 の
+`(4, 3)` 分解で生じる `brick(4)` (cx=2, 相対 {-2, -1, 0, +1}) が非対称
+で、ここで顕在化していた。
 
-2. 各 step (`selh1`, `selh2`, `selv1`, `selv2`) 後の中間 hash を C と
+| Test                             | PR #398 後 | PR #400 後 | C hash    | 状態         |
+| -------------------------------- | ---------- | ---------- | --------- | ------------ |
+| `binmorph3.14 dilate(11, 7) sep` | 2a6524...  | 7285e6...  | 7285e6... | ✅ **Ok 化** |
+| `binmorph3.15 dilate(11, 7) dir` | 2a6524...  | 7285e6...  | 7285e6... | ✅ **Ok 化** |
 
-   Rust で順次比較し、乖離が発生する step を特定
+### 結論: ✅ finding 003 完全解消
 
-3. 該当 step (例: `shift_or_row` の MSB-first bit 順、または cx/cy
-
-   origin 解釈) を C と pixel-level で一致させる
+PR #398 (composite brick 構造) + PR #400 (dilate 方向) の 2 段階で
+`binmorph1` / `binmorph3` 計 3 件 (close 21x15、dilate 11x7 sep/dir) が
+すべて C と pixel-level 完全一致になった。Phase 2.5 修正対象 10 件
+完全解消の最終ピース。
 
 ## 関連
 

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -1,23 +1,24 @@
 # C 互換性ベースライン (Phase 3)
 
-Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 (一連の PR #377〜#398) で確立した
+Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 (一連の PR #377〜#400) で確立した
 C 版 leptonica との互換性検証の **現在地** を整理する。`cargo test
 --all-features` 1 回で `tests/c_compat_report.*.txt` (8 個の test binary
 別ファイル) に集計が出力される仕組みは Phase 2 (PR #378) で導入済み。
 
-> **As of 2026-05-20** (PR #397/#398 merge 後)。Phase 2.5 修正対象
-> 10 件のうち **8 件 (80%)** 解消 (fhmtauto_hmt 7 件 + binmorph1.12
-> close 1 件)。全体 Mismatch は 31 → 23 (8 件減、内訳は JPEG codec 差
-> 21 件は据え置き、修正対象は 10 → 2)。
+> **As of 2026-05-20** (PR #400 merge 後)。**Phase 2.5 修正対象
+> 10 件すべて解消 (100%)** — fhmtauto_hmt 7 件 (PR #397)、binmorph1.12
+> close 1 件 (PR #398)、binmorph3.14/15 dilate 2 件 (PR #400)。
+> 全体 Mismatch は 31 → 21 (10 件減、残 21 件は既知の JPEG codec 差で
+> 修正対象外、finding 001 参照)。
 
 ## 全体集計
 
-| 状態        |    件数 | 説明                                                   |
-| ----------- | ------: | ------------------------------------------------------ |
-| ✅ Ok       |  **30** | C 版と pixel-level 完全一致 (8 件追加、PR #397 + #398) |
-| ⚠️ Mismatch |  **23** | C と Rust で hash 不一致 (内訳は後述)                  |
-| ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                           |
-| 📭 Unmapped | **520** | `scripts/golden_map.tsv` 未登録 (Phase 3+ で整理)      |
+| 状態        |    件数 | 説明                                                       |
+| ----------- | ------: | ---------------------------------------------------------- |
+| ✅ Ok       |  **32** | C 版と pixel-level 完全一致 (10 件追加、PR #397/#398/#400) |
+| ⚠️ Mismatch |  **21** | C と Rust で hash 不一致 (全件 JPEG codec 差、修正対象外)  |
+| ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                               |
+| 📭 Unmapped | **520** | `scripts/golden_map.tsv` 未登録 (Phase 3+ で整理)          |
 
 合計 573 entries が C 比較対象。Rust manifest (`tests/golden_manifest.tsv`)
 全体は **580 entries** (582 行 - ヘッダ 2 行)。加えて Rust 独自テスト 84
@@ -31,7 +32,7 @@ C 版 leptonica との互換性検証の **現在地** を整理する。`cargo 
 | `core`      |      0 |        0 |        0 |       35 |
 | `filter`    |      2 |        5 |        0 |       97 |
 | `io`        |      0 |        0 |        0 |       60 |
-| `morph`     | **28** |   **18** |        0 |        9 |
+| `morph`     | **30** |   **16** |        0 |        9 |
 | `recog`     |      0 |        0 |        0 |       45 |
 | `region`    |      0 |        0 |        0 |       78 |
 | `transform` |      0 |        0 |        0 |       82 |
@@ -44,7 +45,7 @@ C 版 leptonica との互換性検証の **現在地** を整理する。`cargo 
 
 - Phase 2.5 で重点的に修正を進めた領域
 
-## Ok 30 件の内訳
+## Ok 32 件の内訳
 
 C 版と完全一致している領域:
 
@@ -53,13 +54,13 @@ C 版と完全一致している領域:
 | `cthin1_thin` (4) + `cthin2_set` (11) |   15 | `pixThinConnected` / `pixThinConnectedBySet` (1bpp 細線化)                                   |
 | `compfilter_write_synthetic`          |    2 | `pixFillClosedBorders` 等 (合成画像)                                                         |
 | `binmorph1`                           |    4 | `pixDilate/Erode/Open/CloseCompBrick(21,15)` (PR #389 で 3 件 + PR #398 で `close` 1 件追加) |
-| `binmorph3`                           |    1 | `pixDilateCompBrick(21,1)`                                                                   |
+| `binmorph3`                           |    3 | `pixDilateCompBrick(21,1)` 1 件 + `(11,7)` sep/dir 2 件 (PR #400 で追加)                     |
 | `fhmtauto_id`                         |    1 | Identity 1x1 HMT (PR #389 で解消)                                                            |
 | `fhmtauto_hmt` (sel_4_*, sel_8_*)     |    7 | PR #397 で thinning SEL 中心 `'C'` を DontCare に修正し解消                                  |
 
-通算で **8 件追加 Ok 化** (PR #397 で fhmtauto 7、PR #398 で binmorph1.12 1)。
+通算で **10 件追加 Ok 化** (PR #397 で fhmtauto 7、PR #398 で binmorph1.12 1、PR #400 で binmorph3.14/15 2)。
 
-## Mismatch 23 件の内訳
+## Mismatch 21 件の内訳
 
 ### 修正対象外: 既知の JPEG codec 差 (21 件)
 
@@ -74,21 +75,20 @@ C 版と完全一致している領域:
 **JPEG codec 差** (libjpeg-turbo vs jpeg-decoder/jpeg-encoder) と仮説判定
 済み。Rust 実装のアルゴリズムは正しいと推定 (確定検証は別途)。
 
-### 修正対象 (Rust 実装の C 互換性改善): 2 件
+### 修正対象 (Rust 実装の C 互換性改善): **0 件 (✅ 完全解消)**
 
-| カテゴリ                     | 件数 | finding                                                   | 修正方針                                                                                                                                                                                                                                                  |
-| ---------------------------- | ---: | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `binmorph3` (sep/dir dilate) |    2 | [003](c-compat-findings/003-morph-brick-comp-vs-plain.md) | PR #398 で C `pixDilateCompBrick` 準拠の border + 4-step 構造に書き直したが、prime size 11 ((4, 3) で size 12 composite) で C と pixel-level 不一致。Rust 基本 `dilate` (word-shift / boundary) と C `pixDilate` の subtle 差が原因と推定、追加調査が必要 |
+Phase 2.5 開始時の修正対象 10 件はすべて Ok 化済み。詳細は finding
+003 / 004 を参照。
 
 ## 解消した発見の系譜 (Phase 2.5 の調査履歴)
 
-| Finding                                                                                       | 解消状況                                                                                                                                                                                                |
-| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [001 JPEG codec diff](c-compat-findings/001-jpeg-codec-diffs.md)                              | 仮説段階 (修正対象外、21 件カバー)                                                                                                                                                                      |
-| [002 TIFF 1bpp write limit](c-compat-findings/002-tiff-1bpp-write-limit.md)                   | ✅ 実装完了 (PR #383)、bps=1 で書けるように                                                                                                                                                             |
-| [003 brick comp vs plain](c-compat-findings/003-morph-brick-comp-vs-plain.md)                 | 部分対応 (PR #385 verify を Comp 化 / PR #398 で `pixDilate/Erode/Open/CloseCompBrick` 準拠書き直し、`binmorph1.12 close` 1 件解消、`binmorph3.14/15 dilate 11x7` 2 件は subtle な `dilate` 差で残課題) |
-| [004 HMT impl diff](c-compat-findings/004-hmt-impl-diff.md)                                   | ✅ 解消 (PR #397 で thinning SEL 中心 `'C'` を C 準拠で DontCare に修正、`fhmtauto_hmt` 7 件すべて Ok 化)                                                                                               |
-| [005 TIFF 1bpp photometric invert](c-compat-findings/005-tiff-1bpp-photometric-invert-bug.md) | ✅ 実装完了 (PR #389)、5 件 Ok 化                                                                                                                                                                       |
+| Finding                                                                                       | 解消状況                                                                                                                                                                                  |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [001 JPEG codec diff](c-compat-findings/001-jpeg-codec-diffs.md)                              | 仮説段階 (修正対象外、21 件カバー)                                                                                                                                                        |
+| [002 TIFF 1bpp write limit](c-compat-findings/002-tiff-1bpp-write-limit.md)                   | ✅ 実装完了 (PR #383)、bps=1 で書けるように                                                                                                                                               |
+| [003 brick comp vs plain](c-compat-findings/003-morph-brick-comp-vs-plain.md)                 | ✅ 解消 (PR #385 で verify を Comp 化、PR #398 で `pix*CompBrick` 準拠書き直し + `binmorph1.12 close` Ok 化、PR #400 で `dilate_rasterop` 方向修正 + `binmorph3.14/15 dilate 11x7` Ok 化) |
+| [004 HMT impl diff](c-compat-findings/004-hmt-impl-diff.md)                                   | ✅ 解消 (PR #397 で thinning SEL 中心 `'C'` を C 準拠で DontCare に修正、`fhmtauto_hmt` 7 件すべて Ok 化)                                                                                 |
+| [005 TIFF 1bpp photometric invert](c-compat-findings/005-tiff-1bpp-photometric-invert-bug.md) | ✅ 実装完了 (PR #389)、5 件 Ok 化                                                                                                                                                         |
 
 ## Unmapped 520 件について
 
@@ -106,11 +106,11 @@ C 版と完全一致している領域:
 
 ## 次のアクション
 
-### Phase 2.5 残作業 (Rust 修正対象 2 件)
+### Phase 2.5: ✅ 完了 (2026-05-20、PR #400 まで)
 
-**003 finding 続き**: PR #398 で `pixDilate/Erode/Open/CloseCompBrick` 準拠の border / 4-step 構造に書き直した結果、`binmorph1.12 close (21×15)` は C と完全一致したが、`binmorph3.14/15 dilate(11×7)` は新 hash `2a65...` ≠ C `7285...` で残課題。SEL pair (brick(4), comb(4,3)) と border 32 / 4-step は両者完全同一で、差は Rust 基本 `dilate(pix, sel)` の word-shift / boundary 処理にあると推定。
-
-次は (a) C `pixAddBorder(pix, 32, 0)` と Rust `add_border(pix, 32, 32, 32, 32)` の hash 一致確認、(b) 各 step (`selh1`, `selh2`, `selv1`, `selv2`) 後の中間 hash を C と Rust で順次比較、で乖離点を特定する。完了で Mismatch 23 → 21 (JPEG codec 差のみが残る) になる見込み。
+修正対象 10 件すべて解消。残 21 件は finding 001 で JPEG codec 差と
+判定済みで、Rust 実装のアルゴリズムは正しいと推定 (Rust JPEG エンコーダ
+の出力 byte 差が hash に反映されているのみ)。
 
 ### Phase 3 残作業 (本書整理 + golden_map 拡充)
 


### PR DESCRIPTION
## Summary

PR #400 のマージで Phase 2.5 修正対象 10 件の最後の 2 件
(binmorph3.14/15 dilate 11×7) が解消し、Phase 2.5 が完全終了した。
本 PR は \`c-compat-status.md\` と finding 003 を最終状態に更新する
**docs only PR**。

## What

\`docs/porting/c-compat-status.md\`:

- 冒頭 PR 範囲を #377〜#400 に拡張、「As of」要約を「修正対象 10 件
  すべて解消 (100%)」に書き換え
- 全体集計: Ok 30 → 32 / Mismatch 23 → 21
- test binary 別: morph Ok 28 → 30 / Mismatch 18 → 16
- Ok 内訳: binmorph3 1 → 3、通算 10 件追加 Ok 化を明示
- Mismatch 内訳: 「修正対象 0 件 (✅ 完全解消)」
- 系譜表: 003 を「✅ 解消 (PR #385/#398/#400 で段階的に)」
- 次のアクション: Phase 2.5 ✅ 完了を宣言

\`docs/porting/c-compat-findings/003-morph-brick-comp-vs-plain.md\`:

- 「PR #398 結果」の binmorph3.14/15 残課題行を「(PR #400 へ)」に更新
- 新セクション「PR #400 結果 (2026-05-20)」を追加し、root cause
  (\`dilate_rasterop\` の hit-offset 方向反転) と修正 (B ⊕ A の C 準拠
  に揃える) の解析を記録
- 結論として「✅ finding 003 完全解消」を明記

## Impact

- docs only。Rust 実装変更なし
- 最終 C 互換性ベースライン: **Ok 32 / Mismatch 21 (全件 JPEG codec 差、
  修正対象外) / MissingC 0 / Unmapped 520**

## Test plan

- [x] markdownlint 通過確認 (\`scripts/fix-markdown-lint.py\`)
- [ ] CI (fmt / clippy / test) 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)