### PR TITLE
feat(c-compat): falsecolor 整列 — color の合成入力 8 ペア全件 Ok (plan 902 PR 11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-13 実測、plan 902 PR 10 後):
+- 現状ベースライン (As of 2026-08-13 実測、plan 902 PR 11 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 90 / Mismatch 29 / MissingC 0 / Unmapped 407 / Excluded 79**
+  **Ok 98 / Mismatch 29 / MissingC 0 / Unmapped 403 / Excluded 83**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -149,7 +149,23 @@ C 版ソース: `src/quadtree.c` / `src/pixafunc2.c` / `src/scale2.c`。
   (base 7px スケール) で C のビットマップフォント実体と行高が異なるため
   pixel 不一致。C フォントデータ (bmfdata) の移植が必要 (後続 PR 候補)
 
-### PR 11 以降: semantic マッピングの漸進追加
+### PR 11: falsecolor 整列 — color の合成入力系列 (実施済み)
+
+C 版ソース: `prog/falsecolor_reg.c`、`src/pixconv.c` / `src/colormap.c`。
+
+- C prog と同一の合成入力 (768x100 の 8/16bpp gradient) で
+  `convert_gray_to_false_color` を gamma {1.0, 2.0, 3.0} で適用する
+  `falsecolor_c_compat` を追加し、C の 8 出力 (全 PNG) と 8 ペア
+  **全件即 hash 一致 (Ok 90 → 98)**。実装は既に C と等価だった
+- pixel hash は colormap を含まないため、gamma 別 colormap
+  (256 エントリ) は C 出力との decode 後比較で bit 一致を別途実証
+- Rust 独自 API (pix_linear_map_to_target_color 等) の falsecolor.*
+  4 件は C 対応が無く prefix 除外 (Unmapped 407 → 403)
+- **見送り**: coloring_reg (harmoniam100-11.png、PNG 14 件) は全出力が
+  pixAddSingleTextblock (bmf フォント) 経由のため、quadtree 02-04 と
+  同じく bmfdata 移植が前提 (後続 PR 候補)
+
+### PR 12 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,21 +54,21 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        | 件数    | 説明                                                                                                                              |
 | ----------- | ------: | -----------------------------------------------------------------------------------------------------------------------------     |
-| ✅ Ok       | **90**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +46)                                                   |
+| ✅ Ok       | **98**  | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +54)                                                   |
 | ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
 | ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
-| 📭 Unmapped | **407** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 404 → 407 = quadtree display 3 件の新規出力を含む)       |
-| 🚫 Excluded | **79**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + C 対応が JPEG/不在の distance 系 26                   |
+| 📭 Unmapped | **403** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 407 → 403)                                               |
+| 🚫 Excluded | **83**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + Rust 独自 falsecolor 4               |
 
