### PR TITLE
fix(core/pixa): pixaDisplay を C 準拠の合成に修正 + conncomp 2 ペア追加 (plan 902 PR 8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-07-17 実測、plan 902 PR 7 後):
+- 現状ベースライン (As of 2026-08-12 実測、plan 902 PR 8 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 78 / Mismatch 29 / MissingC 0 / Unmapped 406 / Excluded 79**
+  **Ok 80 / Mismatch 29 / MissingC 0 / Unmapped 404 / Excluded 79**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -113,7 +113,19 @@ C 版ソース: `prog/label_reg.c`、`src/pixlabel.c` / `src/rop.c` / `src/shear
   `multiply_constant` 32bpp の C 準拠化 (実装差 8 件目) で
   C label_reg の PNG 出力 10 件が完全制覇 (Ok 76 → 78)
 
-### PR 8 以降: semantic マッピングの漸進追加
+### PR 8: conncomp 整列 — pixaDisplay の合成修正 (実施済み)
+
+C 版ソース: `prog/conncomp_reg.c`、`src/pixafunc2.c` (pixaDisplay)。
+
+- conncomp の pixa 再構成ペアを張る過程で **pixaDisplay の合成が
+  上書きコピーになっており、bbox が重なる成分の fg が消える**実装差
+  (9 件目) を発見。C の PIX_PAINT (OR) + 白背景初期化に修正
+- 4-cc/8-cc の再構成が原画像と bit 一致し 2 ペア Ok (Ok 78 → 80)
+- 未対応: C 11 (pixaDisplayRandomCmap、乱数依存)、C 12-18
+  (pixMakeCoveringOfRectangles — Rust 版はパラメータ意味論が異なり
+  要整列。後続 PR 候補)
+
+### PR 9 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,10 +54,10 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        | 件数    | 説明                                                                                                                              |
 | ----------- | ------: | -----------------------------------------------------------------------------------------------------------------------------     |
-| ✅ Ok       | **78**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +34)                                                   |
+| ✅ Ok       | **80**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +36)                                                   |
 | ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
 | ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
-| 📭 Unmapped | **406** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → 500 → 447 → 445 → 410 → 406)                                 |
+| 📭 Unmapped | **404** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → 500 → 447 → 445 → 410 → 406 → 404)                           |
 | 🚫 Excluded | **79**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + C 対応が JPEG/不在の distance 系 26                   |
 
 合計 573 entries が C 比較対象。Rust manifest (`tests/golden_manifest.tsv`)
@@ -74,7 +74,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 | `io`        |      7 |        2 |        0 |       41 |       10 |
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |      0 |        0 |        0 |       45 |        0 |
-| `region`    | **31** |        2 |        0 |       30 |       29 |
+| `region`    | **33** |        2 |        0 |       28 |       29 |
 | `transform` |      4 |        0 |        0 |       78 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
@@ -85,7 +85,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 - Phase 2.5 で重点的に修正を進めた領域
 
-## Ok 78 件の内訳
+## Ok 80 件の内訳
 
 C 版と完全一致している領域:
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -207,3 +207,7 @@ region	label	15	label_color	3	loc-to-color of rot270 (form1)
 region	label	19	label_color	4	loc-to-color of translate(10,10) (form1)
 region	label	23	label_color	5	loc-to-color of rotate_shear_center_ip(0.1) (form1)
 region	label	27	label_color	6	loc-to-color transform (form2)
+
+# conncomp_reg.c (plan 902 PR 8): feyn.tif の pixa 再構成 (pixaDisplay OR 合成)
+region	conncomp	3	conncomp	4	pixaDisplay of 4-cc pixa == source
+region	conncomp	8	conncomp	11	pixaDisplay of 8-cc pixa == source

--- a/src/core/pixa/mod.rs
+++ b/src/core/pixa/mod.rs
@@ -907,14 +907,28 @@ impl Pixa {
         let canvas = Pix::new(canvas_w, canvas_h, depth)?;
         let mut canvas_mut = canvas.try_into_mut().unwrap_or_else(|p: Pix| p.to_mut());
 
-        // Paint each image onto the canvas
+        // C pixaDisplay: canvases deeper than 1bpp start all-white
+        // (pixSetAll), and 1bpp components are composited with PIX_PAINT
+        // (OR) so overlapping bounding boxes do not erase earlier fg.
+        if depth != PixelDepth::Bit1 {
+            let max = depth.max_value();
+            for y in 0..canvas_h {
+                for x in 0..canvas_w {
+                    canvas_mut.set_pixel_unchecked(x, y, max);
+                }
+            }
+        }
         for (i, src) in self.pix.iter().enumerate() {
             let (ox, oy) = if let Some(b) = self.boxa.get(i) {
                 (b.x, b.y)
             } else {
                 (0, 0)
             };
-            blit_pix(&mut canvas_mut, src, ox, oy);
+            if depth == PixelDepth::Bit1 {
+                blit_pix_or(&mut canvas_mut, src, ox, oy);
+            } else {
+                blit_pix(&mut canvas_mut, src, ox, oy);
+            }
         }
 
         Ok(canvas_mut.into())
@@ -1267,6 +1281,33 @@ use crate::core::box_::{compare_relation, compare_relation_i64};
 /// For bulk image operations, row-level memcpy would be more efficient.
 ///
 /// Clips to destination bounds. Handles all pixel depths.
+/// OR-composite `src` onto `dst` at (ox, oy) — C PIX_PAINT for 1bpp.
+fn blit_pix_or(dst: &mut PixMut, src: &Pix, ox: i32, oy: i32) {
+    let dw = dst.width() as i32;
+    let dh = dst.height() as i32;
+    let sw = src.width() as i32;
+    let sh = src.height() as i32;
+
+    let src_x0 = if ox < 0 { -ox } else { 0 };
+    let src_y0 = if oy < 0 { -oy } else { 0 };
+    let src_x1 = sw.min(dw - ox);
+    let src_y1 = sh.min(dh - oy);
+
+    if src_x0 >= src_x1 || src_y0 >= src_y1 {
+        return;
+    }
+
+    for sy in src_y0..src_y1 {
+        let dy = oy + sy;
+        for sx in src_x0..src_x1 {
+            if src.get_pixel(sx as u32, sy as u32).unwrap_or(0) != 0 {
+                let dx = ox + sx;
+                dst.set_pixel_unchecked(dx as u32, dy as u32, 1);
+            }
+        }
+    }
+}
+
 fn blit_pix(dst: &mut PixMut, src: &Pix, ox: i32, oy: i32) {
     let dw = dst.width() as i32;
     let dh = dst.height() as i32;
@@ -1648,7 +1689,6 @@ mod tests {
     /// previously painted fg pixels, and canvases deeper than 1bpp start
     /// all-white (pixSetAll).
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_display_matches_c_compositing() {
         use crate::core::{Box, Pix, PixelDepth};
 

--- a/src/core/pixa/mod.rs
+++ b/src/core/pixa/mod.rs
@@ -911,12 +911,7 @@ impl Pixa {
         // (pixSetAll), and 1bpp components are composited with PIX_PAINT
         // (OR) so overlapping bounding boxes do not erase earlier fg.
         if depth != PixelDepth::Bit1 {
-            let max = depth.max_value();
-            for y in 0..canvas_h {
-                for x in 0..canvas_w {
-                    canvas_mut.set_pixel_unchecked(x, y, max);
-                }
-            }
+            canvas_mut.set_all();
         }
         for (i, src) in self.pix.iter().enumerate() {
             let (ox, oy) = if let Some(b) = self.boxa.get(i) {
@@ -1300,7 +1295,8 @@ fn blit_pix_or(dst: &mut PixMut, src: &Pix, ox: i32, oy: i32) {
     for sy in src_y0..src_y1 {
         let dy = oy + sy;
         for sx in src_x0..src_x1 {
-            if src.get_pixel(sx as u32, sy as u32).unwrap_or(0) != 0 {
+            // Loop bounds already guarantee in-range coordinates.
+            if src.get_pixel_unchecked(sx as u32, sy as u32) != 0 {
                 let dx = ox + sx;
                 dst.set_pixel_unchecked(dx as u32, dy as u32, 1);
             }

--- a/src/core/pixa/mod.rs
+++ b/src/core/pixa/mod.rs
@@ -1643,6 +1643,43 @@ impl std::ops::IndexMut<usize> for Pixaa {
 
 #[cfg(test)]
 mod tests {
+    /// display must reproduce C pixaDisplay: 1bpp components are composited
+    /// with PIX_PAINT (OR) so overlapping bounding boxes do not erase
+    /// previously painted fg pixels, and canvases deeper than 1bpp start
+    /// all-white (pixSetAll).
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_display_matches_c_compositing() {
+        use crate::core::{Box, Pix, PixelDepth};
+
+        // Two overlapping 1bpp components: a pixel of the first lies inside
+        // the second's bounding box but is bg in the second's mask.
+        let mut pixa = super::Pixa::new();
+        let a = Pix::new(3, 1, PixelDepth::Bit1).unwrap();
+        let mut am = a.try_into_mut().unwrap();
+        am.set_pixel(0, 0, 1).unwrap();
+        am.set_pixel(2, 0, 1).unwrap();
+        pixa.push_with_box(am.into(), Box::new_unchecked(0, 0, 3, 1));
+
+        let b = Pix::new(3, 1, PixelDepth::Bit1).unwrap();
+        let mut bm = b.try_into_mut().unwrap();
+        bm.set_pixel(1, 0, 1).unwrap();
+        pixa.push_with_box(bm.into(), Box::new_unchecked(0, 0, 3, 1));
+
+        let disp = pixa.display(3, 1).unwrap();
+        assert_eq!(disp.get_pixel(0, 0), Some(1), "OR must keep first fg");
+        assert_eq!(disp.get_pixel(1, 0), Some(1));
+        assert_eq!(disp.get_pixel(2, 0), Some(1), "OR must keep first fg");
+
+        // 8bpp canvas starts white (255) outside any component.
+        let mut pixa8 = super::Pixa::new();
+        let g = Pix::new(1, 1, PixelDepth::Bit8).unwrap();
+        pixa8.push_with_box(g, Box::new_unchecked(0, 0, 1, 1));
+        let disp8 = pixa8.display(3, 1).unwrap();
+        assert_eq!(disp8.get_pixel(0, 0), Some(0), "component copied as-is");
+        assert_eq!(disp8.get_pixel(2, 0), Some(255), "background is white");
+    }
+
     use super::*;
 
     fn make_test_pix(width: u32, height: u32) -> Pix {

--- a/tests/core/pixafunc_reg.rs
+++ b/tests/core/pixafunc_reg.rs
@@ -189,8 +189,9 @@ fn test_display_basic() {
     assert_eq!(canvas.height(), 30);
     // Check pixel at (10, 10) - inside the placed image
     assert_eq!(canvas.get_pixel(10, 10).unwrap(), 200);
-    // Check pixel at (0, 0) - outside, should be 0 (background)
-    assert_eq!(canvas.get_pixel(0, 0).unwrap(), 0);
+    // Check pixel at (0, 0) - outside. C pixaDisplay initializes canvases
+    // deeper than 1bpp with pixSetAll, so the background is white (255).
+    assert_eq!(canvas.get_pixel(0, 0).unwrap(), 255);
 }
 
 #[test]

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -174,8 +174,8 @@ compare_perceptual.03.png	cbef06eb92ef8f00
 compare_perceptual.04.png	a382b7cc24806911
 compfilter_write_synthetic.01.png	776f015732796ef4
 compfilter_write_synthetic.02.png	32bbb5fff34c2454
-conncomp.04.png	eaaef6841ce031cb
-conncomp.10.png	c58bc9627c1aa96a
+conncomp.04.png	063e405d5915679a
+conncomp.11.png	063e405d5915679a
 conversion_from_16bpp.04.png	ff9aba5ee2aaace0
 conversion_from_16bpp.05.png	ff9aba5ee2aaace0
 conversion_from_1bpp.07.png	ff9aba5ee2aaace0

--- a/tests/region/conncomp_reg.rs
+++ b/tests/region/conncomp_reg.rs
@@ -47,7 +47,7 @@ fn conncomp_reg() {
     // C check 4: the reassembled display must equal the source exactly.
     rp.compare_pix(&pixs, &display4);
 
-    // C check 4: reconstructed image dimensions match
+    // Rust-specific: reconstructed image dimensions match
     rp.compare_values(pixs.width() as f64, display4.width() as f64, 0.0);
     rp.compare_values(pixs.height() as f64, display4.height() as f64, 0.0);
 

--- a/tests/region/conncomp_reg.rs
+++ b/tests/region/conncomp_reg.rs
@@ -44,6 +44,8 @@ fn conncomp_reg() {
         .expect("display 4-way");
     rp.write_pix_and_check(&display4, ImageFormat::Png)
         .expect("check: conncomp 4-way display");
+    // C check 4: the reassembled display must equal the source exactly.
+    rp.compare_pix(&pixs, &display4);
 
     // C check 4: reconstructed image dimensions match
     rp.compare_values(pixs.width() as f64, display4.width() as f64, 0.0);
@@ -68,6 +70,8 @@ fn conncomp_reg() {
         .expect("display 8-way");
     rp.write_pix_and_check(&display8, ImageFormat::Png)
         .expect("check: conncomp 8-way display");
+    // C check 9: same invariant for 8-cc.
+    rp.compare_pix(&pixs, &display8);
 
     // C check 10: Boxa serialization roundtrip
     let boxa_data = boxa4.write_to_bytes().expect("serialize boxa4");


### PR DESCRIPTION
## Why

conncomp の pixa 再構成ペアを張ろうとしたところ、Rust の再構成が原画像と **529 画素**ずれていた。C `pixaDisplay` は 1bpp を **PIX_PAINT(OR)** で合成するが、Rust `Pixa::display` は上書きコピーのため、bounding box が重なる成分の fg が後続成分の bg で消されていた(実装差 9 件目)。

## What

- **fix(core/pixa)**: `display` を C 準拠に修正(TDD: RED → GREEN)
  - 1bpp 成分は OR 合成(`blit_pix_or`)
  - d>1 のキャンバスは C の `pixSetAll` 同様に白初期化
  - 誤った期待値(8bpp 背景=0)を固定していた既存テストも修正
- **test**: conncomp に C check 4/9 の `compare_pix`(再構成==原画像)を追加
- **mapping**: conncomp 2 ペア追加(4-cc/8-cc の再構成 → C conncomp.03/.08)

## 結果

修正後、4-cc/8-cc とも再構成が原画像と **diff=0** になり、**2 ペアとも hash 完全一致**。

| 指標 | 変化 |
|------|------|
| Ok | 78 → **80** |
| Unmapped | 406 → **404** |

## Impact

- `Pixa::display` の出力が変わる(1bpp: 欠落解消 / d>1: 背景が白に)。影響 golden は conncomp のみ、全 4708 テスト通過
- 未対応として C 11(乱数 colormap)と C 12-18(`pixMakeCoveringOfRectangles` のパラメータ意味論差)を plan 902 に記録(後続 PR 候補)