### PR TITLE
feat(core/pix): make_covering_of_rectangles を C 準拠に書き直し + conncomp 6 ペア追加 (plan 902 PR 9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-12 実測、plan 902 PR 8 後):
+- 現状ベースライン (As of 2026-08-13 実測、plan 902 PR 9 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 80 / Mismatch 29 / MissingC 0 / Unmapped 404 / Excluded 79**
+  **Ok 86 / Mismatch 29 / MissingC 0 / Unmapped 404 / Excluded 79**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -125,7 +125,18 @@ C 版ソース: `prog/conncomp_reg.c`、`src/pixafunc2.c` (pixaDisplay)。
   (pixMakeCoveringOfRectangles — Rust 版はパラメータ意味論が異なり
   要整列。後続 PR 候補)
 
-### PR 9 以降: semantic マッピングの漸進追加
+### PR 9: covering of rectangles の C 準拠化 (実施済み)
+
+C 版ソース: `src/pix5.c` (pixMakeCoveringOfRectangles)。
+
+- `make_covering_of_rectangles` を C 準拠 (maxiters 指定、PIX 返し、
+  bbox 塗り→再ラベル→収束) に書き直し (旧 Rust 版は distance 拡張の
+  Boxa 返しで意味論が異なった)
+- C 12-17 の 6 ペア (rank cascade + covering ×5) が全件即 hash 一致
+  (Ok 80 → 86)。conncomp は乱数依存の C 11 と composite の C 18 を
+  除き全 PNG 出力が Ok
+
+### PR 10 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,7 +54,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        | 件数    | 説明                                                                                                                              |
 | ----------- | ------: | -----------------------------------------------------------------------------------------------------------------------------     |
-| ✅ Ok       | **80**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +36)                                                   |
+| ✅ Ok       | **86**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +42)                                                   |
 | ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
 | ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
 | 📭 Unmapped | **404** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → 500 → 447 → 445 → 410 → 406 → 404)                           |
@@ -74,7 +74,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 | `io`        |      7 |        2 |        0 |       41 |       10 |
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |      0 |        0 |        0 |       45 |        0 |
-| `region`    | **33** |        2 |        0 |       28 |       29 |
+| `region`    | **39** |        2 |        0 |       28 |       29 |
 | `transform` |      4 |        0 |        0 |       78 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
@@ -85,7 +85,7 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 - Phase 2.5 で重点的に修正を進めた領域
 
-## Ok 80 件の内訳
+## Ok 86 件の内訳
 
 C 版と完全一致している領域:
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -211,3 +211,9 @@ region	label	27	label_color	6	loc-to-color transform (form2)
 # conncomp_reg.c (plan 902 PR 8): feyn.tif の pixa 再構成 (pixaDisplay OR 合成)
 region	conncomp	3	conncomp	4	pixaDisplay of 4-cc pixa == source
 region	conncomp	8	conncomp	11	pixaDisplay of 8-cc pixa == source
+region	conncomp	12	conncomp	14	rank binary cascade (rabi.png, levels 1,1,1)
+region	conncomp	13	conncomp	15	covering of rectangles maxiters=1
+region	conncomp	14	conncomp	16	covering of rectangles maxiters=2
+region	conncomp	15	conncomp	17	covering of rectangles maxiters=3
+region	conncomp	16	conncomp	18	covering of rectangles maxiters=4
+region	conncomp	17	conncomp	19	covering of rectangles maxiters=5

--- a/src/core/pix/measurement.rs
+++ b/src/core/pix/measurement.rs
@@ -432,66 +432,23 @@ impl Pix {
         Ok(pix)
     }
 
-    /// Create a set of non-overlapping rectangles that cover all foreground.
+    /// Create a mask of non-overlapping rectangles that covers all foreground.
     ///
-    /// For 1bpp. Iteratively expands bounding boxes of connected components
-    /// until convergence, grouping nearby foreground into covering rectangles.
-    ///
-    /// * `distance` - expansion distance per iteration for merging nearby components.
+    /// For 1bpp. Reproduces C `pixMakeCoveringOfRectangles()`: fill the
+    /// bounding boxes of the 8-connected components, then repeatedly re-box
+    /// and re-fill the result until it stops changing or `maxiters`
+    /// iterations were run (`maxiters == 0` means "until convergence",
+    /// like C's internal cap of 50).
     ///
     /// C equivalent: `pixMakeCoveringOfRectangles()` in `pix5.c`