-合計 573 entries が C 比較対象。Rust manifest (`tests/golden_manifest.tsv`)
-全体は **580 entries** (582 行 - ヘッダ 2 行)。加えて Rust 独自テスト 84
-件 (C 版に対応なし)。
+合計 613 entries がレポート対象 (As of 2026-08-13、plan 902 PR 11 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **620 entries**
+(622 行 - ヘッダ 2 行)。
 
 ## test binary 別の内訳
 
 | Binary      |     Ok | Mismatch | MissingC | Unmapped | Excluded |
 | ----------- | -----: | -------: | -------: | -------: | -------: |
-| `color`     |      3 |        4 |        0 |      112 |        0 |
+| `color`     |     11 |        4 |        0 |      108 |        4 |
 | `core`      |      1 |        0 |        0 |       34 |        0 |
 | `filter`    |      2 |        5 |        0 |       57 |       40 |
 | `io`        |      7 |        2 |        0 |       41 |       10 |

--- a/scripts/c_compat_exclude.tsv
+++ b/scripts/c_compat_exclude.tsv
@@ -25,3 +25,4 @@ key	dist_contours.14.png	C counterpart a+6 is JPEG (finding 001)
 key	dist_contours.16.png	C counterpart a+6 is JPEG (finding 001)
 key	dist_seedfill.05.png	C b-section writes only JPEG (b+1..b+3, finding 001)
 key	dist_seedfill.06.png	C b-section writes only JPEG (b+1..b+3, finding 001)
+prefix	falsecolor	Rust-specific color-mapping API outputs; C falsecolor_reg outputs are paired via falsecolor_c

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -223,3 +223,13 @@ region	quadtree	0	quadtree_c	1	boxaa quadtree regions 1000x500 nlevels=3 (serial
 region	quadtree	1	quadtree_c	2	boxaa quadtree regions 1001x501 nlevels=3 (serialized)
 region	quadtree	5	quadtree_c	6	average_tiled 5x6 MeanAbsVal + expand 4x
 region	quadtree	6	quadtree_c	7	average_tiled 5x6 StdDev + expand 4x
+
+# falsecolor_reg.c (plan 902 PR 11): synthetic 768x100 gradients + false color
+color	falsecolor	0	falsecolor_c	1	8bpp horizontal gradient
+color	falsecolor	1	falsecolor_c	2	16bpp horizontal gradient
+color	falsecolor	2	falsecolor_c	3	false color 8bpp gamma=1.0
+color	falsecolor	3	falsecolor_c	4	false color 8bpp gamma=2.0
+color	falsecolor	4	falsecolor_c	5	false color 8bpp gamma=3.0
+color	falsecolor	5	falsecolor_c	6	false color 16bpp gamma=1.0
+color	falsecolor	6	falsecolor_c	7	false color 16bpp gamma=2.0
+color	falsecolor	7	falsecolor_c	8	false color 16bpp gamma=3.0

--- a/tests/color/falsecolor_reg.rs
+++ b/tests/color/falsecolor_reg.rs
@@ -80,3 +80,66 @@ fn falsecolor_reg() {
 
     assert!(rp.cleanup(), "falsecolor regression test failed");
 }
+
+/// C-comparable false color conversion (plan 902 PR 11).
+///
+/// Mirrors C falsecolor_reg exactly: 768x100 synthetic 8bpp / 16bpp
+/// horizontal gradients, then `convert_gray_to_false_color` with
+/// gamma in {1.0, 2.0, 3.0}. All eight outputs pair with C
+/// falsecolor.00-07 (lossless PNG, no codec ambiguity).
+#[test]
+fn falsecolor_c_compat() {
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("falsecolor_c");
+
+    // C: pixCreate(768, 100, 8/16) with val = 0xff * j / 768 (0xffff for 16)
+    let pix8 = {
+        let p = Pix::new(768, 100, PixelDepth::Bit8).expect("create 8bpp gradient");
+        let mut pm = p.try_into_mut().expect("mutable 8bpp gradient");
+        for y in 0..100 {
+            for x in 0..768u32 {
+                pm.set_pixel_unchecked(x, y, 0xff * x / 768);
+            }
+        }
+        let p: Pix = pm.into();
+        p
+    };
+    let pix16 = {
+        let p = Pix::new(768, 100, PixelDepth::Bit16).expect("create 16bpp gradient");
+        let mut pm = p.try_into_mut().expect("mutable 16bpp gradient");
+        for y in 0..100 {
+            for x in 0..768u32 {
+                pm.set_pixel_unchecked(x, y, 0xffff * x / 768);
+            }
+        }
+        let p: Pix = pm.into();
+        p
+    };
+
+    // C checks 0-1: the raw gradients
+    rp.write_pix_and_check(&pix8, ImageFormat::Png)
+        .expect("check: 8bpp gradient");
+    rp.write_pix_and_check(&pix16, ImageFormat::Png)
+        .expect("check: 16bpp gradient");
+
+    // C checks 2-4 (8bpp) and 5-7 (16bpp): false color with gamma sweep
+    for gamma in [1.0f32, 2.0, 3.0] {
+        let fc = pix8
+            .convert_gray_to_false_color(gamma)
+            .expect("false color 8bpp");
+        rp.write_pix_and_check(&fc, ImageFormat::Png)
+            .expect("check: false color 8bpp");
+    }
+    for gamma in [1.0f32, 2.0, 3.0] {
+        let fc = pix16
+            .convert_gray_to_false_color(gamma)
+            .expect("false color 16bpp");
+        rp.write_pix_and_check(&fc, ImageFormat::Png)
+            .expect("check: false color 16bpp");
+    }
+
+    assert!(rp.cleanup(), "falsecolor c-compat test failed");
+}

--- a/tests/color/falsecolor_reg.rs
+++ b/tests/color/falsecolor_reg.rs
@@ -125,18 +125,30 @@ fn falsecolor_c_compat() {
     rp.write_pix_and_check(&pix16, ImageFormat::Png)
         .expect("check: 16bpp gradient");
 
+    // The manifest hash covers only pixel (index) values, not the colormap,
+    // so assert the gamma-dependent colormap entries directly. Expected
+    // values follow C pixcmapGrayToFalseColor: for index 0,
+    // bval = (int)(255 * (32/64)^(1/gamma) + 0.5).
+    let expected_index0_blue = [128u8, 180, 202]; // gamma 1.0 / 2.0 / 3.0
+
     // C checks 2-4 (8bpp) and 5-7 (16bpp): false color with gamma sweep
-    for gamma in [1.0f32, 2.0, 3.0] {
+    for (gamma, blue) in [1.0f32, 2.0, 3.0].into_iter().zip(expected_index0_blue) {
         let fc = pix8
             .convert_gray_to_false_color(gamma)
             .expect("false color 8bpp");
+        let cmap = fc.colormap().expect("false color colormap");
+        assert_eq!(cmap.len(), 256);
+        assert_eq!(cmap.get_rgb(0).unwrap(), (0, 0, blue), "gamma={gamma}");
+        assert_eq!(cmap.get_rgb(255).unwrap(), (blue, 0, 0), "gamma={gamma}");
         rp.write_pix_and_check(&fc, ImageFormat::Png)
             .expect("check: false color 8bpp");
     }
-    for gamma in [1.0f32, 2.0, 3.0] {
+    for (gamma, blue) in [1.0f32, 2.0, 3.0].into_iter().zip(expected_index0_blue) {
         let fc = pix16
             .convert_gray_to_false_color(gamma)
             .expect("false color 16bpp");
+        let cmap = fc.colormap().expect("false color colormap");
+        assert_eq!(cmap.get_rgb(0).unwrap(), (0, 0, blue), "gamma={gamma}");
         rp.write_pix_and_check(&fc, ImageFormat::Png)
             .expect("check: false color 16bpp");
     }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -306,6 +306,14 @@ falsecolor.03.png	e1729a66a0725609
 falsecolor.06.png	c536660e633daa41
 falsecolor.09.png	a659e972dfc22341
 falsecolor.10.png	b5a98292b3f3b1c9
+falsecolor_c.01.png	c462e8380057cb18
+falsecolor_c.02.png	b8c8e1d8204be5a0
+falsecolor_c.03.png	c462e8380057cb18
+falsecolor_c.04.png	c462e8380057cb18
+falsecolor_c.05.png	c462e8380057cb18
+falsecolor_c.06.png	94fed38e9c8f1218
+falsecolor_c.07.png	94fed38e9c8f1218
+falsecolor_c.08.png	94fed38e9c8f1218
 fhmtauto_hmt.02.tif	d0bab16c9501e70e
 fhmtauto_hmt.04.tif	80991a8414a1539f
 fhmtauto_hmt.06.tif	a0eee581b93887ce


### PR DESCRIPTION
## Why

plan 902 (C 互換 Unmapped 削減) の PR 11。優先度表で最上位だった color
binary は Ok が paintmask 系 3 件のみで、C 比較の未開拓領域だった。
falsecolor_reg は C 側が完全合成入力 (pixCreate による gradient) で
全 8 出力が lossless PNG のため、codec 差の影響なしに pixel-level の
C 互換を検証できる。

## What

- `tests/color/falsecolor_reg.rs`: C prog/falsecolor_reg.c と同一条件の
  `falsecolor_c_compat` を追加 — 768x100 の 8bpp / 16bpp 水平 gradient
  (val = 0xff·j/768, 0xffff·j/768) に `convert_gray_to_false_color` を
  gamma {1.0, 2.0, 3.0} で適用し、falsecolor_c.01-08 を書き出す
- `scripts/golden_map.tsv`: C falsecolor.00-07 ↔ Rust falsecolor_c.01-08
  の 8 ペアを追加。**全件即 hash 一致 (Ok 90 → 98)** — 実装
  (`convert_gray_to_false_color` / `PixColormap::gray_to_false_color`)
  は既に C と bit 等価だったことを実証
- pixel hash は colormap を含まないため、gamma 別の colormap
  (256 エントリ RGB) は C 出力ファイルとの decode 後比較で全 8 ペアの
  colormap・pixel 完全一致を別途確認済み
- `scripts/c_compat_exclude.tsv`: Rust 独自 API
  (pix_linear_map_to_target_color 等) の falsecolor.* 4 件は C 対応が
  存在しないため prefix ルールで Excluded に分離 (Unmapped 407 → 403)
- docs: c-compat-status.md / plan 902 / CLAUDE.md のベースライン更新

見送り: coloring_reg (PNG 14 件) は全出力が pixAddSingleTextblock
(bmf フォント) 経由のため bmfdata 移植が前提 (quadtree 02-04 と同根、
後続 PR 候補)。

## Impact

- ベースライン: **Ok 98 / Mismatch 29 / MissingC 0 / Unmapped 403 /
  Excluded 83**
- color binary: Ok 3 → 11 (Mismatch 増なし)
- ライブラリ本体のコード変更なし (テスト + TSV + docs のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg