### PR TITLE
feat(c-compat): xformbox 整列 — cmapped 描画修正で 3 ペア全件 Ok (plan 902 PR 16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 15 後):
+- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 16 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 140 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 83**
+  **Ok 143 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 85**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -309,7 +309,7 @@ PR 14 で `display_tiled_in_columns` を移植し、両 prog の前提が揃っ�
 - translate 3 ペア + shear2 4 ペア **全件 Ok (Ok 133 → 140)**。
   transform binary は Ok 13 → 20
 
-### PR 16: xformbox 整列 — hash box 描画と box 変換 (IN_PROGRESS)
+### PR 16: xformbox 整列 — hash box 描画と box 変換 (実施済み)
 
 C 版ソース: `prog/xformbox_reg.c`、`src/boxfunc2.c` / `src/graphics.c`。
 
@@ -324,6 +324,20 @@ hash box 描画 3 種と boxa の直交回転・順序付き変換を検証す�
 
 必要 API (`render_hash_box*`, `Boxa::rotate_orth`,
 `Boxa::transform_ordered`, `display_tiled_in_rows`) は移植済み。
+
+実施結果:
+
+- **実装差 22 件目**: `render_pta_color` が cmapped 画像で colormap を
+  使わず生の gray/RGB 値を書いていた (C pixRenderPtaArb は
+  pixcmapAddNearestColor で index を解決)。TDD で修正
+- C 0-2 の 3 ペア **全件 Ok (Ok 140 → 143)**。1bpp / 8bpp cmapped /
+  32bpp blend の 3 描画経路を実証
+- **C 3/4 は次段送り**: どちらも `pixaDisplayTiledIn*` 内部の
+  `pixScale` を経由するが、Rust の `scale_general` は
+  **(a) unsharp masking (C は sharpfract 0.2/0.4 を既定で適用)、
+  (b) area map の 1/2 特別ケース、(c) 出力寸法の丸め**が C と異なる
+  (実装差 23 件目)。理由付きで Excluded に分離し PR 17 で対応する
+- C 5 はさらに `boxaAffineTransform` + 2D 行列ビルダが未移植
 
 ### PR 17 以降: semantic マッピングの漸進追加
 

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -309,7 +309,23 @@ PR 14 で `display_tiled_in_columns` を移植し、両 prog の前提が揃っ�
 - translate 3 ペア + shear2 4 ペア **全件 Ok (Ok 133 → 140)**。
   transform binary は Ok 13 → 20
 
-### PR 16 以降: semantic マッピングの漸進追加
+### PR 16: xformbox 整列 — hash box 描画と box 変換 (IN_PROGRESS)
+
+C 版ソース: `prog/xformbox_reg.c`、`src/boxfunc2.c` / `src/graphics.c`。
+
+transform に残る最後の全 PNG 系列。入力は feyn.tif (lossless) で、
+hash box 描画 3 種と boxa の直交回転・順序付き変換を検証する。
+
+| C check | 内容 |
+| --: | --- |
+| 0-2 | render_hash_box / _color /_blend を成分 boxa に適用 |
+| 3 | rotate_orth x 4 + boxa rotate_orth を tiled in rows |
+| 4-5 | transform_ordered 6 種 (translate / scale 系) の重ね描き |
+
+必要 API (`render_hash_box*`, `Boxa::rotate_orth`,
+`Boxa::transform_ordered`, `display_tiled_in_rows`) は移植済み。
+
+### PR 17 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -52,16 +52,16 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 ## 全体集計
 
-| 状態        | 件数    | 説明                                                                                                                              |
-| ----------- | ------: | -----------------------------------------------------------------------------------------------------------------------------     |
-| ✅ Ok       | **140** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +96)                                                   |
-| ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
-| ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
-| 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                               |
-| 🚫 Excluded | **83**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + Rust 独自 falsecolor 4               |
+| 状態        | 件数    | 説明                                                                                                                                   |
+| ----------- | ------: | -------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Ok       | **143** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +99)                                                        |
+| ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)      |
+| ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                           |
+| 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                                    |
+| 🚫 Excluded | **85**  | 設計上マップ不能または前提未整備 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + xformbox 2 |
 