-    pub fn make_covering_of_rectangles(&self, distance: u32) -> Result<Boxa> {
+    pub fn make_covering_of_rectangles(&self, maxiters: u32) -> Result<Pix> {
         if self.depth() != PixelDepth::Bit1 {
             return Err(Error::UnsupportedDepth(self.depth().bits()));
         }
-        let w = self.width();
-        let h = self.height();
-
-        // Start with CC bounding boxes
-        let (initial_boxa, _pixa) =
-            crate::region::conncomp_pixa(self, crate::region::ConnectivityType::EightWay)
-                .map_err(|e| Error::InvalidParameter(e.to_string()))?;
-
-        if initial_boxa.is_empty() {
-            return Ok(Boxa::new());
-        }
-
-        let dist = distance as i32;
-        let max_iters = 20;
-        let mut current_boxa = initial_boxa;
-
-        for _ in 0..max_iters {
-            // Paint expanded bounding boxes into a mask
-            let canvas = Pix::new(w, h, PixelDepth::Bit1)?;
-            let mut canvas_mut = canvas.try_into_mut().unwrap_or_else(|p| p.to_mut());
-            for b in current_boxa.boxes() {
-                let x0 = (b.x - dist).max(0) as u32;
-                let y0 = (b.y - dist).max(0) as u32;
-                let x1 = ((b.x + b.w + dist) as u32).min(w);
-                let y1 = ((b.y + b.h + dist) as u32).min(h);
-                for y in y0..y1 {
-                    for x in x0..x1 {
-                        canvas_mut.set_pixel_unchecked(x, y, 1);
-                    }
-                }
-            }
-            let canvas_pix: Pix = canvas_mut.into();
-
-            // Extract new CCs from the expanded mask
-            let (new_boxa, _) = crate::region::conncomp_pixa(
-                &canvas_pix,
-                crate::region::ConnectivityType::EightWay,
-            )
-            .map_err(|e| Error::InvalidParameter(e.to_string()))?;
-
-            // Check convergence
-            if new_boxa.len() == current_boxa.len() {
-                return Ok(new_boxa);
-            }
-            current_boxa = new_boxa;
-        }
-
-        Ok(current_boxa)
+        let _ = maxiters;
+        Err(Error::InvalidParameter(
+            "not yet implemented".to_string(), // stub — implemented in GREEN (plan 902 PR 9)
+        ))
     }
 }
 

--- a/src/core/pix/measurement.rs
+++ b/src/core/pix/measurement.rs
@@ -3,7 +3,7 @@
 //! Functions for computing area, perimeter, and overlap ratios.
 //! Corresponds to functions in C Leptonica's `pix5.c`.
 
-use super::{Pix, PixelDepth};
+use super::{Pix, PixMut, PixelDepth};
 use crate::core::box_::{Boxa, SizeRelation};
 use crate::core::error::{Error, Result};
 use crate::core::pixa::Pixa;
@@ -445,10 +445,49 @@ impl Pix {
         if self.depth() != PixelDepth::Bit1 {
             return Err(Error::UnsupportedDepth(self.depth().bits()));
         }
-        let _ = maxiters;
-        Err(Error::InvalidParameter(
-            "not yet implemented".to_string(), // stub — implemented in GREEN (plan 902 PR 9)
-        ))
+        // C: maxiters == 0 → internal cap of 50 ("until convergence").
+        let maxiters = if maxiters == 0 { 50 } else { maxiters };
+
+        let w = self.width();
+        let h = self.height();
+        let out = Pix::new(w, h, PixelDepth::Bit1)?;
+        if self.count_pixels() == 0 {
+            return Ok(out);
+        }
+
+        // Fill the bounding boxes of the 8-connected components, then
+        // repeatedly re-box and re-fill until the mask stops changing.
+        let fill_boxes = |src: &Pix, dst: &mut PixMut| -> Result<()> {
+            let comps = crate::region::find_connected_components(
+                src,
+                crate::region::ConnectivityType::EightWay,
+            )
+            .map_err(|e| Error::InvalidParameter(e.to_string()))?;
+            let boxa: Boxa = comps.iter().map(|c| c.bounds).collect();
+            dst.mask_boxa(&boxa, super::graphics::PixelOp::Set);
+            Ok(())
+        };
+
+        let mut cur = out.try_into_mut().unwrap_or_else(|p| p.to_mut());
+        fill_boxes(self, &mut cur)?;
+        let mut cur: Pix = cur.into();
+        if maxiters == 1 {
+            return Ok(cur);
+        }
+
+        for _ in 1..maxiters {
+            let mut next = cur
+                .deep_clone()
+                .try_into_mut()
+                .unwrap_or_else(|p| p.to_mut());
+            fill_boxes(&cur, &mut next)?;
+            let next: Pix = next.into();
+            if next.equals(&cur) {
+                return Ok(next);
+            }
+            cur = next;
+        }
+        Ok(cur)
     }
 }
 

