### PR TITLE
feat(c-compat): paintmask 19-21 の lossless ペア 3 件を追加 — 全件 Ok (plan 902 PR 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-07-16 実測、plan 902 PR 2 後):
+- 現状ベースライン (As of 2026-07-17 実測、plan 902 PR 4 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 44 / Mismatch 33 / MissingC 0 / Unmapped 445 / Excluded 53**
+  **Ok 47 / Mismatch 33 / MissingC 0 / Unmapped 445 / Excluded 53**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -70,7 +70,17 @@ C 版ソース: `src/scale1.c` (scaleGray2xLILineLow / scaleGray4xLILineLow)。
 - 同一入力検証で dither.04/05 とも diff=0 の bit 一致を確認。これで
   dither 系 4 ペアはすべて「アルゴリズム等価、残差は JPEG decode 差のみ」
 
-### PR 4 以降: semantic マッピングの漸進追加
+### PR 4: paintmask 19-21 の lossless ペア (実施済み)
+
+C 版ソース: `prog/paintmask_reg.c` 19-21 (feyn.tif / rabi.png)。
+
+- C と同条件 (同 box・outval) の 1bpp blend テストを追加し 3 ペアをマップ
+- **全件 hash 完全一致 (Ok 44 → 47)**。clip_rectangle / invert /
+  clip_masked の C 等価性を pixel-level で証明
+- 教訓: **lossless 入力のペアは即 Ok になる**。JPEG 入力系列
+  (decode 差で必ず Mismatch) より lossless 系列を優先してマップする
+
+### PR 5 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -34,12 +34,18 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 > C 専用整数補間に修正 (finding 008 発見 3 解消)。dither 系 4 ペアは
 > すべて同一入力で bit 一致し、残差は JPEG 入力 decode 差のみとなった。
 > 集計値は変化なし (Mismatch 33 のまま、原因の内訳が単純化)。
+>
+> **plan 902 PR 4 (paintmask 19-21) 後**: lossless 入力 (feyn.tif /
+> rabi.png) の 1bpp blend 系列を C prog と同条件で再現し 3 ペア追加、
+> **全件 hash 完全一致で Ok 44 → 47** (color binary 初の Ok)。
+> lossless 入力のペアは即 Ok になることを実証 — 以降のマッピングは
+> lossless 入力系列を優先する。
 
 ## 全体集計
 
 | 状態        | 件数    | 説明                                                                                                                           |
 | ----------- | ------: | -----------------------------------------------------------------------------------------------------------------------------  |
-| ✅ Ok       | **44**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12)                                                                 |
+| ✅ Ok       | **47**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +3)                                                 |
 | ⚠️ Mismatch | **33**  | 内訳: JPEG codec 差 21 件 (finding 001) + seedspread 6 件 (finding 006) + gifio 2 件 (finding 007) + dither 4 件 (finding 008) |
 | ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                   |
 | 📭 Unmapped | **445** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → 500 → 447 → 445)                                          |
@@ -53,7 +59,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | Binary      |     Ok | Mismatch | MissingC | Unmapped | Excluded |
 | ----------- | -----: | -------: | -------: | -------: | -------: |
-| `color`     |      0 |        4 |        0 |      112 |        0 |
+| `color`     |      3 |        4 |        0 |      112 |        0 |
 | `core`      |      1 |        0 |        0 |       34 |        0 |
 | `filter`    |      2 |        5 |        0 |       57 |       40 |
 | `io`        |      7 |        2 |        0 |       41 |       10 |
@@ -70,7 +76,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 - Phase 2.5 で重点的に修正を進めた領域
 
-## Ok 44 件の内訳
+## Ok 47 件の内訳
 
 C 版と完全一致している領域:
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -171,3 +171,8 @@ color	dither	0	dither_bin	3	error-diffusion dither to binary (gamma 1.3)
 color	dither	2	dither_2bpp	3	dither to 2bpp without colormap (gamma 1.3)
 color	dither	4	dither_2bpp	6	scale gray 2x LI dither (gamma 1.3)
 color	dither	5	dither_2bpp	9	scale gray 4x LI dither (gamma 1.3)
+
+# paintmask_reg.c 19-21 (plan 902 PR 4): feyn.tif/rabi.png の lossless 1bpp 系列
+color	paintmask	19	pmask_1bpp	1	clipped 1bpp feyn.tif (box 670,827,800,500)
+color	paintmask	20	pmask_1bpp	2	inverted clipped rabi.png mask (box 303,1983,800,500)
+color	paintmask	21	pmask_1bpp	3	1bpp blend via clip_masked (outval 1)

--- a/tests/color/paintmask_reg.rs
+++ b/tests/color/paintmask_reg.rs
@@ -154,3 +154,41 @@ fn paintmask_reg_clip_masked() {
 
     assert!(rp.cleanup(), "paintmask clip_masked test failed");
 }
+
+/// 1bpp blending through a clipped mask, mirroring C checks 19-21 exactly
+/// (same inputs feyn.tif / rabi.png, same boxes, same outval), so the three
+/// outputs are C-comparable at pixel level (plan 902 PR 4).
+///
+/// C: pixs = feyn.tif; pixt2 = pixClipRectangle(pixs, box(670,827,800,500));
+///    pixm = pixInvert(pixClipRectangle(rabi.png, box(303,1983,800,500)));
+///    pixd = pixClipMasked(pixs, pixm, 670, 827, 1).
+#[test]
+fn paintmask_reg_1bpp_blend() {
+    let mut rp = RegParams::new("pmask_1bpp");
+
+    let pixs = crate::common::load_test_image("feyn.tif").expect("load feyn.tif");
+    assert_eq!(pixs.depth(), PixelDepth::Bit1);
+
+    // C check 19: clipped 1bpp source
+    let clipped = pixs.clip_rectangle(670, 827, 800, 500).expect("clip feyn");
+    rp.write_pix_and_check(&clipped, ImageFormat::Png)
+        .expect("check: clipped feyn");
+
+    // C check 20: inverted clipped mask
+    let rabi = crate::common::load_test_image("rabi.png").expect("load rabi.png");
+    let mask = rabi.clip_rectangle(303, 1983, 800, 500).expect("clip mask");
+    let mask = mask.invert();
+    assert_eq!(mask.depth(), PixelDepth::Bit1);
+    rp.write_pix_and_check(&mask, ImageFormat::Png)
+        .expect("check: inverted mask");
+
+    // C check 21: blend the two 1bpp sources through the mask
+    let result = pixs
+        .clip_masked(&mask, 670, 827, 1)
+        .expect("clip_masked 1bpp blend");
+    assert_eq!(result.depth(), PixelDepth::Bit1);
+    rp.write_pix_and_check(&result, ImageFormat::Png)
+        .expect("check: 1bpp blend");
+
+    assert!(rp.cleanup(), "paintmask 1bpp blend test failed");
+}

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -456,6 +456,9 @@ pixadisp_tiled.05.tif	f820e040504ec64b
 pixcomp_rt.04.tif	f29e3849aca2341e
 pixcomp_rt.06.png	25d12b85fa3e168b
 pixcomp_rt.08.png	25d12b85fa3e168b
+pmask_1bpp.01.png	e8bd6b5ba0733f0a
+pmask_1bpp.02.png	a0ec3f49705c429a
+pmask_1bpp.03.png	450593fb6e06121a
 pmask_32.03.png	796cccba9aa4c5e6
 pmask_clip.03.png	6617bee0e9239144
 pmask_clip.05.png	942cfbc86d858bfa


### PR DESCRIPTION
## Why

plan 902 のマッピング拡充。PR 2/3 で確定した「JPEG 入力は decode 差で hash 一致不可」の教訓を踏まえ、**lossless 入力 (feyn.tif / rabi.png) の系列**を対象に選定した。

## What

- C `paintmask_reg.c` 19-21 を忠実に再現する `pmask_1bpp` テストを追加(同じ入力・box・outval)
- golden_map に 3 ペアを追加

## 結果

**3 ペアとも hash 完全一致で即 Ok**(Ok 44 → 47、color binary 初の Ok):

| C 出力 | 演算 | 結果 |
|--------|------|------|
| paintmask.19 | clip_rectangle (1bpp feyn) | Ok |
| paintmask.20 | clip_rectangle + invert (rabi mask) | Ok |
| paintmask.21 | clip_masked (1bpp blend) | Ok |

`clip_rectangle` / `invert` / `clip_masked` の C 等価性を pixel-level で証明。

## Impact

- テスト・TSV・docs のみ。ライブラリ本体への変更なし
- ベースライン: Ok 44 → 47(docs 更新済み)。全 4683 テスト通過
- 以降のマッピングは lossless 入力系列を優先する方針を plan 902 に明記