-合計 652 entries がレポート対象 (As of 2026-08-16、plan 902 PR 15 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **659 entries**。
+合計 657 entries がレポート対象 (As of 2026-08-16、plan 902 PR 16 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **664 entries**。
 
 ## test binary 別の内訳
 
@@ -74,7 +74,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **659 entries**。
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |      9 |        0 |        0 |       45 |        0 |
 | `region`    | **46** |        2 |        0 |       28 |       29 |
-| `transform` |     20 |        0 |        0 |       78 |        0 |
+| `transform` |     23 |        0 |        0 |       78 |        2 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
 

--- a/scripts/c_compat_exclude.tsv
+++ b/scripts/c_compat_exclude.tsv
@@ -26,3 +26,7 @@ key	dist_contours.16.png	C counterpart a+6 is JPEG (finding 001)
 key	dist_seedfill.05.png	C b-section writes only JPEG (b+1..b+3, finding 001)
 key	dist_seedfill.06.png	C b-section writes only JPEG (b+1..b+3, finding 001)
 prefix	falsecolor	Rust-specific color-mapping API outputs; C falsecolor_reg outputs are paired via falsecolor_c
+# xformbox_reg (plan 902 PR 16): C 3/4 は pixScale の unsharp masking と
+# area map の 1/2 特別ケースが未移植 (scale_general の C 準拠化が前提)
+key	xformbox_c.04.png	needs C pixScale dispatch (unsharp masking); see plan 902 PR 17
+key	xformbox_c.05.png	needs C pixScale dispatch (unsharp masking); see plan 902 PR 17

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -285,3 +285,8 @@ transform	shear2	0	shear2_c	1	quadratic v shear, colour 301x301
 transform	shear2	1	shear2_c	2	quadratic v shear, gray 301x301
 transform	shear2	2	shear2_c	3	quadratic v shear, colour 601x601
 transform	shear2	3	shear2_c	4	quadratic v shear, gray 601x601
+
+# xformbox_reg.c (plan 902 PR 16): feyn.tif hash boxes + ordered transforms
+transform	xformbox	0	xformbox_c	1	render_hash_box on 1bpp components
+transform	xformbox	1	xformbox_c	2	render_hash_box_color on 8bpp
+transform	xformbox	2	xformbox_c	3	render_hash_box_blend on 32bpp

--- a/src/core/pix/graphics.rs
+++ b/src/core/pix/graphics.rs
@@ -966,17 +966,25 @@ impl PixMut {
         let h = self.height();
         let depth = self.depth();
 
-        // Calculate the pixel value based on depth
-        let pixel_val = match depth {
-            PixelDepth::Bit1 => 1u32,
-            PixelDepth::Bit2 => (color.to_gray() >> 6) as u32,
-            PixelDepth::Bit4 => (color.to_gray() >> 4) as u32,
-            PixelDepth::Bit8 => color.to_gray() as u32,
-            PixelDepth::Bit16 => {
-                let g = color.to_gray() as u32;
-                (g << 8) | g
+        // C pixRenderPtaArb: on a colormapped pix the colour is resolved
+        // with pixcmapAddNearestColor and the resulting index is written,
+        // rather than a raw gray/RGB value that would name an unrelated
+        // colormap entry.
+        let pixel_val = if depth != PixelDepth::Bit1 && self.has_colormap() {
+            let cmap = self.colormap_mut().expect("checked has_colormap");
+            cmap.add_nearest_color(color.r, color.g, color.b)? as u32
+        } else {
+            match depth {
+                PixelDepth::Bit1 => 1u32,
+                PixelDepth::Bit2 => (color.to_gray() >> 6) as u32,
+                PixelDepth::Bit4 => (color.to_gray() >> 4) as u32,
+                PixelDepth::Bit8 => color.to_gray() as u32,
+                PixelDepth::Bit16 => {
+                    let g = color.to_gray() as u32;
+                    (g << 8) | g
+                }
+                PixelDepth::Bit32 => color.to_pixel32(),
             }
-            PixelDepth::Bit32 => color.to_pixel32(),
         };
 
         for (x, y) in pta.iter() {

--- a/src/core/pix/graphics.rs
+++ b/src/core/pix/graphics.rs
@@ -960,7 +960,19 @@ impl PixMut {
 
     /// Render a point array with a specific RGB color.
     ///
-    /// For non-32bpp images, the color is converted to grayscale.
+    /// The value actually written depends on the image:
+    ///
+    /// - **colormapped** (any depth above 1 bpp): the colour is resolved
+    ///   against the colormap — added when there is room, otherwise the
+    ///   nearest existing entry — and that index is written, so the
+    ///   requested RGB is preserved
+    /// - **32 bpp**: the packed RGB value
+    /// - **1 bpp**: the foreground bit
+    /// - other depths: the colour converted to grayscale
+    ///
+    /// # See also
+    ///
+    /// C Leptonica: `pixRenderPtaArb()` in `graphics.c`
     pub fn render_pta_color(&mut self, pta: &Pta, color: Color) -> Result<()> {
         let w = self.width();
         let h = self.height();
@@ -971,7 +983,7 @@ impl PixMut {
         // rather than a raw gray/RGB value that would name an unrelated
         // colormap entry.
         let pixel_val = if depth != PixelDepth::Bit1 && self.has_colormap() {
-            let cmap = self.colormap_mut().expect("checked has_colormap");
+            let cmap = self.colormap_mut().ok_or(Error::ColormapRequired)?;
             cmap.add_nearest_color(color.r, color.g, color.b)? as u32
         } else {
             match depth {

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -479,3 +479,41 @@ fn conversion_to_8_ignores_1bpp_colormap() {
     assert_eq!(out.get_pixel(0, 0).unwrap(), 255);
     assert_eq!(out.get_pixel(1, 0).unwrap(), 0);
 }
+
+/// Arb-colour rendering on a colormapped pix must go through the
+/// colormap (plan 902 PR 16).
+///
+/// C `pixRenderPtaArb` resolves the requested colour with
+/// `pixcmapAddNearestColor` and writes that index, adding the colour when
+/// there is room. Writing a raw gray/RGB value instead names an unrelated
+/// colormap entry.
+#[test]
+#[ignore = "not yet implemented: render_pta_color ignores the colormap"]
+fn render_pta_color_uses_colormap() {
+    use leptonica::core::pix::graphics::Color;
+    use leptonica::core::{PixColormap, Pta, RgbaQuad};
+
+    let pix = {
+        let p = leptonica::Pix::new(4, 1, PixelDepth::Bit8).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        let mut cmap = PixColormap::new(8).unwrap();
+        cmap.add_color(RgbaQuad::rgb(255, 255, 255)).unwrap();
+        cmap.add_color(RgbaQuad::rgb(0, 0, 0)).unwrap();
+        pm.set_colormap(Some(cmap)).unwrap();
+        let p: leptonica::Pix = pm.into();
+        p
+    };
+
+    let mut pta = Pta::new();
+    pta.push(1.0, 0.0);
+    let mut m = pix.to_mut();
+    m.render_pta_color(&pta, Color::new(200, 30, 150))
+        .expect("render_pta_color");
+    let out: leptonica::Pix = m.into();
+
+    let cmap = out.colormap().expect("colormap preserved");
+    assert_eq!(cmap.len(), 3, "the new colour must be added to the cmap");
+    assert_eq!(cmap.get_rgb(2).unwrap(), (200, 30, 150));
+    // The raster must reference the new index, not a raw gray value.
+    assert_eq!(out.get_pixel(1, 0).unwrap(), 2);
+}

--- a/tests/core/conversion_reg.rs
+++ b/tests/core/conversion_reg.rs
@@ -488,7 +488,6 @@ fn conversion_to_8_ignores_1bpp_colormap() {
 /// there is room. Writing a raw gray/RGB value instead names an unrelated
 /// colormap entry.
 #[test]
-#[ignore = "not yet implemented: render_pta_color ignores the colormap"]
 fn render_pta_color_uses_colormap() {
     use leptonica::core::pix::graphics::Color;
     use leptonica::core::{PixColormap, Pta, RgbaQuad};

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -659,3 +659,8 @@ writetext_multi.12.png	72745f4cc9889e53
 writetext_multi.14.png	6d1cee7ff33ba0b2
 writetext_multi.16.png	2d62f79367498692
 writetext_setline.01.png	5ed9a5b9156de512
+xformbox_c.01.png	28993e9a4de8e97a
+xformbox_c.02.png	0d3e996267f3a878
+xformbox_c.03.png	28e411c8fcfdbdd6
+xformbox_c.04.png	f036ee328e790bc3
+xformbox_c.05.png	f5e7d000f1fac774

--- a/tests/transform/xformbox_reg.rs
+++ b/tests/transform/xformbox_reg.rs
@@ -235,3 +235,190 @@ fn xformbox_reg_hash_rendering() {
 
     assert!(rp.cleanup(), "xformbox hash rendering test failed");
 }
+
+/// C-comparable hash-box and box-transform series (plan 902 PR 16).
+///
+/// Mirrors C xformbox_reg checks 0-4: feyn.tif clipped to the same box,
+/// connected components rendered with the three hash-box variants, the
+/// four orthogonal rotations with correspondingly rotated boxa, and the
+/// six `transform_ordered` orders applied to translation and scaling.
+///
+/// C check 5 additionally needs `boxaAffineTransform` with the 2D matrix
+/// builders, which this port does not have yet.
+#[test]
+fn xformbox_c_compat() {
+    use leptonica::TransformOrder;
+    use leptonica::core::pix::PixelOp;
+    use leptonica::core::pix::graphics::{Color, HashOrientation};
+    use leptonica::io::ImageFormat;
+    use leptonica::region::{ConnectivityType, find_connected_components};
+    use leptonica::transform::rotate_orth;
+    use leptonica::{Boxa, Pix, Pixa, PixelDepth};
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("xformbox_c");
+
+    // C: pixClipRectangle(feyn.tif, boxCreate(461, 429, 1393, 342))
+    let feyn = crate::common::load_test_image("feyn.tif").expect("load feyn.tif");
+    let pix1 = feyn.clip_rectangle(461, 429, 1393, 342).expect("clip");
+    let comps = find_connected_components(&pix1, ConnectivityType::EightWay).expect("conncomp");
+    let mut boxa = Boxa::new();
+    for c in &comps {
+        boxa.push(c.bounds);
+    }
+
+    // C uses i % 4 as the hash orientation index.
+    let orient_of = |i: usize| match i % 4 {
+        0 => HashOrientation::Horizontal,
+        1 => HashOrientation::PosSlope,
+        2 => HashOrientation::Vertical,
+        _ => HashOrientation::NegSlope,
+    };
+    let color_of = |i: usize| {
+        Color::new(
+            ((1413 * i) % 256) as u8,
+            ((4917 * i) % 256) as u8,
+            ((7341 * i) % 256) as u8,
+        )
+    };
+
+    // C checks 0-2: the three hash-box renderers over the same boxa.
+    let mut bin = pix1.deep_clone().to_mut();
+    // C: pixConvertTo8(pix1, 1) -> pixConvert1To8Cmap (8bpp with colormap).
+    let mut gray = pix1.convert_1_to_8_cmap().expect("to 8bpp cmap").to_mut();
+    let mut rgb = pix1.convert_to_32().expect("to 32bpp").to_mut();
+    for (i, b) in boxa.iter().enumerate() {
+        let orient = orient_of(i);
+        let color = color_of(i + 1);
+        bin.render_hash_box(b, 8, 2, orient, true, PixelOp::Set)
+            .expect("render_hash_box");
+        gray.render_hash_box_color(b, 7, 2, orient, true, color)
+            .expect("render_hash_box_color");
+        rgb.render_hash_box_blend(b, 7, 2, orient, true, color, 0.5)
+            .expect("render_hash_box_blend");
+    }
+    for pix in [Pix::from(bin), Pix::from(gray), Pix::from(rgb)] {
+        rp.write_pix_and_check(&pix, ImageFormat::Png)
+            .expect("check: xformbox hash render");
+    }
+
+    // C check 3: four orthogonal rotations with matching boxa rotations.
+    let (w, h) = (pix1.width() as i32, pix1.height() as i32);
+    let pixc = pix1.convert_to_32().expect("to 32bpp");
+    let mut pixa = Pixa::new();
+    for i in 0..4u32 {
+        let rotated = rotate_orth(&pixc, i).expect("rotate_orth");
+        let boxa2 = boxa.rotate_orth(w, h, i as i32).expect("boxa rotate_orth");
+        let mut m = rotated.to_mut();
+        m.render_hash_boxa_color(
+            &boxa2,
+            10,
+            3,
+            orient_of(i as usize),
+            true,
+            color_of(i as usize + 4),
+        )
+        .expect("render_hash_boxa_color");
+        pixa.push(m.into());
+    }
+    let tiled = pixa
+        .display_tiled_in_rows(PixelDepth::Bit32, 1200, 0.7, 0, 30, 3)
+        .expect("tiled in rows");
+    rp.write_pix_and_check(&tiled, ImageFormat::Png)
+        .expect("check: xformbox rotate orth");
+
+    // C check 4: the six transform orders, over translation then scaling.
+    // pixs = clip(feyn, 420, 360, 1500, 465) with a 200px right border.
+    let pixt = feyn.clip_rectangle(420, 360, 1500, 465).expect("clip 2");
+    let pixs = pixt
+        .add_border_general(0, 200, 0, 0, 0)
+        .expect("add right border");
+    let comps = find_connected_components(&pixs, ConnectivityType::EightWay).expect("conncomp 2");
+    let mut boxa = Boxa::new();
+    for c in &comps {
+        boxa.push(c.bounds);
+    }
+
+    let render = |pix: &Pix, boxa: &Boxa, i: usize| -> Pix {
+        let mut m = pix.deep_clone().to_mut();
+        for b in boxa.iter() {
+            m.render_hash_box_color(b, 10, 3, orient_of(i), true, color_of(i))
+                .expect("render_hash_box_color");
+        }
+        m.into()
+    };
+
+    // (shift, scale, orders) per C group.
+    /// (shift, scale, three transform orders, base colour index).
+    struct Group {
+        shift: (i32, i32),
+        scale: (f32, f32),
+        orders: [TransformOrder; 3],
+        base_index: usize,
+    }
+    let groups: [Group; 4] = [
+        Group {
+            shift: (50, 70),
+            scale: (1.0, 1.0),
+            orders: [
+                TransformOrder::TrScRo,
+                TransformOrder::TrRoSc,
+                TransformOrder::ScTrRo,
+            ],
+            base_index: 0,
+        },
+        Group {
+            shift: (50, 70),
+            scale: (1.0, 1.0),
+            orders: [
+                TransformOrder::RoTrSc,
+                TransformOrder::RoScTr,
+                TransformOrder::ScRoTr,
+            ],
+            base_index: 4,
+        },
+        Group {
+            shift: (0, 0),
+            scale: (1.17, 1.13),
+            orders: [
+                TransformOrder::TrScRo,
+                TransformOrder::ScRoTr,
+                TransformOrder::ScTrRo,
+            ],
+            base_index: 8,
+        },
+        Group {
+            shift: (0, 0),
+            scale: (1.17, 1.13),
+            orders: [
+                TransformOrder::RoTrSc,
+                TransformOrder::RoScTr,
+                TransformOrder::TrRoSc,
+            ],
+            base_index: 12,
+        },
+    ];
+
+    let base = pixs.convert_to_32().expect("pixs to 32bpp");
+    let mut pixa = Pixa::new();
+    for group in groups {
+        let (sx, sy) = group.shift;
+        let (scx, scy) = group.scale;
+        let mut acc = base.deep_clone();
+        for (i, order) in group.orders.into_iter().enumerate() {
+            let boxat = boxa.transform_ordered(sx, sy, scx, scy, 450, 250, 0.10, order);
+            acc = render(&acc, &boxat, group.base_index + i);
+        }
+        pixa.push(acc);
+    }
+    let tiled = pixa
+        .display_tiled_in_columns(1, 0.5, 20, 0)
+        .expect("tiled in columns");
+    rp.write_pix_and_check(&tiled, ImageFormat::Png)
+        .expect("check: xformbox ordered transforms");
+
+    assert!(rp.cleanup(), "xformbox c-compat test failed");
+}


### PR DESCRIPTION
## Why

transform に残る最後の全 PNG 系列。入力は feyn.tif (lossless) で、hash box
描画 3 種と boxa の直交回転・順序付き変換を検証できる。

## What

### 実装差 22 件目: cmapped への arb-colour 描画

`render_pta_color` が colormap 付き画像でも深度から求めた生の gray/RGB 値を
書いており、無関係な colormap エントリを指していた。C `pixRenderPtaArb` は
`pixcmapAddNearestColor` で色を解決してその index を書き込む。TDD で修正
(PR 13 の `paint_through_mask`、PR 15 の `rasterop_hip/vip` と同系統の欠陥)。

### C 互換ペア 3 件追加 — 全件 Ok (Ok 140 → 143)

`xformbox.00-02` ↔ `xformbox_c.01-03`。C prog と同条件 (feyn.tif の
461,429,1393,342 切り出し → 8 連結成分に hash box を 3 方式で描画) で
**1bpp / 8bpp cmapped / 32bpp blend の 3 描画経路**が bit 一致。

### C 3/4 は次段送り (理由付き Excluded)

どちらも `pixaDisplayTiledIn*` 内部の `pixScale` を経由するが、Rust の
`scale_general` は C と以下が異なる (**実装差 23 件目**として記録):

- **unsharp masking** — C `pixScale` は sharpfract 0.2/0.4、sharpwidth 1/2 を
  既定で適用するが Rust は引数を無視 (`_sharpfract`, `_sharpwidth`)
- **area map の 1/2 特別ケース**と**出力寸法の丸め** — 0.5 倍で C は 232、
  Rust は 233 になり寸法から食い違う

修正は `scale_general` の C 準拠化 + unsharp masking の連鎖になり影響範囲が
広いため、本 PR では `c_compat_exclude.tsv` に理由付きで分離し PR 17 で扱う。
C 5 はさらに `boxaAffineTransform` + 2D 行列ビルダの移植が必要。

## Impact

- ベースライン: **Ok 143 / Mismatch 29 / MissingC 0 / Unmapped 400 /
  Excluded 85**。transform binary は Ok 20 → 23
- 公開 API の挙動変更: cmapped 画像への `render_pta_color` (および
  `render_hash_box_color` など経由する描画) が colormap index を書くようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg