### PR TITLE
feat(c-compat): translate / shear2 整列 — cmapped 経路の実装差 4 件修正で 7 ペア全件 Ok (plan 902 PR 15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-13 実測、plan 902 PR 14 後):
+- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 15 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 133 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 83**
+  **Ok 140 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 83**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -276,7 +276,27 @@ codec 差なしで主要変換 9 種を一挙に検証できる:
 - smallpix 9 ペア **全件 Ok (Ok 124 → 133)**。transform binary が
   Ok 4 → 13 になり、主要変換 9 種の C 等価性を実証
 
-### PR 15 以降: semantic マッピングの漸進追加
+### PR 15: translate / shear2 整列 — transform の残り lossless (IN_PROGRESS)
+
+C 版ソース: `prog/translate_reg.c` / `prog/shear2_reg.c`、
+`src/rop.c` / `src/warper.c`。
+
+PR 14 で `display_tiled_in_columns` を移植し、両 prog の前提が揃った。
+どちらも全出力が PNG で、入力は lossless (weasel2.4c.png) または完全合成。
+
+| C prog | 出力 | 入力 | 使用関数 |
+| --- | --: | --- | --- |
+| translate | 3 | weasel2.4c.png | pixTranslate x 4 種 x 深度別 |
+| shear2 | 4 | 合成 (RenderLineArb) | pixQuadraticVShear (sampled/interp) |
+
+作業内容:
+
+1. translate_c テスト: C と同条件 (3x sampling → clip 209x214、
+   cmap 除去 2 種 + 1bpp 化 + rotate_am 4 種) で 3 出力
+2. shear2_c テスト: C と同条件 (301/601 の合成 RGB に 6 本の色線、
+   sampled/interp x left/right、border 3 + textblock) で 4 出力
+
+### PR 16 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -276,7 +276,7 @@ codec 差なしで主要変換 9 種を一挙に検証できる:
 - smallpix 9 ペア **全件 Ok (Ok 124 → 133)**。transform binary が
   Ok 4 → 13 になり、主要変換 9 種の C 等価性を実証
 
-### PR 15: translate / shear2 整列 — transform の残り lossless (IN_PROGRESS)
+### PR 15: translate / shear2 整列 — transform の残り lossless (実施済み)
 
 C 版ソース: `prog/translate_reg.c` / `prog/shear2_reg.c`、
 `src/rop.c` / `src/warper.c`。
@@ -295,6 +295,19 @@ PR 14 で `display_tiled_in_columns` を移植し、両 prog の前提が揃っ�
    cmap 除去 2 種 + 1bpp 化 + rotate_am 4 種) で 3 出力
 2. shear2_c テスト: C と同条件 (301/601 の合成 RGB に 6 本の色線、
    sampled/interp x left/right、border 3 + textblock) で 4 出力
+
+実施結果:
+
+- **cmapped 経路の実装差 4 件 (18-21 件目) を発見・修正**:
+  (18) convert_to_8 が colormap を無視 (8bpp cmapped を deep copy)、
+  (19) **clip_rectangle が colormap を落とす** — 以降の
+  remove_colormap / convert_* が全て無効化される根本原因、
+  (20) rasterop_hip/vip の cmapped 充填が生値 (0 / max) で
+  get_rank_intensity の index を使っていない、
+  (21) 32bpp warp の白充填が 0xffffff00 (C は pixSetAll = 0xffffffff)
+- あわせて convert_to_1 (C pixConvertTo1) を新規実装
+- translate 3 ペア + shear2 4 ペア **全件 Ok (Ok 133 → 140)**。
+  transform binary は Ok 13 → 20
 
 ### PR 16 以降: semantic マッピングの漸進追加
 

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,14 +54,14 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        | 件数    | 説明                                                                                                                              |
 | ----------- | ------: | -----------------------------------------------------------------------------------------------------------------------------     |
-| ✅ Ok       | **133** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +89)                                                   |
+| ✅ Ok       | **140** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +96)                                                   |
 | ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
 | ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
 | 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                               |
 | 🚫 Excluded | **83**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + Rust 独自 falsecolor 4               |
 
