### PR TITLE
feat(region): conn_comp_transform_depth 追加 + multiply_constant 32bpp の C 準拠化 (plan 902 PR 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-07-17 実測、plan 902 PR 6 後):
+- 現状ベースライン (As of 2026-07-17 実測、plan 902 PR 7 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 76 / Mismatch 29 / MissingC 0 / Unmapped 406 / Excluded 79**
+  **Ok 78 / Mismatch 29 / MissingC 0 / Unmapped 406 / Excluded 79**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -107,7 +107,13 @@ C 版ソース: `prog/label_reg.c`、`src/pixlabel.c` / `src/rop.c` / `src/shear
 - 未対応: C check 1 (ConnCompTransform 8bpp) と check 5
   (pixMultConstantGray) は API 追加が必要 (finding 009 参照)
 
-### PR 7 以降: semantic マッピングの漸進追加
+### PR 7: label 残り 2 ペア — conn_comp_transform_depth + multiply_constant (実施済み)
+
+- `conn_comp_transform_depth` 新設 (C pixConnCompTransform 準拠) と
+  `multiply_constant` 32bpp の C 準拠化 (実装差 8 件目) で
+  C label_reg の PNG 出力 10 件が完全制覇 (Ok 76 → 78)
+
+### PR 8 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-findings/009-label-alignment-chain.md
+++ b/docs/porting/c-compat-findings/009-label-alignment-chain.md
@@ -48,9 +48,12 @@ label 8 ペア全件 hash 完全一致 (Ok +8)。roundtrip 規約で seedspread 
 (finding 008、JPEG 入力 decode 差) + seedspread 2 (finding 006 残) +
 gifio 2 (finding 007)。
 
-## 未対応 (後続 PR 候補)
+## 未対応 → PR 7 で解消
 
-- C label_reg の check 1 (`pixConnCompTransform` の 8bpp 出力):
-  Rust の `conn_comp_transform` は出力 depth パラメータを持たず、
-  ラベル値の規約 (1 + i % 254) と成分列挙順の一致確認も必要
-- C check 5 (`pixMultConstantGray` 0.3 倍): 対応 API が未移植
+- C check 1: `conn_comp_transform_depth` を新設 (8bpp: 1 + i%254)。
+  Rust のラベル列挙順 (raster 初出順) が C pixConnComp と一致することを
+  feyn-fract (mod 254 wrap 含む) の hash 一致で実証
+- C check 5: `multiply_constant` の 32bpp を C pixMultConstantGray 準拠
+  (語全体の乗算・clip なし) に修正して対応
+
+→ **C label_reg の PNG 出力 10 件すべてが Ok** (Ok 76 → 78)

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,7 +54,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        | 件数    | 説明                                                                                                                              |
 | ----------- | ------: | -----------------------------------------------------------------------------------------------------------------------------     |
-| ✅ Ok       | **76**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +32)                                                   |
+| ✅ Ok       | **78**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +34)                                                   |
 | ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
 | ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
 | 📭 Unmapped | **406** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → 500 → 447 → 445 → 410 → 406)                                 |
@@ -74,7 +74,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 | `io`        |      7 |        2 |        0 |       41 |       10 |
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |      0 |        0 |        0 |       45 |        0 |
-| `region`    | **29** |        2 |        0 |       30 |       29 |
+| `region`    | **31** |        2 |        0 |       30 |       29 |
 | `transform` |      4 |        0 |        0 |       78 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
@@ -85,7 +85,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 - Phase 2.5 で重点的に修正を進めた領域
 
-## Ok 76 件の内訳
+## Ok 78 件の内訳
 
 C 版と完全一致している領域:
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -197,8 +197,10 @@ region	distance	52	dist_contours	13	render_contours binary c8/d16/bg
 region	distance	58	dist_contours	15	render_contours binary c8/d16/fg
 
 # label_reg.c (plan 902 PR 6): feyn-fract/form1/form2 の lossless 系列
-region	label	4	label	21	cc area transform 8bpp (feyn-fract, LS_TWO_BYTES/CLIP_TO_FF)
-region	label	6	label	24	loc-to-color transform (form1)
+region	label	1	label	20	cc transform 8bpp (feyn-fract, 1 + i%254)
+region	label	4	label	23	cc area transform 8bpp (feyn-fract, LS_TWO_BYTES/CLIP_TO_FF)
+region	label	5	label	24	cc area transform x0.3 (pixMultConstantGray) 8bpp
+region	label	6	label	27	loc-to-color transform (form1)
 region	label	7	label_color	1	loc-to-color of rot90 (form1)
 region	label	11	label_color	2	loc-to-color of rot180 (form1)
 region	label	15	label_color	3	loc-to-color of rot270 (form1)

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -196,7 +196,7 @@ region	distance	43	dist_contours	11	render_contours binary c8/d8/fg
 region	distance	52	dist_contours	13	render_contours binary c8/d16/bg
 region	distance	58	dist_contours	15	render_contours binary c8/d16/fg
 
-# label_reg.c (plan 902 PR 6): feyn-fract/form1/form2 の lossless 系列
+# label_reg.c (plan 902 PR 6-7): feyn-fract/form1/form2 の lossless 系列
 region	label	1	label	20	cc transform 8bpp (feyn-fract, 1 + i%254)
 region	label	4	label	23	cc area transform 8bpp (feyn-fract, LS_TWO_BYTES/CLIP_TO_FF)
 region	label	5	label	24	cc area transform x0.3 (pixMultConstantGray) 8bpp

--- a/src/core/pix/arith.rs
+++ b/src/core/pix/arith.rs
@@ -724,17 +724,13 @@ impl PixMut {
                 }
             }
             PixelDepth::Bit32 => {
+                // C pixMultConstantGray: the whole 32-bit word is a single
+                // gray value, multiplied without clipping (for per-channel
+                // RGB scaling use filter::mult_constant_color).
                 for y in 0..height {
                     for x in 0..width {
-                        let pixel = self.get_pixel(x, y).unwrap_or(0);
-                        let (r, g, b) = pixel::extract_rgb(pixel);
-
-                        let r_new = ((factor * r as f32) as u32).min(255) as u8;
-                        let g_new = ((factor * g as f32) as u32).min(255) as u8;
-                        let b_new = ((factor * b as f32) as u32).min(255) as u8;
-
-                        let new_pixel = pixel::compose_rgb(r_new, g_new, b_new);
-                        self.set_pixel_unchecked(x, y, new_pixel);
+                        let pval = self.get_pixel(x, y).unwrap_or(0) as f32;
+                        self.set_pixel_unchecked(x, y, (factor * pval) as u32);
                     }
                 }
             }
@@ -930,7 +926,6 @@ mod tests {
     /// whole word is treated as a single gray value and multiplied without
     /// clipping (the per-channel RGB variant lives in filter::mult_constant_color).
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_multiply_constant_32bpp_matches_c() {
         let pix = Pix::new(2, 1, PixelDepth::Bit32).unwrap();
         let mut pm = pix.try_into_mut().unwrap();

--- a/src/core/pix/arith.rs
+++ b/src/core/pix/arith.rs
@@ -685,8 +685,11 @@ impl PixMut {
 
     /// Multiply all pixels by a constant factor in place.
     ///
-    /// Modifies this image so that each pixel value is multiplied by the factor.
-    /// Values are clipped to the valid range for the pixel depth.
+    /// Modifies this image so that each pixel value is multiplied by the
+    /// factor. For 8/16 bpp the result is clipped to the valid range; for
+    /// 32 bpp the whole word is treated as a single gray value and is *not*
+    /// clipped, matching C `pixMultConstantGray()` (per-channel RGB scaling
+    /// is `filter::mult_constant_color`).
     ///
     /// # Arguments
     ///

--- a/src/core/pix/arith.rs
+++ b/src/core/pix/arith.rs
@@ -926,6 +926,23 @@ enum ArithBinaryOp {
 mod tests {
     use super::*;
 
+    /// multiply_constant must reproduce C pixMultConstantGray: for 32bpp the
+    /// whole word is treated as a single gray value and multiplied without
+    /// clipping (the per-channel RGB variant lives in filter::mult_constant_color).
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_multiply_constant_32bpp_matches_c() {
+        let pix = Pix::new(2, 1, PixelDepth::Bit32).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        pm.set_pixel(0, 0, 100_000).unwrap();
+        pm.set_pixel(1, 0, 3).unwrap();
+        pm.multiply_constant_inplace(0.3).unwrap();
+        let out: Pix = pm.into();
+        // C: upval = (l_uint32)(0.3 * 100000) = 30000 (truncation, no clip)
+        assert_eq!(out.get_pixel(0, 0), Some(30_000));
+        assert_eq!(out.get_pixel(1, 0), Some(0));
+    }
+
     #[test]
     fn test_add_constant_gray() {
         let pix = Pix::new(10, 10, PixelDepth::Bit8).unwrap();

--- a/src/core/pix/arith.rs
+++ b/src/core/pix/arith.rs
@@ -57,8 +57,11 @@ impl Pix {
 
     /// Multiply all pixels by a constant factor.
     ///
-    /// Creates a new image where each pixel value is multiplied by the factor.
-    /// Values are clipped to the valid range for the pixel depth.
+    /// Creates a new image where each pixel value is multiplied by the
+    /// factor. For 8/16 bpp the result is clipped to the valid range; for
+    /// 32 bpp the whole word is treated as a single gray value and is *not*
+    /// clipped, matching C `pixMultConstantGray()` (per-channel RGB scaling
+    /// is `filter::mult_constant_color`).
     ///
     /// # Arguments
     ///

--- a/src/region/label.rs
+++ b/src/region/label.rs
@@ -982,11 +982,15 @@ pub fn conn_comp_transform_depth(
     // order of the first-encountered pixel — the same enumeration order as
     // C pixConnComp, so `label - 1` corresponds to C's component index i.
     let labeled = label_connected_components(pix, connectivity)?;
+    if out_depth == PixelDepth::Bit32 {
+        // At 32bpp the C value 1 + i equals the label itself.
+        return Ok(labeled);
+    }
     let w = labeled.width();
     let h = labeled.height();
 
     let out = Pix::new(w, h, out_depth).map_err(RegionError::Core)?;
-    let mut out_mut = out.try_into_mut().unwrap();
+    let mut out_mut = out.try_into_mut().unwrap_or_else(|p| p.to_mut());
     for y in 0..h {
         for x in 0..w {
             let label = labeled.get_pixel_unchecked(x, y);

--- a/src/region/label.rs
+++ b/src/region/label.rs
@@ -960,6 +960,20 @@ pub fn pix_loc_to_color_transform(pix: &Pix) -> RegionResult<Pix> {
     Ok(out_mut.into())
 }
 
+/// Label each connected component with a depth-limited index, exactly as
+/// C `pixConnCompTransform()`: component i (0-based, raster order of the
+/// first-encountered pixel) gets value `1 + (i % 254)` at 8bpp,
+/// `1 + (i % 0xfffe)` at 16bpp, and `1 + i` at 32bpp.
+pub fn conn_comp_transform_depth(
+    _pix: &Pix,
+    _connectivity: ConnectivityType,
+    _out_depth: PixelDepth,
+) -> RegionResult<Pix> {
+    Err(RegionError::InvalidParameters(
+        "not yet implemented".to_string(), // stub — implemented in GREEN (plan 902 PR 7)
+    ))
+}
+
 /// Get the unique sorted neighbor values for a pixel in a labeled image.
 ///
 /// Returns the set of non-zero neighboring pixel values, sorted smallest
@@ -1026,6 +1040,37 @@ pub fn pix_get_sorted_neighbor_values(
     }
 
     Ok(values.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests_c_compat {
+    use super::*;
+    use crate::core::{Pix, PixelDepth};
+
+    /// conn_comp_transform_depth must reproduce C pixConnCompTransform:
+    /// component i (0-based, in raster order of first-encountered pixel)
+    /// is labeled 1 + (i % 254) for 8bpp output.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_conn_comp_transform_depth_matches_c() {
+        // Three 4-connected components, first pixels in raster order:
+        // (1,0) → label 1, (3,0) → label 2, (0,2) → label 3.
+        let pix = Pix::new(5, 3, PixelDepth::Bit1).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        for (x, y) in [(1, 0), (1, 1), (3, 0), (0, 2), (1, 2)] {
+            pm.set_pixel(x, y, 1).unwrap();
+        }
+        let pix: Pix = pm.into();
+        let out =
+            conn_comp_transform_depth(&pix, ConnectivityType::FourWay, PixelDepth::Bit8).unwrap();
+        assert_eq!(out.depth(), PixelDepth::Bit8);
+        assert_eq!(out.get_pixel(1, 0), Some(1));
+        assert_eq!(out.get_pixel(1, 1), Some(1));
+        assert_eq!(out.get_pixel(3, 0), Some(2));
+        assert_eq!(out.get_pixel(0, 2), Some(3));
+        assert_eq!(out.get_pixel(1, 2), Some(3));
+        assert_eq!(out.get_pixel(0, 0), Some(0));
+    }
 }
 
 #[cfg(test)]

--- a/src/region/label.rs
+++ b/src/region/label.rs
@@ -965,13 +965,44 @@ pub fn pix_loc_to_color_transform(pix: &Pix) -> RegionResult<Pix> {
 /// first-encountered pixel) gets value `1 + (i % 254)` at 8bpp,
 /// `1 + (i % 0xfffe)` at 16bpp, and `1 + i` at 32bpp.
 pub fn conn_comp_transform_depth(
-    _pix: &Pix,
-    _connectivity: ConnectivityType,
-    _out_depth: PixelDepth,
+    pix: &Pix,
+    connectivity: ConnectivityType,
+    out_depth: PixelDepth,
 ) -> RegionResult<Pix> {
-    Err(RegionError::InvalidParameters(
-        "not yet implemented".to_string(), // stub — implemented in GREEN (plan 902 PR 7)
-    ))
+    if !matches!(
+        out_depth,
+        PixelDepth::Bit8 | PixelDepth::Bit16 | PixelDepth::Bit32
+    ) {
+        return Err(RegionError::InvalidParameters(
+            "out_depth must be 8, 16 or 32".to_string(),
+        ));
+    }
+
+    // label_connected_components assigns sequential 1-based labels in raster
+    // order of the first-encountered pixel — the same enumeration order as
+    // C pixConnComp, so `label - 1` corresponds to C's component index i.
+    let labeled = label_connected_components(pix, connectivity)?;
+    let w = labeled.width();
+    let h = labeled.height();
+
+    let out = Pix::new(w, h, out_depth).map_err(RegionError::Core)?;
+    let mut out_mut = out.try_into_mut().unwrap();
+    for y in 0..h {
+        for x in 0..w {
+            let label = labeled.get_pixel_unchecked(x, y);
+            if label == 0 {
+                continue;
+            }
+            let i = label - 1;
+            let val = match out_depth {
+                PixelDepth::Bit8 => 1 + (i % 254),
+                PixelDepth::Bit16 => 1 + (i % 0xfffe),
+                _ => 1 + i,
+            };
+            out_mut.set_pixel_unchecked(x, y, val);
+        }
+    }
+    Ok(out_mut.into())
 }
 
 /// Get the unique sorted neighbor values for a pixel in a labeled image.
@@ -1051,13 +1082,12 @@ mod tests_c_compat {
     /// component i (0-based, in raster order of first-encountered pixel)
     /// is labeled 1 + (i % 254) for 8bpp output.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_conn_comp_transform_depth_matches_c() {
         // Three 4-connected components, first pixels in raster order:
-        // (1,0) → label 1, (3,0) → label 2, (0,2) → label 3.
+        // (1,0) → label 1, (3,0) → label 2, (4,2) → label 3.
         let pix = Pix::new(5, 3, PixelDepth::Bit1).unwrap();
         let mut pm = pix.try_into_mut().unwrap();
-        for (x, y) in [(1, 0), (1, 1), (3, 0), (0, 2), (1, 2)] {
+        for (x, y) in [(1, 0), (1, 1), (3, 0), (4, 2)] {
             pm.set_pixel(x, y, 1).unwrap();
         }
         let pix: Pix = pm.into();
@@ -1067,8 +1097,7 @@ mod tests_c_compat {
         assert_eq!(out.get_pixel(1, 0), Some(1));
         assert_eq!(out.get_pixel(1, 1), Some(1));
         assert_eq!(out.get_pixel(3, 0), Some(2));
-        assert_eq!(out.get_pixel(0, 2), Some(3));
-        assert_eq!(out.get_pixel(1, 2), Some(3));
+        assert_eq!(out.get_pixel(4, 2), Some(3));
         assert_eq!(out.get_pixel(0, 0), Some(0));
     }
 }

--- a/src/region/mod.rs
+++ b/src/region/mod.rs
@@ -85,10 +85,10 @@ pub use conncomp::{
 // Re-export label types and functions
 pub use label::{
     ComponentStats, ConnCompTransform, IncrementalLabeler, conn_comp_transform,
-    get_component_bounds_from_labels, get_component_sizes, get_component_stats, label_to_color,
-    pix_conn_comp_incr_add, pix_conn_comp_incr_init, pix_count_components,
-    pix_get_component_bounds, pix_get_sorted_neighbor_values, pix_label_connected_components,
-    pix_loc_to_color_transform,
+    conn_comp_transform_depth, get_component_bounds_from_labels, get_component_sizes,
+    get_component_stats, label_to_color, pix_conn_comp_incr_add, pix_conn_comp_incr_init,
+    pix_count_components, pix_get_component_bounds, pix_get_sorted_neighbor_values,
+    pix_label_connected_components, pix_loc_to_color_transform,
 };
 
 // Re-export seedfill types and functions

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -418,8 +418,10 @@ italic_wordmask.04.tif	4071cc9b223b8cd3
 jbclass_corr.05.tif	842e5123f700fef3
 jbclass_haus.05.tif	7f2f146e8bb1eda3
 jbclass_wordmask.04.tif	758c03d8749670b6
-label.21.png	715814efd086eb93
-label.24.png	9be055426073ca15
+label.20.png	c6533395412a46ed
+label.23.png	715814efd086eb93
+label.24.png	4e08c1a0ab36d180
+label.27.png	9be055426073ca15
 label_color.01.png	2eaf5120a40d96c3
 label_color.02.png	0d15c7d2124c48e2
 label_color.03.png	af14a30d7c08f1a0

--- a/tests/region/label_reg.rs
+++ b/tests/region/label_reg.rs
@@ -14,8 +14,9 @@ use leptonica::PixelDepth;
 use leptonica::core::pix::{Convert16To8Type, Convert32To16Type};
 use leptonica::io::ImageFormat;
 use leptonica::region::{
-    ConnectivityType, component_area_transform, find_connected_components,
-    label_connected_components, pix_get_sorted_neighbor_values, pix_loc_to_color_transform,
+    ConnectivityType, component_area_transform, conn_comp_transform_depth,
+    find_connected_components, label_connected_components, pix_get_sorted_neighbor_values,
+    pix_loc_to_color_transform,
 };
 
 #[test]
@@ -95,6 +96,14 @@ fn label_reg() {
     eprintln!("  feyn-fract 8-way components: {}", comps_fract.len());
     rp.compare_values(1.0, if comps_fract.len() > 100 { 1.0 } else { 0.0 }, 0.0);
 
+    // --- Test 5.5: conn_comp_transform 8bpp (C check 1) ---
+    // C: pix2 = pixConnCompTransform(feyn-fract, 8, 8);
+    let cc8 = conn_comp_transform_depth(&pixf, ConnectivityType::EightWay, PixelDepth::Bit8)
+        .expect("conn_comp_transform_depth");
+    rp.compare_values(pixf.width() as f64, cc8.width() as f64, 0.0);
+    rp.write_pix_and_check(&cc8, ImageFormat::Png)
+        .expect("check: cc transform 8bpp");
+
     // --- Test 6: component_area_transform (C check 4) ---
     // C: pix2 = pixConnCompAreaTransform(feyn-fract, 8);
     //    pix3 = pixConvert32To8(pix2, L_LS_TWO_BYTES, L_CLIP_TO_FF);
@@ -108,6 +117,20 @@ fn label_reg() {
     rp.compare_values(pixf.height() as f64, area8.height() as f64, 0.0);
     rp.write_pix_and_check(&area8, ImageFormat::Png)
         .expect("check: area transform");
+
+    // --- Test 6.5: pixMultConstantGray 0.3 on the 32bpp area (C check 5) ---
+    // C: pixMultConstantGray(pix2, 0.3);
+    //    pix4 = pixConvert32To8(pix2, L_LS_TWO_BYTES, L_CLIP_TO_FF);
+    let mut area_mut = area32.try_into_mut().expect("area32 into mut");
+    area_mut
+        .multiply_constant_inplace(0.3)
+        .expect("multiply_constant 0.3");
+    let area32m: leptonica::Pix = area_mut.into();
+    let area8m = area32m
+        .convert_32_to_8(Convert32To16Type::LsTwoBytes, Convert16To8Type::ClipToFf)
+        .expect("convert scaled area to 8bpp");
+    rp.write_pix_and_check(&area8m, ImageFormat::Png)
+        .expect("check: scaled area transform");
 
     // --- Test 7: pix_loc_to_color_transform (C check 6) ---
     // C: pix5 = pixLocToColorTransform(pixRead("form1.tif"));

--- a/tests/region/label_reg.rs
+++ b/tests/region/label_reg.rs
@@ -101,6 +101,9 @@ fn label_reg() {
     let cc8 = conn_comp_transform_depth(&pixf, ConnectivityType::EightWay, PixelDepth::Bit8)
         .expect("conn_comp_transform_depth");
     rp.compare_values(pixf.width() as f64, cc8.width() as f64, 0.0);
+    // assert_eq! (index を消費しない) で高さも検証。compare_values を足すと
+    // 以降の manifest key がずれるため。
+    assert_eq!(cc8.height(), pixf.height());
     rp.write_pix_and_check(&cc8, ImageFormat::Png)
         .expect("check: cc transform 8bpp");
 


### PR DESCRIPTION
## Why

finding 009 で未対応だった C label_reg の check 1(`pixConnCompTransform` の 8bpp 出力)と check 5(`pixMultConstantGray` 0.3 倍)に対応し、C label_reg の PNG 出力 10 件を完全制覇する。

## What

- **feat**: `conn_comp_transform_depth(pix, connectivity, out_depth)` を新設 — C `pixConnCompTransform` 準拠の depth 付き cc ラベリング(8bpp: `1 + i%254`、16bpp: `1 + i%0xfffe`、32bpp: `1 + i`)
- **fix(実装差 8 件目)**: `multiply_constant` の 32bpp が RGB チャンネル毎の乗算になっていたのを、C `pixMultConstantGray` 準拠(**語全体を単一グレー値として乗算、clip なし**)に修正。RGB 変種は既存の `filter::mult_constant_color` が担当
- label テストに C 1 / C 5 の出力を追加し 2 ペアをマップ(TDD: RED → GREEN)

## 結果

**2 ペアとも即 hash 一致**(Ok 76 → **78**)。特筆事項として、Rust のラベル列挙順(raster 初出順)が C `pixConnComp` と一致することが、feyn-fract(254 超の成分 = mod 254 wrap を含む)の hash 一致で実証された。

これで **C label_reg の PNG 出力 10 件すべてが Ok**。

## Impact

- `multiply_constant` の 32bpp 挙動が変わる(利用箇所は 8bpp テストのみで影響なし)
- 全 4707 テスト通過、clippy/fmt クリーン