--- a/tests/core/core_coverage_reg.rs
+++ b/tests/core/core_coverage_reg.rs
@@ -464,11 +464,11 @@ fn filter_component_by_size() {
 
 /// `make_covering_of_rectangles` must reproduce C
 /// `pixMakeCoveringOfRectangles()`. Expected values hand-computed from the
-/// C algorithm: components {(0,0),(1,1)} (one 8-cc, bbox 2x2) and {(2,2)};
-/// after the first boxing the filled 2x2 block touches (2,2) 8-connectedly,
-/// so the second iteration merges them into a 3x3 box.
+/// C algorithm: components {(0,1),(1,0)} (one 8-cc, bbox 2x2) and {(2,2)}
+/// (not 8-adjacent to either pixel); the first boxing fills (1,1), which
+/// touches (2,2) 8-connectedly, so the second iteration merges them into
+/// a 3x3 box.
 #[test]
-#[ignore = "not yet implemented"]
 fn make_covering_of_rectangles() {
     let pix = Pix::new(20, 20, PixelDepth::Bit1).unwrap();
     let covering = pix.make_covering_of_rectangles(2).unwrap();
@@ -478,7 +478,7 @@ fn make_covering_of_rectangles() {
 
     let pix = Pix::new(4, 4, PixelDepth::Bit1).unwrap();
     let mut pm = pix.try_into_mut().unwrap();
-    for (x, y) in [(0, 0), (1, 1), (2, 2)] {
+    for (x, y) in [(0, 1), (1, 0), (2, 2)] {
         pm.set_pixel(x, y, 1).unwrap();
     }
     let pix: Pix = pm.into();

--- a/tests/core/core_coverage_reg.rs
+++ b/tests/core/core_coverage_reg.rs
@@ -462,14 +462,39 @@ fn filter_component_by_size() {
     assert_eq!(result.width(), 20);
 }
 
-/// Test `Pix::make_covering_of_rectangles` – create covering rectangles.
+/// `make_covering_of_rectangles` must reproduce C
+/// `pixMakeCoveringOfRectangles()`. Expected values hand-computed from the
+/// C algorithm: components {(0,0),(1,1)} (one 8-cc, bbox 2x2) and {(2,2)};
+/// after the first boxing the filled 2x2 block touches (2,2) 8-connectedly,
+/// so the second iteration merges them into a 3x3 box.
 #[test]
-
+#[ignore = "not yet implemented"]
 fn make_covering_of_rectangles() {
     let pix = Pix::new(20, 20, PixelDepth::Bit1).unwrap();
-    let boxa = pix.make_covering_of_rectangles(2).unwrap();
-    // No foreground → no covering rects
-    assert_eq!(boxa.len(), 0);
+    let covering = pix.make_covering_of_rectangles(2).unwrap();
+    // No foreground → empty mask of the same size
+    assert_eq!((covering.width(), covering.height()), (20, 20));
+    assert_eq!(covering.count_pixels(), 0);
+
+    let pix = Pix::new(4, 4, PixelDepth::Bit1).unwrap();
+    let mut pm = pix.try_into_mut().unwrap();
+    for (x, y) in [(0, 0), (1, 1), (2, 2)] {
+        pm.set_pixel(x, y, 1).unwrap();
+    }
+    let pix: Pix = pm.into();
+
+    // maxiters = 1: just the filled bounding boxes (2x2 block + 1 px).
+    let one = pix.make_covering_of_rectangles(1).unwrap();
+    assert_eq!(one.count_pixels(), 5);
+
+    // Until convergence: second iteration merges into a 3x3 box.
+    let full = pix.make_covering_of_rectangles(0).unwrap();
+    assert_eq!(full.count_pixels(), 9);
+    for y in 0..3 {
+        for x in 0..3 {
+            assert_eq!(full.get_pixel(x, y), Some(1), "pixel ({x}, {y})");
+        }
+    }
 }
 
 /// Test `Pix::reversal_profile` – count reversals along rows/columns.

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -176,6 +176,12 @@ compfilter_write_synthetic.01.png	776f015732796ef4
 compfilter_write_synthetic.02.png	32bbb5fff34c2454
 conncomp.04.png	063e405d5915679a
 conncomp.11.png	063e405d5915679a
+conncomp.14.png	42b54790faa297cc
+conncomp.15.png	493b24d863e61eac
+conncomp.16.png	5dcb067b35a000ad
+conncomp.17.png	604361cbc25220ed
+conncomp.18.png	5b50b1d54cefe4ad
+conncomp.19.png	8c3cd7c98217d09c
 conversion_from_16bpp.04.png	ff9aba5ee2aaace0
 conversion_from_16bpp.05.png	ff9aba5ee2aaace0
 conversion_from_1bpp.07.png	ff9aba5ee2aaace0

--- a/tests/region/conncomp_reg.rs
+++ b/tests/region/conncomp_reg.rs
@@ -78,14 +78,6 @@ fn conncomp_reg() {
     let boxa_rt = leptonica::Boxa::read_from_bytes(&boxa_data).expect("deserialize boxa4");
     rp.compare_values(n1 as f64, boxa_rt.len() as f64, 0.0);
 
-    // C checks 12-17: covering rectangles with increasing distance
-    for dist in [1, 2, 3] {
-        let covering = pixs
-            .make_covering_of_rectangles(dist)
-            .expect("covering rects");
-        rp.compare_values(1.0, if !covering.is_empty() { 1.0 } else { 0.0 }, 0.0);
-    }
-
     // 8-way should find fewer or equal components than 4-way
     assert!(n2 <= n1);
 

--- a/tests/region/conncomp_reg.rs
+++ b/tests/region/conncomp_reg.rs
@@ -93,5 +93,23 @@ fn conncomp_reg() {
         );
     }
 
+    // C checks 12-17: rank-binary reduction of rabi.png, then coverings of
+    // rectangles with maxiters 1..5 (same inputs and parameters as C).
+    // C: pix2 = pixReduceRankBinaryCascade(pixRead("rabi.png"), 1, 1, 1, 0);
+    let rabi = load_test_image("rabi.png").expect("load rabi.png");
+    let reduced = leptonica::transform::reduce_rank_binary_cascade(&rabi, &[1, 1, 1])
+        .expect("reduce_rank_binary_cascade");
+    rp.write_pix_and_check(&reduced, ImageFormat::Png)
+        .expect("check: rank cascade");
+
+    // C: pix3 = pixMakeCoveringOfRectangles(pix2, i) for i in 1..=5
+    for maxiters in 1..=5u32 {
+        let covering = reduced
+            .make_covering_of_rectangles(maxiters)
+            .expect("make_covering_of_rectangles");
+        rp.write_pix_and_check(&covering, ImageFormat::Png)
+            .expect("check: covering of rectangles");
+    }
+
     assert!(rp.cleanup(), "conncomp regression test failed");
 }


### PR DESCRIPTION
## Why

conncomp C 12-17 のペアを張るため。Rust の `make_covering_of_rectangles` は distance 拡張で Boxa を返す実装で、C `pixMakeCoveringOfRectangles`(maxiters 指定、PIX 返し、bbox 塗り→再ラベル→収束反復)と**意味論から異なっていた**(実装差 10 件目)。

## What

- **TDD RED→GREEN**: `make_covering_of_rectangles(maxiters: u32) -> Result<Pix>` に C 準拠で書き直し(maxiters=0 は C の内部上限 50 と同じ「収束まで」)。手計算期待値(bbox 塗りで生まれた画素が第2反復で隣接成分と併合するケース)で固定
- conncomp テストに C 12-17 の系列(`reduce_rank_binary_cascade(rabi, [1,1,1])` + covering maxiters 1..5)を追加し 6 ペアをマップ

## 結果

**6 ペアとも即 hash 一致**(cascade も新 covering も C 等価)。

| 指標 | 変化 |
|------|------|
| Ok | 80 → **86** |

conncomp は乱数依存の C 11(pixaDisplayRandomCmap)と composite の C 18 を除き、全 PNG 出力が Ok になりました。

## Impact

- `make_covering_of_rectangles` のシグネチャが変わる breaking change(利用箇所は 2 テストのみ、更新済み)
- 全 4708 テスト通過、clippy/fmt クリーン