-合計 645 entries がレポート対象 (As of 2026-08-13、plan 902 PR 14 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **652 entries**。
+合計 652 entries がレポート対象 (As of 2026-08-16、plan 902 PR 15 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **659 entries**。
 
 ## test binary 別の内訳
 
@@ -74,7 +74,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **652 entries**。
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |      9 |        0 |        0 |       45 |        0 |
 | `region`    | **46** |        2 |        0 |       28 |       29 |
-| `transform` |     13 |        0 |        0 |       78 |        0 |
+| `transform` |     20 |        0 |        0 |       78 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -279,3 +279,9 @@ transform	smallpix	8	smallpix_c	9	scale_li sweep 1.0-3.0
 transform	translate	0	translate_c	1	translate 4 ways x cmap/gray/rgb/1bpp
 transform	translate	1	translate_c	2	translate 4 ways x gray/rotate_am(+0.25)
 transform	translate	2	translate_c	3	translate 4 ways x 8 variants
+
+# shear2_reg.c (plan 902 PR 15): synthetic RGB canvases + quadratic v shear
+transform	shear2	0	shear2_c	1	quadratic v shear, colour 301x301
+transform	shear2	1	shear2_c	2	quadratic v shear, gray 301x301
+transform	shear2	2	shear2_c	3	quadratic v shear, colour 601x601
+transform	shear2	3	shear2_c	4	quadratic v shear, gray 601x601

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -274,3 +274,8 @@ transform	smallpix	5	smallpix_c	6	rotate_am_corner sweep 0.10-0.60 rad
 transform	smallpix	6	smallpix_c	7	rotate_am_color_fast sweep 0.10-0.60 rad
 transform	smallpix	7	smallpix_c	8	scale_color_li sweep 1.0-3.0 (re-expand 4x)
 transform	smallpix	8	smallpix_c	9	scale_li sweep 1.0-3.0
+
+# translate_reg.c (plan 902 PR 15): weasel2.4c.png 3x sampling + clip
+transform	translate	0	translate_c	1	translate 4 ways x cmap/gray/rgb/1bpp
+transform	translate	1	translate_c	2	translate 4 ways x gray/rotate_am(+0.25)
+transform	translate	2	translate_c	3	translate 4 ways x 8 variants

--- a/src/core/pix/clip.rs
+++ b/src/core/pix/clip.rs
@@ -115,6 +115,12 @@ impl Pix {
         // Copy resolution from source
         pixd_mut.set_resolution(self.xres(), self.yres());
 
+        // C pixClipRectangle also copies the colormap, so index values in
+        // the clipped raster keep their meaning.
+        if let Some(cmap) = self.colormap() {
+            pixd_mut.set_colormap(Some(cmap.clone()))?;
+        }
+
         // Copy pixel data
         for dy in 0..clip_h {
             for dx in 0..clip_w {

--- a/src/core/pix/convert.rs
+++ b/src/core/pix/convert.rs
@@ -141,6 +141,23 @@ impl Pix {
     /// let pix8 = pix32.convert_to_8().unwrap();
     /// assert_eq!(pix8.depth(), PixelDepth::Bit8);
     /// ```
+    /// Convert any depth to 1 bpp by thresholding.
+    ///
+    /// Depths other than 1 bpp are converted to 8 bpp first (removing any
+    /// colormap to grayscale), then thresholded: values below `threshold`
+    /// become 1 (black, the leptonica foreground convention).
+    ///
+    /// A 1 bpp input is returned unchanged, except that a colormapped one
+    /// has the colormap stripped and is inverted when index 1 is the
+    /// lighter colour, so the result follows standard binary photometry.
+    ///
+    /// # See also
+    ///
+    /// C Leptonica: `pixConvertTo1()` in `pixconv.c`
+    pub fn convert_to_1(&self, _threshold: u8) -> Result<Pix> {
+        Err(Error::InvalidParameter("not yet implemented".to_string()))
+    }
+
     pub fn convert_to_8(&self) -> Result<Pix> {
         let w = self.width();
         let h = self.height();

--- a/src/core/pix/convert.rs
+++ b/src/core/pix/convert.rs
@@ -154,8 +154,37 @@ impl Pix {
     /// # See also
     ///
     /// C Leptonica: `pixConvertTo1()` in `pixconv.c`
-    pub fn convert_to_1(&self, _threshold: u8) -> Result<Pix> {
-        Err(Error::InvalidParameter("not yet implemented".to_string()))
+    pub fn convert_to_1(&self, threshold: u8) -> Result<Pix> {
+        if self.depth() == PixelDepth::Bit1 {
+            let Some(cmap) = self.colormap() else {
+                return Ok(self.deep_clone());
+            };
+            // Strip the colormap, inverting when index 1 is the lighter
+            // colour so that 1 means black.
+            let sum = |i: usize| {
+                cmap.get_rgb(i)
+                    .map(|(r, g, b)| r as u32 + g as u32 + b as u32)
+                    .unwrap_or(0)
+            };
+            let invert = sum(1) > sum(0);
+            let mut out = self.deep_clone().to_mut();
+            out.set_colormap(None)?;
+            let out: Pix = out.into();
+            return Ok(if invert { out.invert() } else { out });
+        }
+
+        // All other depths go through 8 bpp (which removes any colormap).
+        let gray = self.convert_to_8()?;
+        let (w, h) = (gray.width(), gray.height());
+        let out = Pix::new(w, h, PixelDepth::Bit1)?;
+        let mut out_mut = out.try_into_mut().unwrap();
+        for y in 0..h {
+            for x in 0..w {
+                let val = gray.get_pixel_unchecked(x, y) as u8;
+                out_mut.set_pixel_unchecked(x, y, u32::from(val < threshold));
+            }
+        }
+        Ok(out_mut.into())
     }
 
     pub fn convert_to_8(&self) -> Result<Pix> {

--- a/src/core/pix/convert.rs
+++ b/src/core/pix/convert.rs
@@ -145,6 +145,19 @@ impl Pix {
         let w = self.width();
         let h = self.height();
 
+        // C pixConvertTo8(pixs, FALSE) removes a colormap to grayscale
+        // rather than passing the raw indices through. Sub-8bpp cmapped
+        // input is expanded the same way (C pixConvert{2,4}To8 with
+        // cmapflag = FALSE).
+        if self.has_colormap()
+            && matches!(
+                self.depth(),
+                PixelDepth::Bit2 | PixelDepth::Bit4 | PixelDepth::Bit8
+            )
+        {
+            return self.remove_colormap(RemoveColormapTarget::ToGrayscale);
+        }
+
         match self.depth() {
             PixelDepth::Bit8 => {
                 // Already 8-bit: return a deep copy

--- a/src/core/pix/convert.rs
+++ b/src/core/pix/convert.rs
@@ -192,9 +192,15 @@ impl Pix {
         let h = self.height();
 
         // C pixConvertTo8(pixs, FALSE) removes a colormap to grayscale
-        // rather than passing the raw indices through. Sub-8bpp cmapped
-        // input is expanded the same way (C pixConvert{2,4}To8 with
-        // cmapflag = FALSE).
+        // rather than passing the raw indices through, for 2, 4 and 8 bpp
+        // (pixConvert{2,4}To8 with cmapflag = FALSE, and pixRemoveColormap
+        // for 8 bpp).
+        //
+        // 1 bpp is deliberately excluded: C takes the
+        // `pixConvert1To8(NULL, pixs, 255, 0)` branch regardless of any
+        // colormap, so bit 0 always becomes 255 and bit 1 always becomes 0.
+        // The Bit1 arm below reproduces that, which is why a colormapped
+        // 1 bpp pix does not go through remove_colormap here.
         if self.has_colormap()
             && matches!(
                 self.depth(),

--- a/src/core/pix/rop.rs
+++ b/src/core/pix/rop.rs
@@ -703,6 +703,31 @@ impl PixMut {
     /// * `vshift` - Vertical shift (positive = down, negative = up)
     /// * `incolor` - Color to fill exposed areas
     ///
+    /// Pixel value that `incolor` names for this image.
+    ///
+    /// For a colormapped image C fills the vacated band with the colormap
+    /// index of the darkest / lightest entry
+    /// (`pixcmapGetRankIntensity`), since the raw 0 / max value would name
+    /// an unrelated colour. Otherwise: 1 bpp has white = 0 (foreground is
+    /// 1 = black) and black = 1; deeper images have white = max, black = 0.
+    fn incolor_fill_value(&self, incolor: InColor) -> u32 {
+        if let Some(cmap) = self.colormap() {
+            let rank = match incolor {
+                InColor::White => 1.0,
+                InColor::Black => 0.0,
+            };
+            if let Ok(index) = cmap.get_rank_intensity(rank) {
+                return index as u32;
+            }
+        }
+        match (incolor, self.depth()) {
+            (InColor::White, PixelDepth::Bit1) => 0,
+            (InColor::White, d) => d.max_value(),
+            (InColor::Black, PixelDepth::Bit1) => 1,
+            (InColor::Black, _) => 0,
+        }
+    }
+
     /// # See also
     ///
     /// C Leptonica: `pixRasteropVip()` in `rop.c`
@@ -723,14 +748,7 @@ impl PixMut {
             return;
         }
 
-        // C pixRasteropHip/Vip: for 1bpp, white = 0 (fg = 1 = black) and
-        // black = 1; for deeper images white = max and black = 0.
-        let fill_val = match (incolor, self.depth()) {
-            (InColor::White, PixelDepth::Bit1) => 0,
-            (InColor::White, d) => d.max_value(),
-            (InColor::Black, PixelDepth::Bit1) => 1,
-            (InColor::Black, _) => 0,
-        };
+        let fill_val = self.incolor_fill_value(incolor);
 
         if vshift > 0 {
             // Shift down: copy from bottom to top to avoid overwriting
@@ -793,14 +811,7 @@ impl PixMut {
             return;
         }
 
-        // C pixRasteropHip/Vip: for 1bpp, white = 0 (fg = 1 = black) and
-        // black = 1; for deeper images white = max and black = 0.
-        let fill_val = match (incolor, self.depth()) {
-            (InColor::White, PixelDepth::Bit1) => 0,
-            (InColor::White, d) => d.max_value(),
-            (InColor::Black, PixelDepth::Bit1) => 1,
-            (InColor::Black, _) => 0,
-        };
+        let fill_val = self.incolor_fill_value(incolor);
 
         if hshift > 0 {
             // Shift right: copy from right to left to avoid overwriting

--- a/src/transform/warper.rs
+++ b/src/transform/warper.rs
@@ -122,7 +122,15 @@ pub enum WarpFill {
 }
 
 impl WarpFill {
-    /// Get the fill value for a specific pixel depth
+    /// Get the fill value for a specific pixel depth.
+    ///
+    /// Matches C `pixSetBlackOrWhite()`, which fills with every bit set
+    /// for white (so 32 bpp white is `0xffffffff`, alpha included) and
+    /// every bit clear for black.
+    ///
+    /// Note the C warp functions validate their `incolor` argument but
+    /// then always fill white; this port honours [`WarpFill::Black`]
+    /// instead, which only differs from C when black is requested.
     pub fn to_value(self, depth: PixelDepth) -> u32 {
         match self {
             WarpFill::White => match depth {
@@ -131,7 +139,7 @@ impl WarpFill {
                 PixelDepth::Bit4 => 15,
                 PixelDepth::Bit8 => 255,
                 PixelDepth::Bit16 => 65535,
-                PixelDepth::Bit32 => 0xFFFFFF00,
+                PixelDepth::Bit32 => 0xFFFFFFFF,
             },
             WarpFill::Black => match depth {
                 PixelDepth::Bit1 => 1, // 1 = black for binary
@@ -1380,7 +1388,8 @@ mod tests {
         assert_eq!(WarpFill::Black.to_value(PixelDepth::Bit1), 1);
         assert_eq!(WarpFill::White.to_value(PixelDepth::Bit8), 255);
         assert_eq!(WarpFill::Black.to_value(PixelDepth::Bit8), 0);
-        assert_eq!(WarpFill::White.to_value(PixelDepth::Bit32), 0xFFFFFF00);
+        // C pixSetBlackOrWhite fills white with every bit set.
+        assert_eq!(WarpFill::White.to_value(PixelDepth::Bit32), 0xFFFFFFFF);
         assert_eq!(WarpFill::Black.to_value(PixelDepth::Bit32), 0);
     }
 

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -376,3 +376,34 @@ fn conversion_to_1_matches_c() {
     assert_eq!(out.get_pixel(0, 0).unwrap(), 1);
     assert_eq!(out.get_pixel(1, 0).unwrap(), 0);
 }
+
+/// clip_rectangle must carry the colormap over (plan 902 PR 15).
+///
+/// C `pixClipRectangle` calls `pixCopyColormap(pixd, pixs)`, so a clip of
+/// a colormapped image stays colormapped. Dropping it silently turns the
+/// indices into raw pixel values.
+#[test]
+#[ignore = "not yet implemented: clip_rectangle drops the colormap"]
+fn clip_rectangle_preserves_colormap() {
+    use leptonica::core::{PixColormap, RgbaQuad};
+
+    let pix = {
+        let p = leptonica::Pix::new(4, 2, PixelDepth::Bit2).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        let mut cmap = PixColormap::new(2).unwrap();
+        cmap.add_color(RgbaQuad::rgb(10, 20, 30)).unwrap();
+        cmap.add_color(RgbaQuad::rgb(200, 150, 100)).unwrap();
+        pm.set_colormap(Some(cmap)).unwrap();
+        pm.set_pixel(2, 0, 1).unwrap();
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+
+    let clipped = pix.clip_rectangle(1, 0, 3, 2).expect("clip");
+    assert_eq!(clipped.depth(), PixelDepth::Bit2);
+    let cmap = clipped.colormap().expect("colormap must be preserved");
+    assert_eq!(cmap.len(), 2);
+    assert_eq!(cmap.get_rgb(1).unwrap(), (200, 150, 100));
+    // The index raster is shifted by the clip origin.
+    assert_eq!(clipped.get_pixel(1, 0).unwrap(), 1);
+}

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -281,3 +281,36 @@ fn conversion_to_32_applies_colormap() {
     assert_eq!(out.get_pixel(0, 0).unwrap(), 0x0a141e00);
     assert_eq!(out.get_pixel(1, 0).unwrap(), 0xc8966400);
 }
+
+/// convert_to_8 must apply the colormap (plan 902 PR 15).
+///
+/// C `pixConvertTo8(pixs, FALSE)` on an 8 bpp colormapped input routes
+/// through `pixRemoveColormap(REMOVE_CMAP_TO_GRAYSCALE)`, so the output
+/// holds luminance values — not the raw indices. Sub-8bpp colormapped
+/// inputs are likewise expanded rather than value-mapped.
+#[test]
+#[ignore = "not yet implemented: convert_to_8 ignores the colormap"]
+fn conversion_to_8_applies_colormap() {
+    use leptonica::core::{PixColormap, RgbaQuad};
+
+    let pix = {
+        let p = leptonica::Pix::new(2, 1, PixelDepth::Bit8).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        let mut cmap = PixColormap::new(8).unwrap();
+        // Luminance uses C's 0.3 / 0.5 / 0.2 weights (+0.5 rounding).
+        cmap.add_color(RgbaQuad::rgb(255, 255, 255)).unwrap(); // -> 255
+        cmap.add_color(RgbaQuad::rgb(100, 200, 50)).unwrap(); // -> 140
+        pm.set_colormap(Some(cmap)).unwrap();
+        pm.set_pixel(0, 0, 0).unwrap();
+        pm.set_pixel(1, 0, 1).unwrap();
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+
+    let out = pix.convert_to_8().expect("convert_to_8");
+    assert_eq!(out.depth(), PixelDepth::Bit8);
+    assert!(!out.has_colormap(), "colormap must be removed");
+    assert_eq!(out.get_pixel(0, 0).unwrap(), 255);
+    // 0.3*100 + 0.5*200 + 0.2*50 = 30 + 100 + 10 = 140
+    assert_eq!(out.get_pixel(1, 0).unwrap(), 140);
+}

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -322,7 +322,6 @@ fn conversion_to_8_applies_colormap() {
 /// inverted when index 1 is the lighter colour, so the result follows
 /// the standard binary photometry (1 = black).
 #[test]
-#[ignore = "not yet implemented: convert_to_1 does not exist"]
 fn conversion_to_1_matches_c() {
     use leptonica::core::{PixColormap, RgbaQuad};
 

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -313,3 +313,67 @@ fn conversion_to_8_applies_colormap() {
     // 0.3*100 + 0.5*200 + 0.2*50 = 30 + 100 + 10 = 140
     assert_eq!(out.get_pixel(1, 0).unwrap(), 140);
 }
+
+/// convert_to_1 must follow C pixConvertTo1 (plan 902 PR 15).
+///
+/// For depths other than 1 bpp, C converts to 8 bpp (removing any
+/// colormap to grayscale) and thresholds. For 1 bpp input it copies,
+/// except that a colormapped 1 bpp pix has the colormap stripped and is
+/// inverted when index 1 is the lighter colour, so the result follows
+/// the standard binary photometry (1 = black).
+#[test]
+#[ignore = "not yet implemented: convert_to_1 does not exist"]
+fn conversion_to_1_matches_c() {
+    use leptonica::core::{PixColormap, RgbaQuad};
+
+    // 8 bpp cmapped: luminance 255 and 140, threshold 128 -> 0 and 0
+    // (both above), so use a darker entry to get a set pixel.
+    let pix = {
+        let p = leptonica::Pix::new(2, 1, PixelDepth::Bit8).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        let mut cmap = PixColormap::new(8).unwrap();
+        cmap.add_color(RgbaQuad::rgb(255, 255, 255)).unwrap(); // -> 255
+        cmap.add_color(RgbaQuad::rgb(10, 10, 10)).unwrap(); // -> 10
+        pm.set_colormap(Some(cmap)).unwrap();
+        pm.set_pixel(0, 0, 0).unwrap();
+        pm.set_pixel(1, 0, 1).unwrap();
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+    let out = pix.convert_to_1(128).expect("convert_to_1");
+    assert_eq!(out.depth(), PixelDepth::Bit1);
+    // threshold_to_binary: value < threshold becomes 1 (black).
+    assert_eq!(out.get_pixel(0, 0).unwrap(), 0);
+    assert_eq!(out.get_pixel(1, 0).unwrap(), 1);
+
+    // 1 bpp without a colormap is copied unchanged.
+    let bin = {
+        let p = leptonica::Pix::new(2, 1, PixelDepth::Bit1).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        pm.set_pixel(1, 0, 1).unwrap();
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+    let out = bin.convert_to_1(128).expect("convert_to_1 on 1bpp");
+    assert_eq!(out.get_pixel(0, 0).unwrap(), 0);
+    assert_eq!(out.get_pixel(1, 0).unwrap(), 1);
+
+    // 1 bpp with a colormap whose index 1 is lighter gets inverted.
+    let cmapped = {
+        let p = leptonica::Pix::new(2, 1, PixelDepth::Bit1).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        let mut cmap = PixColormap::new(1).unwrap();
+        cmap.add_color(RgbaQuad::rgb(0, 0, 0)).unwrap(); // index 0 dark
+        cmap.add_color(RgbaQuad::rgb(255, 255, 255)).unwrap(); // index 1 light
+        pm.set_colormap(Some(cmap)).unwrap();
+        pm.set_pixel(1, 0, 1).unwrap();
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+    let out = cmapped
+        .convert_to_1(128)
+        .expect("convert_to_1 cmapped 1bpp");
+    assert!(!out.has_colormap());
+    assert_eq!(out.get_pixel(0, 0).unwrap(), 1);
+    assert_eq!(out.get_pixel(1, 0).unwrap(), 0);
+}

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -289,7 +289,6 @@ fn conversion_to_32_applies_colormap() {
 /// holds luminance values — not the raw indices. Sub-8bpp colormapped
 /// inputs are likewise expanded rather than value-mapped.
 #[test]
-#[ignore = "not yet implemented: convert_to_8 ignores the colormap"]
 fn conversion_to_8_applies_colormap() {
     use leptonica::core::{PixColormap, RgbaQuad};
 

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -449,3 +449,33 @@ fn translate_cmapped_brings_in_colormap_index() {
     assert_eq!(black.get_pixel(1, 0).unwrap(), 2);
     assert_eq!(black.get_pixel(2, 0).unwrap(), 0);
 }
+
+/// convert_to_8 must leave 1 bpp colormaps alone (plan 902 PR 15).
+///
+/// C `pixConvertTo8(pixs, FALSE)` takes the
+/// `pixConvert1To8(NULL, pixs, 255, 0)` branch for 1 bpp regardless of any
+/// colormap, so bit 0 becomes 255 and bit 1 becomes 0 even when the
+/// colormap says otherwise.
+#[test]
+fn conversion_to_8_ignores_1bpp_colormap() {
+    use leptonica::core::{PixColormap, RgbaQuad};
+
+    let pix = {
+        let p = leptonica::Pix::new(2, 1, PixelDepth::Bit1).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        let mut cmap = PixColormap::new(1).unwrap();
+        // Inverted photometry: index 0 is black, index 1 is white.
+        cmap.add_color(RgbaQuad::rgb(0, 0, 0)).unwrap();
+        cmap.add_color(RgbaQuad::rgb(255, 255, 255)).unwrap();
+        pm.set_colormap(Some(cmap)).unwrap();
+        pm.set_pixel(1, 0, 1).unwrap();
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+
+    let out = pix.convert_to_8().expect("convert_to_8");
+    assert_eq!(out.depth(), PixelDepth::Bit8);
+    // C ignores the colormap here: bit 0 -> 255, bit 1 -> 0.
+    assert_eq!(out.get_pixel(0, 0).unwrap(), 255);
+    assert_eq!(out.get_pixel(1, 0).unwrap(), 0);
+}

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -415,7 +415,6 @@ fn clip_rectangle_preserves_colormap() {
 /// or lightest colour — rather than the raw 0 / max value, which would
 /// name an unrelated colormap entry.
 #[test]
-#[ignore = "not yet implemented: translate ignores the colormap when filling"]
 fn translate_cmapped_brings_in_colormap_index() {
     use leptonica::core::pix::rop::InColor;
     use leptonica::core::{PixColormap, RgbaQuad};

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -406,3 +406,47 @@ fn clip_rectangle_preserves_colormap() {
     // The index raster is shifted by the clip origin.
     assert_eq!(clipped.get_pixel(1, 0).unwrap(), 1);
 }
+
+/// Shifting a colormapped image must bring in a colormap index
+/// (plan 902 PR 15).
+///
+/// C `pixRasteropHip` / `pixRasteropVip` fill the vacated band with
+/// `pixcmapGetRankIntensity(cmap, 0.0 or 1.0)` — the index of the darkest
+/// or lightest colour — rather than the raw 0 / max value, which would
+/// name an unrelated colormap entry.
+#[test]
+#[ignore = "not yet implemented: translate ignores the colormap when filling"]
+fn translate_cmapped_brings_in_colormap_index() {
+    use leptonica::core::pix::rop::InColor;
+    use leptonica::core::{PixColormap, RgbaQuad};
+
+    // Colormap ordered so that neither the darkest nor the lightest
+    // colour sits at index 0 or at the maximum index.
+    let pix = {
+        let p = leptonica::Pix::new(4, 1, PixelDepth::Bit2).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        let mut cmap = PixColormap::new(2).unwrap();
+        cmap.add_color(RgbaQuad::rgb(128, 128, 128)).unwrap(); // 0: mid
+        cmap.add_color(RgbaQuad::rgb(255, 255, 255)).unwrap(); // 1: lightest
+        cmap.add_color(RgbaQuad::rgb(0, 0, 0)).unwrap(); // 2: darkest
+        cmap.add_color(RgbaQuad::rgb(200, 200, 200)).unwrap(); // 3: light
+        pm.set_colormap(Some(cmap)).unwrap();
+        for x in 0..4u32 {
+            pm.set_pixel(x, 0, 0).unwrap();
+        }
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+
+    // Bringing in white must use index 1, not the raw max value 3.
+    let white = pix.translate(2, 0, InColor::White);
+    assert_eq!(white.get_pixel(0, 0).unwrap(), 1);
+    assert_eq!(white.get_pixel(1, 0).unwrap(), 1);
+    assert_eq!(white.get_pixel(2, 0).unwrap(), 0);
+
+    // Bringing in black must use index 2, not the raw value 0.
+    let black = pix.translate(2, 0, InColor::Black);
+    assert_eq!(black.get_pixel(0, 0).unwrap(), 2);
+    assert_eq!(black.get_pixel(1, 0).unwrap(), 2);
+    assert_eq!(black.get_pixel(2, 0).unwrap(), 0);
+}

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -383,7 +383,6 @@ fn conversion_to_1_matches_c() {
 /// a colormapped image stays colormapped. Dropping it silently turns the
 /// indices into raw pixel values.
 #[test]
-#[ignore = "not yet implemented: clip_rectangle drops the colormap"]
 fn clip_rectangle_preserves_colormap() {
     use leptonica::core::{PixColormap, RgbaQuad};
 

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -623,6 +623,9 @@ texturefill.10.tif	2e20e4a993fc7663
 texturefill.12.tif	d9438c4b4fe4b9a8
 threshnorm_spread.03.png	37098b8e48b64382
 threshnorm_sweep.05.tif	9e647d02eaee9e18
+translate_c.01.png	c3a0a2dfa9525060
+translate_c.02.png	809850b7d5f7e8de
+translate_c.03.png	660f56bbe91369dd
 translate_neg.03.png	ac10e8157f49a7ff
 translate_pos.03.png	be54eaaf1dbc1451
 translate_rgb.03.png	44c7bde8439cab39

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -584,8 +584,12 @@ shear1_binary.03.tif	35cc1394f62d30f9
 shear1_gray8.02.png	fdbeb7c41eda1506
 shear1_inplace.01.png	2d873b2b2eafe19a
 shear1_interp.02.png	b0e04c28ec1d8b6e
-shear2_color_samp.02.png	626bb2a2e1c2b0f8
-shear2_general.02.png	626bb2a2e1c2b0f8
+shear2_c.01.png	5f117f8af731b02e
+shear2_c.02.png	500fa1dab5e94f5e
+shear2_c.03.png	c33034c28d3739e3
+shear2_c.04.png	53ce644a10809831
+shear2_color_samp.02.png	339f0b19dd6b59d4
+shear2_general.02.png	339f0b19dd6b59d4
 shear2_gray_interp.03.png	7366c9f9e594f1f2
 skew.05.tif	a82f76ea1682d511
 smallpix_c.01.png	d9479798307abea0

--- a/tests/transform/shear2_reg.rs
+++ b/tests/transform/shear2_reg.rs
@@ -136,3 +136,127 @@ fn shear2_reg_general() {
 
     assert!(rp.cleanup(), "shear2 general test failed");
 }
+
+/// C-comparable quadratic vertical shear series (plan 902 PR 15).
+///
+/// Mirrors C shear2_reg exactly: 301x301 and 601x601 white RGB canvases
+/// with six coloured horizontal lines, sheared to left/right in both
+/// sampled and interpolated modes (vmax 60 / -20), each result converted
+/// to 32 bpp, given a 3 px black border and a labelled textblock, then
+/// tiled with `display_tiled_in_columns(2, 1.0, 20, 0)`.
+#[test]
+fn shear2_c_compat() {
+    use leptonica::core::bmf::TextblockLocation;
+    use leptonica::core::pix::graphics::Color;
+    use leptonica::transform::{WarpDirection, WarpFill, WarpOperation, quadratic_v_shear};
+    use leptonica::{Bmf, Pix, Pixa, PixelDepth};
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("shear2_c");
+    let bmf = Bmf::new(8).expect("bmf size 8");
+
+    // C: white canvas with six coloured lines of width 5 at fixed rows.
+    let make_canvas = |size: u32| -> Pix {
+        let p = Pix::new(size, size, PixelDepth::Bit32).expect("create canvas");
+        let mut pm = p.try_into_mut().expect("into_mut");
+        pm.set_all();
+        let lines: [(i32, Color); 6] = [
+            (20, Color::new(0, 0, 255)),
+            (70, Color::new(0, 255, 0)),
+            (120, Color::new(0, 255, 255)),
+            (170, Color::new(255, 0, 0)),
+            (220, Color::new(255, 0, 255)),
+            (270, Color::new(255, 255, 0)),
+        ];
+        for (y, color) in lines {
+            pm.render_line_color(0, y, 300, y, 5, color)
+                .expect("render line");
+        }
+        pm.into()
+    };
+    let pixs1 = make_canvas(301);
+    let pixs2 = make_canvas(601);
+
+    // C PixSave: convert to 32bpp, add a 3px black border, label below.
+    let save = |pixa: &mut Pixa, pix: &Pix, text: &str| {
+        let p32 = pix.convert_to_32().expect("to 32bpp");
+        let bordered = p32.add_border(3, 0).expect("add border");
+        let (labelled, _) = bmf
+            .add_single_textblock(&bordered, text, 0xff000000, TextblockLocation::Below)
+            .expect("textblock");
+        pixa.push(labelled);
+    };
+
+    // C checks 0-3: colour/gray x small/large.
+    let sources = [
+        pixs1.clone(),
+        pixs1.convert_to_8().expect("gray small"),
+        pixs2.clone(),
+        pixs2.convert_to_8().expect("gray large"),
+    ];
+    for src in &sources {
+        let mut pixa = Pixa::new();
+        for (op, opname) in [
+            (WarpOperation::Sampled, "sampled"),
+            (WarpOperation::Interpolated, "interpolated"),
+        ] {
+            for (dir, dirname) in [
+                (WarpDirection::ToLeft, "left"),
+                (WarpDirection::ToRight, "right"),
+            ] {
+                let sheared = quadratic_v_shear(src, dir, 60, -20, op, WarpFill::White)
+                    .expect("quadratic_v_shear");
+                save(&mut pixa, &sheared, &format!("{opname}-{dirname}"));
+            }
+        }
+        let out = pixa
+            .display_tiled_in_columns(2, 1.0, 20, 0)
+            .expect("tiled columns");
+        rp.write_pix_and_check(&out, ImageFormat::Png)
+            .expect("check: shear2 quadratic v shear");
+    }
+
+    assert!(rp.cleanup(), "shear2 c-compat test failed");
+}
+
+/// The 32 bpp white warp fill must be opaque white (plan 902 PR 15).
+///
+/// C fills the vacated region with `pixSetBlackOrWhite(pixd,
+/// L_BRING_IN_WHITE)`, which for depths above 1 bpp is `pixSetAll` — every
+/// bit set, i.e. 0xffffffff including the alpha byte. A fill of
+/// 0xffffff00 leaves the alpha byte clear and diverges from C.
+#[test]
+#[ignore = "not yet implemented: 32bpp warp white fill leaves alpha 0"]
+fn shear2_warp_white_fill_is_opaque() {
+    use leptonica::transform::{WarpDirection, WarpFill, WarpOperation, quadratic_v_shear};
+    use leptonica::{Pix, PixelDepth};
+
+    // A small canvas whose top-right corner is vacated by a right warp.
+    let pix = {
+        let p = Pix::new(64, 64, PixelDepth::Bit32).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        for y in 0..64u32 {
+            for x in 0..64u32 {
+                pm.set_pixel(x, y, 0x0000_00ff).unwrap();
+            }
+        }
+        let p: Pix = pm.into();
+        p
+    };
+    let out = quadratic_v_shear(
+        &pix,
+        WarpDirection::ToRight,
+        30,
+        -10,
+        WarpOperation::Sampled,
+        WarpFill::White,
+    )
+    .expect("quadratic_v_shear");
+
+    // The vacated pixels must be fully opaque white.
+    let vacated = out.get_pixel(63, 0).unwrap();
+    assert_eq!(vacated, 0xffff_ffff, "got {vacated:08x}");
+}

--- a/tests/transform/shear2_reg.rs
+++ b/tests/transform/shear2_reg.rs
@@ -190,14 +190,15 @@ fn shear2_c_compat() {
         pixa.push(labelled);
     };
 
-    // C checks 0-3: colour/gray x small/large.
+    // C checks 0-3: colour/gray x small/large. Note the colour 601 case
+    // uses a stronger shear (120 / -40) than the other three.
     let sources = [
-        pixs1.clone(),
-        pixs1.convert_to_8().expect("gray small"),
-        pixs2.clone(),
-        pixs2.convert_to_8().expect("gray large"),
+        (pixs1.clone(), 60, -20),
+        (pixs1.convert_to_8().expect("gray small"), 60, -20),
+        (pixs2.clone(), 120, -40),
+        (pixs2.convert_to_8().expect("gray large"), 60, -20),
     ];
-    for src in &sources {
+    for (src, vmax_top, vmax_bottom) in &sources {
         let mut pixa = Pixa::new();
         for (op, opname) in [
             (WarpOperation::Sampled, "sampled"),
@@ -207,8 +208,9 @@ fn shear2_c_compat() {
                 (WarpDirection::ToLeft, "left"),
                 (WarpDirection::ToRight, "right"),
             ] {
-                let sheared = quadratic_v_shear(src, dir, 60, -20, op, WarpFill::White)
-                    .expect("quadratic_v_shear");
+                let sheared =
+                    quadratic_v_shear(src, dir, *vmax_top, *vmax_bottom, op, WarpFill::White)
+                        .expect("quadratic_v_shear");
                 save(&mut pixa, &sheared, &format!("{opname}-{dirname}"));
             }
         }
@@ -229,7 +231,6 @@ fn shear2_c_compat() {
 /// bit set, i.e. 0xffffffff including the alpha byte. A fill of
 /// 0xffffff00 leaves the alpha byte clear and diverges from C.
 #[test]
-#[ignore = "not yet implemented: 32bpp warp white fill leaves alpha 0"]
 fn shear2_warp_white_fill_is_opaque() {
     use leptonica::transform::{WarpDirection, WarpFill, WarpOperation, quadratic_v_shear};
     use leptonica::{Pix, PixelDepth};

--- a/tests/transform/translate_reg.rs
+++ b/tests/transform/translate_reg.rs
@@ -111,3 +111,89 @@ fn translate_reg_multitype() {
     // 4. Rotate with area mapping (bring in black/white)
     // 5. Translate each with +/- shifts and white/black fill
 }
+
+/// C-comparable translate series (plan 902 PR 15).
+///
+/// Mirrors C translate_reg exactly: weasel2.4c.png sampled 3x and
+/// clipped to 209x214, then the cmapped / gray / RGB / binary variants
+/// (plus four `rotate_am` results) are each translated four ways
+/// (±shift x white/black) and tiled with
+/// `display_tiled_in_columns(4, 1.0, 30, 3)`.
+#[test]
+fn translate_c_compat() {
+    use leptonica::core::pix::RemoveColormapTarget;
+    use leptonica::core::pix::rop::InColor;
+    use leptonica::transform::{RotateFill, rotate_am, scale_by_sampling};
+    use leptonica::{Pix, Pixa};
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("translate_c");
+
+    // C: pixScaleBySampling(weasel2.4c.png, 3, 3) clipped to 209x214.
+    let src = crate::common::load_test_image("weasel2.4c.png").expect("load weasel2.4c.png");
+    let scaled = scale_by_sampling(&src, 3.0, 3.0).expect("scale 3x");
+    let pixs = scaled.clip_rectangle(0, 0, 209, 214).expect("clip");
+
+    let pix1 = pixs
+        .remove_colormap(RemoveColormapTarget::ToGrayscale)
+        .expect("to gray");
+    let pix2 = pixs
+        .remove_colormap(RemoveColormapTarget::ToFullColor)
+        .expect("to full color");
+    let pix3 = pixs.convert_to_1(128).expect("convert to 1bpp");
+    let pix4 = rotate_am(&pix1, 0.25, RotateFill::Black).expect("rotate +0.25 black");
+    let pix5 = rotate_am(&pix1, -0.25, RotateFill::White).expect("rotate -0.25 white");
+    let pix6 = rotate_am(&pix2, -0.15, RotateFill::Black).expect("rotate -0.15 black");
+    let pix7 = rotate_am(&pix2, 0.15, RotateFill::White).expect("rotate +0.15 white");
+
+    // C TranslateAndSave{1,2}: four translations per image.
+    let push_four = |pixa: &mut Pixa, pix: &Pix, xs: i32, ys: i32| {
+        pixa.push(pix.translate(xs, ys, InColor::White));
+        pixa.push(pix.translate(xs, ys, InColor::Black));
+        pixa.push(pix.translate(-xs, -ys, InColor::White));
+        pixa.push(pix.translate(-xs, -ys, InColor::Black));
+    };
+
+    // C check 0
+    let mut pixa = Pixa::new();
+    push_four(&mut pixa, &pixs, 30, 30);
+    push_four(&mut pixa, &pix1, 35, 20);
+    push_four(&mut pixa, &pix2, 20, 35);
+    push_four(&mut pixa, &pix3, 20, 35);
+    let out = pixa
+        .display_tiled_in_columns(4, 1.0, 30, 3)
+        .expect("tiled 0");
+    rp.write_pix_and_check(&out, ImageFormat::Png)
+        .expect("check: translate set 0");
+
+    // C check 1
+    let mut pixa = Pixa::new();
+    push_four(&mut pixa, &pix1, 35, 20);
+    push_four(&mut pixa, &pix4, 35, 20);
+    let out = pixa
+        .display_tiled_in_columns(4, 1.0, 30, 3)
+        .expect("tiled 1");
+    rp.write_pix_and_check(&out, ImageFormat::Png)
+        .expect("check: translate set 1");
+
+    // C check 2
+    let mut pixa = Pixa::new();
+    push_four(&mut pixa, &pixs, 30, 30);
+    push_four(&mut pixa, &pix1, 30, 30);
+    push_four(&mut pixa, &pix2, 35, 20);
+    push_four(&mut pixa, &pix3, 20, 35);
+    push_four(&mut pixa, &pix4, 25, 25);
+    push_four(&mut pixa, &pix5, 25, 25);
+    push_four(&mut pixa, &pix6, 25, 25);
+    push_four(&mut pixa, &pix7, 25, 25);
+    let out = pixa
+        .display_tiled_in_columns(4, 1.0, 30, 3)
+        .expect("tiled 2");
+    rp.write_pix_and_check(&out, ImageFormat::Png)
+        .expect("check: translate set 2");
+
+    assert!(rp.cleanup(), "translate c-compat test failed");
+}


### PR DESCRIPTION
## Why

PR 14 で `display_tiled_in_columns` を移植し、transform に残る lossless
系列 (translate / shear2) の前提が揃った。どちらも全出力が PNG で、入力は
lossless (weasel2.4c.png) または完全合成。

## What

### 実装差 4 件 (18〜21 件目) を発見・修正 (各 TDD)

translate のペアを張る過程で **colormapped 画像の扱いに連鎖的な欠陥**が
見つかった:

1. **`clip_rectangle` が colormap を落とす** (根本原因) — C
   `pixClipRectangle` は `pixCopyColormap` で引き継ぐ。これが無いと切り出し
   後の index が生のピクセル値として扱われ、後続の `remove_colormap` /
   `convert_to_*` がすべて無効化される
2. **`convert_to_8` が colormap を無視** — C `pixConvertTo8(pixs, FALSE)` は
   `REMOVE_CMAP_TO_GRAYSCALE` で輝度化する (PR 13 の `convert_to_32` と同型)
3. **`rasterop_hip/vip` の cmapped 充填** — C は
   `pixcmapGetRankIntensity(cmap, 0.0/1.0)` の index を入れるが、Rust は
   深度から決めた生値 (0 / max) を書いており無関係な色が入っていた
4. **32bpp warp の白充填** — C `pixSetBlackOrWhite` は `pixSetAll` で全 bit
   を立てる (0xffffffff) が、Rust は 0xffffff00 で alpha が 0 だった

あわせて **`convert_to_1` (C `pixConvertTo1`) を新規実装** (1bpp cmapped の
photometry 反転を含む)。

### C 互換ペア 7 件追加 — 全件 Ok (Ok 133 → 140)

- **translate 3 ペア**: weasel2.4c.png を 3x sampling → 209x214 clip し、
  cmap/gray/rgb/1bpp と `rotate_am` 4 種を ±shift × white/black で平行移動。
  cmapped 系の clip / convert / 充填の全経路の C 等価性を実証
- **shear2 4 ペア**: 301/601 の合成 RGB キャンバスに 6 本の色線を描き、
  sampled/interpolated × left/right で quadratic v shear (601 colour のみ
  vmax 120/-40)

## Impact

- ベースライン: **Ok 140 / Mismatch 29 / MissingC 0 / Unmapped 400 /
  Excluded 83**。transform binary は Ok 13 → 20
- **公開 API の挙動変更**: `clip_rectangle` が colormap を保持、
  `convert_to_8` が cmapped 入力を輝度化、cmapped の `translate` が
  colormap index を充填、32bpp warp の白が不透明に。いずれも C 準拠への修正
- `WarpFill::to_value` の 32bpp 白の変更に伴い unit テスト期待値 1 件を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg