### PR TITLE
chore(nix): flake devShell と direnv 連携を追加

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+use flake
+
+# flake の変更を検知して自動で再ロードする
+watch_file flake.nix
+watch_file flake.lock

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /tests/golden/
 /tests/regout/
 /tests/c_compat_report.*.txt
+
+# direnv (nix-direnv) が生成する devShell のキャッシュ
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785044261,
+        "narHash": "sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "fe2124391e739e7b3e8720cd8a73f06edd0aceba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "leptonica-rs development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Rust ツールチェーンを flake.lock で固定するために使用する。
+    # nixpkgs の rustc と違い、rust-src / rust-analyzer などの
+    # コンポーネントやターゲットを宣言的に指定できる。
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, rust-overlay, ... }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      pkgsFor = forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        }
+      );
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor.${system};
+
+          # default プロファイルに rustc / cargo / rustfmt / clippy が含まれる。
+          # rust-src と rust-analyzer は rust-analyzer の補完・定義ジャンプに必要。
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
+            ];
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              rustToolchain
+              # .config/nextest.toml のプロファイル（slow-timeout、JUnit 出力）を
+              # ローカルで使うため同梱する。CI は cargo test を使用。
+              pkgs.cargo-nextest
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Why

開発環境の Rust ツールチェーンがグローバルにインストールした rustup に暗黙に依存しており、開発機ごとにバージョンやコンポーネント構成がずれる状態だった。

## What

- `flake.nix` を追加。rust-overlay の `stable.latest.default` に `rust-src` / `rust-analyzer` を加えた devShell を定義
- `.config/nextest.toml` のプロファイルをローカルで使うため `cargo-nextest` を同梱（CI は従来どおり `cargo test`）
- `.envrc` を追加。direnv (nix-direnv) がディレクトリ移動時に自動でロードする
- `.gitignore` に `/.direnv` を追加

## Impact

- 開発環境のみの変更。ソース・CI ワークフローには影響しない
- Nix を使わない環境は従来どおり任意の Rust ツールチェーンでビルドできる
- 検証: devShell 内で `rustc 1.97.1` / `cargo-nextest 0.9.140` を確認、`cargo check --all-features --all-targets` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kvk3JVSdLPR1XpET3qNtkK