### PR TITLE
feat(c-compat): scale_general の C 準拠化 — 実装差 5 件修正で xformbox 5 ペア全件 Ok (plan 902 PR 17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 16 後):
+- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 17 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 143 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 85**
+  **Ok 145 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 83**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -339,7 +339,7 @@ hash box 描画 3 種と boxa の直交回転・順序付き変換を検証す�
   (実装差 23 件目)。理由付きで Excluded に分離し PR 17 で対応する
 - C 5 はさらに `boxaAffineTransform` + 2D 行列ビルダが未移植
 
-### PR 17: scale_general の C 準拠化 (IN_PROGRESS)
+### PR 17: scale_general の C 準拠化 (実施済み)
 
 C 版ソース: `src/scale1.c` (pixScale / pixScaleGeneral)、
 `src/enhance.c` (pixUnsharpMasking* )。
@@ -363,6 +363,20 @@ C `pixScaleGeneral` との差:
 `blockconv_gray` による全面ブラーで、C の分離型 box フィルタ
 (内部のみ更新、border は原画コピー、`(int)(s + f*(s-L) + 0.5)`) と
 異なる。
+
+実施結果 — 追跡の過程で **実装差 5 件 (23-27) を発見・修正**:
+
+- **23** `scale_general` の dispatch と unsharp masking (上記)
+- **24** `unsharp_masking_gray_fast` の分離型 box 化
+- **25** `scale_area_map_2` の 2x2 平均が `+2` の四捨五入 (C は
+  `val >>= 2` の切り捨て)、alpha も平均していた
+- **26** 対角 hash の spacing を f32 で計算しており、C の double と
+  切り捨て位置がずれる (`generatePtaHashBox`)
+- **27** **閾値比較の精度**。C は `l_float32` を double literal と
+  比較するため float が昇格し、`0.7f` は「< 0.7」と判定される。
+  Rust の f32 同士比較では false になり dispatch が分岐していた
+- xformbox 5 ペア **全件 Ok (Ok 143 → 145)**、PR 16 の Excluded 2 件も
+  解消。transform binary は Unmapped/Excluded ともに残り 0 の Ok 25
 
 ### PR 18 以降: semantic マッピングの漸進追加
 

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -339,7 +339,32 @@ hash box 描画 3 種と boxa の直交回転・順序付き変換を検証す�
   (実装差 23 件目)。理由付きで Excluded に分離し PR 17 で対応する
 - C 5 はさらに `boxaAffineTransform` + 2D 行列ビルダが未移植
 
-### PR 17 以降: semantic マッピングの漸進追加
+### PR 17: scale_general の C 準拠化 (IN_PROGRESS)
+
+C 版ソース: `src/scale1.c` (pixScale / pixScaleGeneral)、
+`src/enhance.c` (pixUnsharpMasking* )。
+
+PR 16 で記録した実装差 23 件目の解消。`pixScale` は移植済み関数の中でも
+利用箇所が広く (`display_tiled_in_*` の scalefactor 経路を含む)、C との
+乖離が xformbox 2 ペアのブロッカーになっている。
+
+C `pixScaleGeneral` との差:
+
+- **unsharp masking を適用していない** — C は `pixScale` から
+  sharpfract 0.2 (maxscale < 0.7) / 0.4、sharpwidth 1 / 2 を既定で渡し、
+  縮小時は maxscale > 0.2、拡大時は maxscale < 1.4 の条件で適用する。
+  Rust は引数を `_sharpfract` / `_sharpwidth` として無視
+- **sub-dispatch** — C は公開関数 (`pixScaleAreaMap` / `pixScaleGrayLI` /
+  `pixScaleColorLI`) を呼ぶため 1/2 の特別ケースや寸法規約が効くが、
+  Rust は impl を直接呼び `.round()` で寸法を決めている
+- 1bpp は `pixScaleBinary`、それ以外は `pixConvertTo8Or32` を通す
+
+あわせて **実装差 24 件目**: `unsharp_masking_gray_fast` が
+`blockconv_gray` による全面ブラーで、C の分離型 box フィルタ
+(内部のみ更新、border は原画コピー、`(int)(s + f*(s-L) + 0.5)`) と
+異なる。
+
+### PR 18 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -52,15 +52,15 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 ## 全体集計
 
-| 状態        | 件数    | 説明                                                                                                                                   |
-| ----------- | ------: | -------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **143** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +99)                                                        |
-| ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)      |
-| ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                           |
-| 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                                    |
-| 🚫 Excluded | **85**  | 設計上マップ不能または前提未整備 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + xformbox 2 |
+| 状態        | 件数    | 説明                                                                                                                              |
+| ----------- | ------: | --------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Ok       | **145** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +101)                                                  |
+| ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
+| ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
+| 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                               |
+| 🚫 Excluded | **83**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + Rust 独自 falsecolor 4               |
 
-合計 657 entries がレポート対象 (As of 2026-08-16、plan 902 PR 16 後)。
+合計 657 entries がレポート対象 (As of 2026-08-16、plan 902 PR 17 後)。
 Rust manifest (`tests/golden_manifest.tsv`) 全体は **664 entries**。
 
 ## test binary 別の内訳
@@ -74,7 +74,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **664 entries**。
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |      9 |        0 |        0 |       45 |        0 |
 | `region`    | **46** |        2 |        0 |       28 |       29 |
-| `transform` |     23 |        0 |        0 |       78 |        2 |
+| `transform` |     25 |        0 |        0 |       78 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
 

--- a/scripts/c_compat_exclude.tsv
+++ b/scripts/c_compat_exclude.tsv
@@ -26,7 +26,3 @@ key	dist_contours.16.png	C counterpart a+6 is JPEG (finding 001)
 key	dist_seedfill.05.png	C b-section writes only JPEG (b+1..b+3, finding 001)
 key	dist_seedfill.06.png	C b-section writes only JPEG (b+1..b+3, finding 001)
 prefix	falsecolor	Rust-specific color-mapping API outputs; C falsecolor_reg outputs are paired via falsecolor_c
-# xformbox_reg (plan 902 PR 16): C 3/4 は pixScale の unsharp masking と
-# area map の 1/2 特別ケースが未移植 (scale_general の C 準拠化が前提)
-key	xformbox_c.04.png	needs C pixScale dispatch (unsharp masking); see plan 902 PR 17
-key	xformbox_c.05.png	needs C pixScale dispatch (unsharp masking); see plan 902 PR 17

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -290,3 +290,5 @@ transform	shear2	3	shear2_c	4	quadratic v shear, gray 601x601
 transform	xformbox	0	xformbox_c	1	render_hash_box on 1bpp components
 transform	xformbox	1	xformbox_c	2	render_hash_box_color on 8bpp
 transform	xformbox	2	xformbox_c	3	render_hash_box_blend on 32bpp
+transform	xformbox	3	xformbox_c	4	rotate_orth x4 + boxa rotate_orth, tiled in rows
+transform	xformbox	4	xformbox_c	5	transform_ordered 6 orders (translate + scale)

--- a/src/core/pix/graphics.rs
+++ b/src/core/pix/graphics.rs
@@ -492,10 +492,11 @@ pub fn generate_hash_box_pta(
             }
         }
         HashOrientation::PosSlope => {
-            let diag = bw as f32 + bh as f32;
-            let n = (2.0 + diag / (1.4 * spacing as f32)) as usize;
+            // C computes these in double precision; f32 truncates the line
+            // origins to different columns.
+            let n = 2 + ((bw as f64 + bh as f64) / (1.4 * spacing as f64)) as usize;
             for i in 0..n {
-                let x = (bx as f32 + (i as f32 + 0.5) * 1.4 * spacing as f32) as i32;
+                let x = (bx as f64 + (i as f64 + 0.5) * 1.4 * spacing as f64) as i32;
                 if let Ok(isect) = b.intersect_by_line(x, by - 1, 1.0)
                     && isect.count == 2
                 {
@@ -509,10 +510,9 @@ pub fn generate_hash_box_pta(
             }
         }
         HashOrientation::NegSlope => {
-            let diag = bw as f32 + bh as f32;
-            let n = (2.0 + diag / (1.4 * spacing as f32)) as usize;
+            let n = 2 + ((bw as f64 + bh as f64) / (1.4 * spacing as f64)) as usize;
             for i in 0..n {
-                let x = (bx as f32 - bh as f32 + (i as f32 + 0.5) * 1.4 * spacing as f32) as i32;
+                let x = (bx as f64 - bh as f64 + (i as f64 + 0.5) * 1.4 * spacing as f64) as i32;
                 if let Ok(isect) = b.intersect_by_line(x, by - 1, -1.0)
                     && isect.count == 2
                 {

--- a/src/core/pixa/mod.rs
+++ b/src/core/pixa/mod.rs
@@ -1299,11 +1299,12 @@ impl Pixa {
                 }
             };
             let pix1 = if scalefactor != 1.0 {
+                // C uses pixScale, i.e. the auto dispatch with sharpening.
                 crate::transform::scale(
                     &pixn,
                     scalefactor,
                     scalefactor,
-                    crate::transform::ScaleMethod::Linear,
+                    crate::transform::ScaleMethod::Auto,
                 )
                 .map_err(|e| Error::InvalidParameter(e.to_string()))?
             } else {

--- a/src/filter/edge.rs
+++ b/src/filter/edge.rs
@@ -316,14 +316,19 @@ pub fn unsharp_masking_gray_fast(pix: &Pix, halfwidth: u32, amount: f32) -> Filt
     }
 
     // Separable box filter: horizontal sums first, then vertical.
-    let mut rowsum = vec![0f32; (w * h) as usize];
+    // Index in usize so the buffer offset cannot overflow for large images.
+    let (wu, hu) = (w as usize, h as usize);
+    let len = wu.checked_mul(hu).ok_or_else(|| {
+        FilterError::InvalidParameters("image too large for the row-sum buffer".to_string())
+    })?;
+    let mut rowsum = vec![0f32; len];
     for y in 0..h {
         for x in hw..(w - hw) {
             let mut sum = 0u32;
             for k in (x - hw)..=(x + hw) {
                 sum += pix.get_pixel_unchecked(k, y);
             }
-            rowsum[(y * w + x) as usize] = sum as f32;
+            rowsum[y as usize * wu + x as usize] = sum as f32;
         }
     }
 
@@ -333,7 +338,7 @@ pub fn unsharp_masking_gray_fast(pix: &Pix, halfwidth: u32, amount: f32) -> Filt
         for x in hw..(w - hw) {
             let mut colsum = 0f32;
             for k in (y - hw)..=(y + hw) {
-                colsum += rowsum[(k * w + x) as usize];
+                colsum += rowsum[k as usize * wu + x as usize];
             }
             let lowpass = norm * colsum;
             let sval = pix.get_pixel_unchecked(x, y) as f32;

--- a/src/filter/edge.rs
+++ b/src/filter/edge.rs
@@ -1,7 +1,7 @@
 //! Edge detection and enhancement operations
 
 use crate::core::{Numa, Pix, PixelDepth, pix::RgbComponent};
-use crate::filter::{FilterError, FilterResult, Kernel, blockconv_gray, convolve_gray};
+use crate::filter::{FilterError, FilterResult, Kernel, convolve_gray};
 
 /// Edge detection orientation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -303,25 +303,43 @@ pub fn unsharp_masking_gray_fast(pix: &Pix, halfwidth: u32, amount: f32) -> Filt
 
     let w = pix.width();
     let h = pix.height();
+    let hw = halfwidth;
 
-    // Use block convolution for fast blurring
-    // blockconv_gray(pix, None, wc, hc) where kernel size = 2*halfwidth+1
-    let blurred = blockconv_gray(pix, None, halfwidth, halfwidth)?;
+    // C pixUnsharpMaskingGray2D starts from pixCopyBorder: the halfwidth
+    // border keeps the source values and only the interior is sharpened.
+    let blank = Pix::new(w, h, PixelDepth::Bit8)?;
+    let mut out_mut = blank.copy_border(pix, hw, hw, hw, hw)?.to_mut();
 
-    // Compute: result = original + amount * (original - blurred)
-    let out_pix = Pix::new(w, h, PixelDepth::Bit8)?;
-    let mut out_mut = out_pix.try_into_mut().unwrap();
+    if w <= 2 * hw || h <= 2 * hw {
+        // No interior to sharpen.
+        return Ok(out_mut.into());
+    }
 
+    // Separable box filter: horizontal sums first, then vertical.
+    let mut rowsum = vec![0f32; (w * h) as usize];
     for y in 0..h {
-        for x in 0..w {
-            let orig = pix.get_pixel_unchecked(x, y) as f32;
-            let blur = blurred.get_pixel_unchecked(x, y) as f32;
+        for x in hw..(w - hw) {
+            let mut sum = 0u32;
+            for k in (x - hw)..=(x + hw) {
+                sum += pix.get_pixel_unchecked(k, y);
+            }
+            rowsum[(y * w + x) as usize] = sum as f32;
+        }
+    }
 
-            let diff = orig - blur;
-            let result = orig + amount * diff;
-            let result = result.round().clamp(0.0, 255.0) as u32;
-
-            out_mut.set_pixel_unchecked(x, y, result);
+    let side = 2 * hw + 1;
+    let norm = 1.0 / (side * side) as f32;
+    for y in hw..(h - hw) {
+        for x in hw..(w - hw) {
+            let mut colsum = 0f32;
+            for k in (y - hw)..=(y + hw) {
+                colsum += rowsum[(k * w + x) as usize];
+            }
+            let lowpass = norm * colsum;
+            let sval = pix.get_pixel_unchecked(x, y) as f32;
+            // C: ival = (l_int32)(sval + fract * (sval - val) + 0.5)
+            let ival = (sval + amount * (sval - lowpass) + 0.5) as i32;
+            out_mut.set_pixel_unchecked(x, y, ival.clamp(0, 255) as u32);
         }
     }
 

--- a/src/transform/scale.rs
+++ b/src/transform/scale.rs
@@ -58,24 +58,23 @@ pub fn scale(pix: &Pix, scale_x: f32, scale_y: f32, method: ScaleMethod) -> Tran
         ));
     }
 
-    let method = match method {
-        ScaleMethod::Auto => {
-            // Choose method based on scale factors
-            let min_scale = scale_x.min(scale_y);
-            if min_scale < 0.7 {
-                ScaleMethod::AreaMap
-            } else {
-                ScaleMethod::Linear
-            }
-        }
-        m => m,
-    };
-
     match method {
+        // C pixScale: pick the sharpening parameters by scale, then let
+        // pixScaleGeneral do the dispatch.
+        ScaleMethod::Auto => {
+            let maxscale = scale_x.max(scale_y);
+            // C compares an l_float32 against a double literal, promoting
+            // the float, so a scale of 0.7f counts as < 0.7. Compare in f64.
+            let (sharpfract, sharpwidth) = if (maxscale as f64) < 0.7 {
+                (0.2, 1)
+            } else {
+                (0.4, 2)
+            };
+            scale_general(pix, scale_x, scale_y, sharpfract, sharpwidth)
+        }
         ScaleMethod::Sampling => scale_by_sampling_impl(pix, new_w, new_h),
         ScaleMethod::Linear => scale_linear(pix, new_w, new_h),
         ScaleMethod::AreaMap => scale_area_map_impl(pix, new_w, new_h),
-        ScaleMethod::Auto => unreachable!(),
     }
 }
 
@@ -250,7 +249,8 @@ pub fn scale_area_map_2(pix: &Pix) -> TransformResult<Pix> {
                     let v10 = pix.get_pixel_unchecked(2 * j + 1, 2 * i);
                     let v01 = pix.get_pixel_unchecked(2 * j, 2 * i + 1);
                     let v11 = pix.get_pixel_unchecked(2 * j + 1, 2 * i + 1);
-                    let avg = (v00 + v10 + v01 + v11 + 2) / 4;
+                    // C scaleAreaMapLow2: val >>= 2 (truncating).
+                    let avg = (v00 + v10 + v01 + v11) >> 2;
                     out_mut.set_pixel_unchecked(j, i, avg);
                 }
             }
@@ -266,15 +266,16 @@ pub fn scale_area_map_2(pix: &Pix) -> TransformResult<Pix> {
                     let p10 = pix.get_pixel_unchecked(2 * j + 1, 2 * i);
                     let p01 = pix.get_pixel_unchecked(2 * j, 2 * i + 1);
                     let p11 = pix.get_pixel_unchecked(2 * j + 1, 2 * i + 1);
-                    let (r0, g0, b0, a0) = pixel::extract_rgba(p00);
-                    let (r1, g1, b1, a1) = pixel::extract_rgba(p10);
-                    let (r2, g2, b2, a2) = pixel::extract_rgba(p01);
-                    let (r3, g3, b3, a3) = pixel::extract_rgba(p11);
-                    let r = ((r0 as u32 + r1 as u32 + r2 as u32 + r3 as u32 + 2) / 4) as u8;
-                    let g = ((g0 as u32 + g1 as u32 + g2 as u32 + g3 as u32 + 2) / 4) as u8;
-                    let b = ((b0 as u32 + b1 as u32 + b2 as u32 + b3 as u32 + 2) / 4) as u8;
-                    let a = ((a0 as u32 + a1 as u32 + a2 as u32 + a3 as u32 + 2) / 4) as u8;
-                    out_mut.set_pixel_unchecked(j, i, pixel::compose_rgba(r, g, b, a));
+                    let (r0, g0, b0, _) = pixel::extract_rgba(p00);
+                    let (r1, g1, b1, _) = pixel::extract_rgba(p10);
+                    let (r2, g2, b2, _) = pixel::extract_rgba(p01);
+                    let (r3, g3, b3, _) = pixel::extract_rgba(p11);
+                    // C scaleAreaMapLow2 shifts by 2 (truncating) and
+                    // composes only the colour bytes, leaving alpha 0.
+                    let r = ((r0 as u32 + r1 as u32 + r2 as u32 + r3 as u32) >> 2) as u8;
+                    let g = ((g0 as u32 + g1 as u32 + g2 as u32 + g3 as u32) >> 2) as u8;
+                    let b = ((b0 as u32 + b1 as u32 + b2 as u32 + b3 as u32) >> 2) as u8;
+                    out_mut.set_pixel_unchecked(j, i, pixel::compose_rgba(r, g, b, 0));
                 }
             }
             Ok(out_mut.into())
@@ -497,7 +498,8 @@ pub fn scale_li(pix: &Pix, scale_x: f32, scale_y: f32) -> TransformResult<Pix> {
         )));
     }
     let max_scale = scale_x.max(scale_y);
-    if max_scale < 0.7 {
+    // C promotes the l_float32 scale to double for this comparison.
+    if (max_scale as f64) < 0.7 {
         return scale_general(pix, scale_x, scale_y, 0.0, 0);
     }
     let depth = pix.depth();
@@ -528,7 +530,8 @@ pub fn scale_color_li(pix: &Pix, scale_x: f32, scale_y: f32) -> TransformResult<
         ));
     }
     let max_scale = scale_x.max(scale_y);
-    if max_scale < 0.7 {
+    // C promotes the l_float32 scale to double for this comparison.
+    if (max_scale as f64) < 0.7 {
         return scale_general(pix, scale_x, scale_y, 0.0, 0);
     }
     // C fast special cases.
@@ -563,7 +566,8 @@ pub fn scale_gray_li(pix: &Pix, scale_x: f32, scale_y: f32) -> TransformResult<P
         ));
     }
     let max_scale = scale_x.max(scale_y);
-    if max_scale < 0.7 {
+    // C promotes the l_float32 scale to double for this comparison.
+    if (max_scale as f64) < 0.7 {
         return scale_general(pix, scale_x, scale_y, 0.0, 0);
     }
     // C fast special cases.
@@ -595,44 +599,53 @@ pub fn scale_general(
     pix: &Pix,
     scale_x: f32,
     scale_y: f32,
-    _sharpfract: f32,
-    _sharpwidth: i32,
+    sharpfract: f32,
+    sharpwidth: i32,
 ) -> TransformResult<Pix> {
     if scale_x <= 0.0 || scale_y <= 0.0 {
         return Err(TransformError::InvalidScaleFactor(format!(
-            "scale factors must be positive: ({}, {})",
-            scale_x, scale_y
+            "scale factors must be positive: ({scale_x}, {scale_y})"
         )));
     }
     if scale_x == 1.0 && scale_y == 1.0 {
         return Ok(pix.deep_clone());
     }
-
-    let depth = pix.depth();
-    // 1bpp: fall through to sampling
-    if depth == PixelDepth::Bit1 {
-        let new_w = ((pix.width() as f32) * scale_x).round() as u32;
-        let new_h = ((pix.height() as f32) * scale_y).round() as u32;
-        return scale_by_sampling_impl(pix, new_w.max(1), new_h.max(1));
+    if pix.depth() == PixelDepth::Bit1 {
+        return scale_binary(pix, scale_x, scale_y);
     }
 
+    // C: pixConvertTo8Or32(pixs, L_CLONE, 0) — removes any colormap.
+    let src = pix
+        .convert_to_8_or_32()
+        .map_err(|e| TransformError::InvalidParameters(e.to_string()))?;
+    let depth = src.depth();
     let max_scale = scale_x.max(scale_y);
     let min_scale = scale_x.min(scale_y);
 
-    if max_scale < 0.7 {
-        if min_scale < 0.02 {
-            scale_smooth(pix, scale_x, scale_y)
+    // C compares l_float32 scales against double literals, so the floats
+    // are promoted; 0.7f counts as < 0.7. Compare in f64 throughout.
+    let (scaled, sharpen) = if (max_scale as f64) < 0.7 {
+        // Low-pass filter for anti-aliasing.
+        let out = if (min_scale as f64) < 0.02 {
+            scale_smooth(&src, scale_x, scale_y)?
         } else {
-            let new_w = ((pix.width() as f32) * scale_x).round() as u32;
-            let new_h = ((pix.height() as f32) * scale_y).round() as u32;
-            scale_area_map_impl(pix, new_w.max(1), new_h.max(1))
-        }
+            scale_area_map(&src, scale_x, scale_y)?
+        };
+        (out, max_scale as f64 > 0.2)
     } else {
-        // Linear interpolation
-        let new_w = ((pix.width() as f32) * scale_x).round() as u32;
-        let new_h = ((pix.height() as f32) * scale_y).round() as u32;
-        scale_linear(pix, new_w.max(1), new_h.max(1))
+        let out = if depth == PixelDepth::Bit8 {
+            scale_gray_li(&src, scale_x, scale_y)?
+        } else {
+            scale_color_li(&src, scale_x, scale_y)?
+        };
+        (out, (max_scale as f64) < 1.4)
+    };
+
+    if sharpen && sharpfract > 0.0 && sharpwidth > 0 {
+        return crate::filter::unsharp_masking(&scaled, sharpwidth as u32, sharpfract)
+            .map_err(|e| TransformError::InvalidParameters(e.to_string()));
     }
+    Ok(scaled)
 }
 
 /// Scale to a target resolution.
@@ -745,7 +758,8 @@ pub fn scale_smooth(pix: &Pix, scale_x: f32, scale_y: f32) -> TransformResult<Pi
             scale_x, scale_y
         )));
     }
-    if scale_x >= 0.7 || scale_y >= 0.7 {
+    // C: maxscale >= 0.7 with the float promoted to double.
+    if (scale_x as f64) >= 0.7 || (scale_y as f64) >= 0.7 {
         return scale_general(pix, scale_x, scale_y, 0.0, 0);
     }
 
@@ -1930,11 +1944,12 @@ pub fn scale_area_map(pix: &Pix, scale_x: f32, scale_y: f32) -> TransformResult<
         )));
     }
 
-    if scale_x.min(scale_y) < 0.02 {
+    // C promotes the l_float32 scales to double for these comparisons.
+    if (scale_x.min(scale_y) as f64) < 0.02 {
         // Too small for area mapping.
         return scale_smooth(pix, scale_x, scale_y);
     }
-    if scale_x.max(scale_y) >= 0.7 {
+    if (scale_x.max(scale_y) as f64) >= 0.7 {
         // Too large for area mapping.
         return scale_general(pix, scale_x, scale_y, 0.0, 0);
     }

--- a/src/transform/scale.rs
+++ b/src/transform/scale.rs
@@ -588,13 +588,23 @@ pub fn scale_gray_li(pix: &Pix, scale_x: f32, scale_y: f32) -> TransformResult<P
 
 /// General-purpose scaling with optional sharpening.
 ///
-/// Dispatches to the appropriate method based on scale factors:
-/// - For 1bpp: nearest-neighbor sampling
-/// - For `max_scale < 0.7`: smooth (box-filter) or area mapping
-/// - Otherwise: linear interpolation (LI)
+/// Dispatches like C `pixScaleGeneral`:
 ///
-/// **Note**: The `sharpfract` and `sharpwidth` parameters are accepted for API compatibility
-/// but sharpening is not applied. Use an external unsharp-masking step if needed.
+/// - 1 bpp goes to [`scale_binary`]; deeper input is first reduced to 8 or
+///   32 bpp (removing any colormap)
+/// - `max_scale < 0.7` uses a low-pass filter — [`scale_smooth`] when
+///   `min_scale < 0.02`, otherwise [`scale_area_map`]
+/// - otherwise linear interpolation ([`scale_gray_li`] / [`scale_color_li`])
+///
+/// `sharpfract` and `sharpwidth` control a final unsharp-masking pass: it
+/// runs when both are positive and the scale is in the useful range
+/// (`max_scale > 0.2` for reductions, `max_scale < 1.4` for magnifications).
+/// Pass `0.0` / `0` to skip sharpening; [`scale`] with
+/// [`ScaleMethod::Auto`] supplies C's defaults (0.2/1 or 0.4/2).
+///
+/// # See also
+///
+/// C Leptonica: `pixScaleGeneral()` in `scale1.c`
 pub fn scale_general(
     pix: &Pix,
     scale_x: f32,
@@ -615,9 +625,7 @@ pub fn scale_general(
     }
 
     // C: pixConvertTo8Or32(pixs, L_CLONE, 0) — removes any colormap.
-    let src = pix
-        .convert_to_8_or_32()
-        .map_err(|e| TransformError::InvalidParameters(e.to_string()))?;
+    let src = pix.convert_to_8_or_32()?;
     let depth = src.depth();
     let max_scale = scale_x.max(scale_y);
     let min_scale = scale_x.min(scale_y);

--- a/tests/core/pta_graphics_reg.rs
+++ b/tests/core/pta_graphics_reg.rs
@@ -220,19 +220,28 @@ fn replicate_pattern_from_pix() {
 /// Evaluating it in f32 truncates differently — for a box at x = 5 with
 /// spacing 10, line 1 lands at 25 in C but at 26 in f32.
 #[test]
-#[ignore = "not yet implemented: hash spacing is computed in f32"]
 fn hash_box_diagonal_spacing_matches_c() {
     use leptonica::Box as LeptBox;
     use leptonica::core::pix::graphics::{HashOrientation, generate_hash_box_pta};
 
+    // width = 1 so each diagonal is a single pixel wide and its position
+    // is unambiguous.
     let b = LeptBox::new(5, 5, 45, 28).unwrap();
-    let pta = generate_hash_box_pta(&b, 10, 3, HashOrientation::PosSlope, false)
+    let pta = generate_hash_box_pta(&b, 10, 1, HashOrientation::PosSlope, false)
         .expect("generate_hash_box_pta");
 
-    // C's second diagonal starts at x = 25 (not 26), so its topmost point
-    // on the box's top edge is (24, 5) after the intersection.
-    let has_24_5 = pta.iter().any(|(x, y)| x as i32 == 24 && y as i32 == 5);
-    let has_25_5 = pta.iter().any(|(x, y)| x as i32 == 25 && y as i32 == 5);
-    assert!(has_24_5, "expected C's diagonal through (24, 5)");
-    assert!(!has_25_5, "f32 rounding would put the diagonal at (25, 5)");
+    // C's diagonals meet the top edge (y = 5) at x = 11, 24, 39 — the
+    // second one is 24 because C evaluates the origin in double precision
+    // (f32 would place it at 25).
+    let top_xs: Vec<i32> = {
+        let mut xs: Vec<i32> = pta
+            .iter()
+            .filter(|(_, y)| *y as i32 == 5)
+            .map(|(x, _)| x as i32)
+            .collect();
+        xs.sort_unstable();
+        xs.dedup();
+        xs
+    };
+    assert_eq!(top_xs, vec![11, 24, 39], "diagonal origins on the top edge");
 }

--- a/tests/core/pta_graphics_reg.rs
+++ b/tests/core/pta_graphics_reg.rs
@@ -211,3 +211,28 @@ fn replicate_pattern_from_pix() {
     assert!(pts.contains(&(4, 4)));
     assert!(pts.contains(&(6, 6)));
 }
+
+/// Diagonal hash lines must use C's double-precision spacing
+/// (plan 902 PR 17).
+///
+/// C `generatePtaHashBox` computes the line origin as
+/// `(l_int32)(bx + (i + 0.5) * 1.4 * spacing)` in double precision.
+/// Evaluating it in f32 truncates differently — for a box at x = 5 with
+/// spacing 10, line 1 lands at 25 in C but at 26 in f32.
+#[test]
+#[ignore = "not yet implemented: hash spacing is computed in f32"]
+fn hash_box_diagonal_spacing_matches_c() {
+    use leptonica::Box as LeptBox;
+    use leptonica::core::pix::graphics::{HashOrientation, generate_hash_box_pta};
+
+    let b = LeptBox::new(5, 5, 45, 28).unwrap();
+    let pta = generate_hash_box_pta(&b, 10, 3, HashOrientation::PosSlope, false)
+        .expect("generate_hash_box_pta");
+
+    // C's second diagonal starts at x = 25 (not 26), so its topmost point
+    // on the box's top edge is (24, 5) after the intersection.
+    let has_24_5 = pta.iter().any(|(x, y)| x as i32 == 24 && y as i32 == 5);
+    let has_25_5 = pta.iter().any(|(x, y)| x as i32 == 25 && y as i32 == 5);
+    assert!(has_24_5, "expected C's diagonal through (24, 5)");
+    assert!(!has_25_5, "f32 rounding would put the diagonal at (25, 5)");
+}

--- a/tests/filter/enhance_reg.rs
+++ b/tests/filter/enhance_reg.rs
@@ -234,3 +234,53 @@ fn enhance_reg_mosaic_color_shift() {
     // Applies spatially-varying color shift across image tiles
     assert!(rp.cleanup(), "enhance mosaic_color_shift test failed");
 }
+
+/// Fast unsharp masking must follow C's separable box filter
+/// (plan 902 PR 17).
+///
+/// C `pixUnsharpMaskingGray2D` starts from `pixCopyBorder`, so the
+/// `halfwidth`-wide border keeps the source values, and only the interior
+/// is sharpened as `(int)(s + fract * (s - L) + 0.5)` where L is a
+/// separable box average over `(2*halfwidth+1)²`.
+#[test]
+#[ignore = "not yet implemented: unsharp fast blurs the whole image via blockconv"]
+fn enhance_unsharp_fast_matches_c() {
+    use leptonica::filter::unsharp_masking_gray_fast;
+    use leptonica::{Pix, PixelDepth};
+
+    // 5x5 with a bright centre; halfwidth 1 sharpens only the 3x3 interior.
+    let pix = {
+        let p = Pix::new(5, 5, PixelDepth::Bit8).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        for y in 0..5u32 {
+            for x in 0..5u32 {
+                pm.set_pixel(x, y, 100).unwrap();
+            }
+        }
+        pm.set_pixel(2, 2, 200).unwrap();
+        let p: Pix = pm.into();
+        p
+    };
+
+    let out = unsharp_masking_gray_fast(&pix, 1, 0.4).expect("unsharp fast");
+    assert_eq!((out.width(), out.height()), (5, 5));
+
+    // Border keeps the source values (C pixCopyBorder).
+    for x in 0..5u32 {
+        assert_eq!(out.get_pixel(x, 0).unwrap(), 100, "top border at x={x}");
+        assert_eq!(out.get_pixel(x, 4).unwrap(), 100, "bottom border at x={x}");
+    }
+    for y in 0..5u32 {
+        assert_eq!(out.get_pixel(0, y).unwrap(), 100, "left border at y={y}");
+        assert_eq!(out.get_pixel(4, y).unwrap(), 100, "right border at y={y}");
+    }
+
+    // Centre: L = (8*100 + 200) / 9 = 111.111; s = 200
+    //   ival = (int)(200 + 0.4 * (200 - 111.111) + 0.5) = (int)(236.055) = 236
+    assert_eq!(out.get_pixel(2, 2).unwrap(), 236);
+
+    // A neighbour of the centre: L = (8*100 + 200)/9 = 111.111 as well
+    // (the 3x3 window around (1,1) covers the centre), s = 100
+    //   ival = (int)(100 + 0.4 * (100 - 111.111) + 0.5) = (int)(96.055) = 96
+    assert_eq!(out.get_pixel(1, 1).unwrap(), 96);
+}

--- a/tests/filter/enhance_reg.rs
+++ b/tests/filter/enhance_reg.rs
@@ -243,7 +243,6 @@ fn enhance_reg_mosaic_color_shift() {
 /// is sharpened as `(int)(s + fract * (s - L) + 0.5)` where L is a
 /// separable box average over `(2*halfwidth+1)²`.
 #[test]
-#[ignore = "not yet implemented: unsharp fast blurs the whole image via blockconv"]
 fn enhance_unsharp_fast_matches_c() {
     use leptonica::filter::unsharp_masking_gray_fast;
     use leptonica::{Pix, PixelDepth};

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -419,7 +419,7 @@ graymorph1.18.png	30b9cd78569f8b93
 graymorph1.21.png	f0bf0443c990972b
 hardlight_color.03.png	281943cdfdbdf537
 hardlight_gray.03.png	3152a69afc6e4c40
-hardlight_orig.03.png	4b75beb05c1cfc9a
+hardlight_orig.03.png	d404d6e21d903a89
 hash.04.tif	5e6de61a46a887d8
 hash.06.tif	5e6de61a46a887d8
 hash.08.tif	3c1631dedc785bd8
@@ -470,11 +470,11 @@ lineremoval_morph.03.png	75e5ba2f861cdc3e
 lineremoval_morph.06.png	fc8919170aa50eab
 lineremoval_pipe.03.png	c8d9ac4cf5a3e493
 logicops_invert.03.tif	2fd7502f5f315b39
-multitype_affine.13.png	fc5cec9cc60d3d5c
-multitype_bilinear.13.png	7193594b9b90a957
-multitype_projective.13.png	e71b1c9ab1375894
-multitype_rotate.11.png	c67432d4578642e4
-multitype_scale.15.png	c9d53e149971375f
+multitype_affine.13.png	4f1ee754f2651fe8
+multitype_bilinear.13.png	7d7be38cae72e408
+multitype_projective.13.png	e9449302d5b1726f
+multitype_rotate.11.png	26811882472cd3fc
+multitype_scale.15.png	5acb94f75d497ae5
 newspaper_lines.03.tif	110dbc79418357ed
 newspaper_removal.05.tif	eacb2c7b194ebbed
 newspaper_scale.03.png	305f9d43d0f66b33
@@ -567,7 +567,7 @@ rotateorth.16.png	4e0162ba6433c1f6
 rotateorth.28.png	bcc1922c2afc4e9a
 scale.03.png	6f29584fc6b18824
 scale.06.png	018b9de25103953d
-scale.09.png	659231111c5a8dcd
+scale.09.png	25ccc27d0749f008
 scale.16.png	06dab1f73264af7d
 scale.22.png	e03d45f20ae6ef39
 scale.24.png	a050038134b26386
@@ -662,5 +662,5 @@ writetext_setline.01.png	5ed9a5b9156de512
 xformbox_c.01.png	28993e9a4de8e97a
 xformbox_c.02.png	0d3e996267f3a878
 xformbox_c.03.png	28e411c8fcfdbdd6
-xformbox_c.04.png	f036ee328e790bc3
-xformbox_c.05.png	f5e7d000f1fac774
+xformbox_c.04.png	f34ba323f1c18c8c
+xformbox_c.05.png	3500a61b4aed61f4

--- a/tests/transform/scale_reg.rs
+++ b/tests/transform/scale_reg.rs
@@ -209,7 +209,6 @@ fn scale_general_matches_c_dispatch() {
 /// truncating shift, not a `+2` round-half-up — and composes only the
 /// three colour bytes (alpha stays 0).
 #[test]
-#[ignore = "not yet implemented: scale_area_map_2 rounds instead of truncating"]
 fn scale_area_map_2_truncates_like_c() {
     use leptonica::transform::scale_area_map_2;
     use leptonica::{Pix, PixelDepth};

--- a/tests/transform/scale_reg.rs
+++ b/tests/transform/scale_reg.rs
@@ -141,3 +141,58 @@ fn scale_reg() {
 
     assert!(rp.cleanup(), "scale regression test failed");
 }
+
+/// scale_general must follow C pixScaleGeneral (plan 902 PR 17).
+///
+/// C dispatches to the public `pixScaleAreaMap` / `pixScaleGrayLI` /
+/// `pixScaleColorLI` entry points (so their special cases and
+/// `(int)(scale * ws + 0.5)` sizing apply) and then sharpens with
+/// `pixUnsharpMasking` when `sharpfract`/`sharpwidth` are positive:
+/// for reductions when `maxscale > 0.2`, for magnifications when
+/// `maxscale < 1.4`.
+#[test]
+#[ignore = "not yet implemented: scale_general ignores sharpening and sub-dispatch"]
+fn scale_general_matches_c_dispatch() {
+    use leptonica::transform::{scale, scale_area_map, scale_general};
+    use leptonica::{Pix, PixelDepth};
+
+    // A 465-tall image at 0.5 must use the area-map 1/2 special case,
+    // giving 232 (not the 233 that rounding would produce).
+    let pix = Pix::new(300, 465, PixelDepth::Bit32).expect("create");
+    let out = scale_general(&pix, 0.5, 0.5, 0.0, 0).expect("scale_general");
+    assert_eq!((out.width(), out.height()), (150, 232));
+    let direct = scale_area_map(&pix, 0.5, 0.5).expect("scale_area_map");
+    assert_eq!((direct.width(), direct.height()), (150, 232));
+
+    // With sharpening disabled the result must equal the bare area map.
+    let gradient = {
+        let p = Pix::new(64, 64, PixelDepth::Bit8).expect("create gray");
+        let mut pm = p.try_into_mut().unwrap();
+        for y in 0..64u32 {
+            for x in 0..64u32 {
+                pm.set_pixel(x, y, (x * 4) % 256).unwrap();
+            }
+        }
+        let p: Pix = pm.into();
+        p
+    };
+    let plain = scale_general(&gradient, 0.5, 0.5, 0.0, 0).expect("no sharpening");
+    let area = scale_area_map(&gradient, 0.5, 0.5).expect("area map");
+    for y in 0..plain.height() {
+        for x in 0..plain.width() {
+            assert_eq!(plain.get_pixel(x, y), area.get_pixel(x, y), "({x}, {y})");
+        }
+    }
+
+    // pixScale applies sharpening by default, so it must differ from the
+    // unsharpened path on an image with edges.
+    let sharpened =
+        scale(&gradient, 0.5, 0.5, leptonica::transform::ScaleMethod::Auto).expect("scale");
+    assert_eq!(
+        (sharpened.width(), sharpened.height()),
+        (plain.width(), plain.height())
+    );
+    let differs = (0..plain.height())
+        .any(|y| (0..plain.width()).any(|x| sharpened.get_pixel(x, y) != plain.get_pixel(x, y)));
+    assert!(differs, "pixScale must sharpen by default");
+}

--- a/tests/transform/scale_reg.rs
+++ b/tests/transform/scale_reg.rs
@@ -151,7 +151,6 @@ fn scale_reg() {
 /// for reductions when `maxscale > 0.2`, for magnifications when
 /// `maxscale < 1.4`.
 #[test]
-#[ignore = "not yet implemented: scale_general ignores sharpening and sub-dispatch"]
 fn scale_general_matches_c_dispatch() {
     use leptonica::transform::{scale, scale_area_map, scale_general};
     use leptonica::{Pix, PixelDepth};
@@ -165,12 +164,19 @@ fn scale_general_matches_c_dispatch() {
     assert_eq!((direct.width(), direct.height()), (150, 232));
 
     // With sharpening disabled the result must equal the bare area map.
+    // A blocky pattern: a linear ramp would make the box lowpass equal the
+    // centre value, so sharpening would be a no-op.
     let gradient = {
         let p = Pix::new(64, 64, PixelDepth::Bit8).expect("create gray");
         let mut pm = p.try_into_mut().unwrap();
         for y in 0..64u32 {
             for x in 0..64u32 {
-                pm.set_pixel(x, y, (x * 4) % 256).unwrap();
+                let v = if ((x / 4) + (y / 4)) % 2 == 0 {
+                    40
+                } else {
+                    210
+                };
+                pm.set_pixel(x, y, v).unwrap();
             }
         }
         let p: Pix = pm.into();
@@ -195,4 +201,52 @@ fn scale_general_matches_c_dispatch() {
     let differs = (0..plain.height())
         .any(|y| (0..plain.width()).any(|x| sharpened.get_pixel(x, y) != plain.get_pixel(x, y)));
     assert!(differs, "pixScale must sharpen by default");
+}
+
+/// scale_area_map_2 must truncate like C (plan 902 PR 17).
+///
+/// C `scaleAreaMapLow2` averages each 2x2 block with `val >>= 2` — a
+/// truncating shift, not a `+2` round-half-up — and composes only the
+/// three colour bytes (alpha stays 0).
+#[test]
+#[ignore = "not yet implemented: scale_area_map_2 rounds instead of truncating"]
+fn scale_area_map_2_truncates_like_c() {
+    use leptonica::transform::scale_area_map_2;
+    use leptonica::{Pix, PixelDepth};
+
+    // 2x2 gray block summing to 402: C gives 402 >> 2 = 100,
+    // rounding would give (402 + 2) / 4 = 101.
+    let gray = {
+        let p = Pix::new(2, 2, PixelDepth::Bit8).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        pm.set_pixel(0, 0, 100).unwrap();
+        pm.set_pixel(1, 0, 101).unwrap();
+        pm.set_pixel(0, 1, 100).unwrap();
+        pm.set_pixel(1, 1, 101).unwrap();
+        let p: Pix = pm.into();
+        p
+    };
+    let out = scale_area_map_2(&gray).expect("scale_area_map_2 gray");
+    assert_eq!((out.width(), out.height()), (1, 1));
+    assert_eq!(out.get_pixel(0, 0).unwrap(), 100);
+
+    // Same for each colour channel of a 32bpp block.
+    let color = {
+        let p = Pix::new(2, 2, PixelDepth::Bit32).unwrap();
+        let mut pm = p.try_into_mut().unwrap();
+        for (x, y, v) in [
+            (0u32, 0u32, 0x6465_66ffu32),
+            (1, 0, 0x6566_67ff),
+            (0, 1, 0x6465_66ff),
+            (1, 1, 0x6566_67ff),
+        ] {
+            pm.set_pixel(x, y, v).unwrap();
+        }
+        let p: Pix = pm.into();
+        p
+    };
+    let out = scale_area_map_2(&color).expect("scale_area_map_2 color");
+    // r: (100+101)*2 = 402 >> 2 = 100 = 0x64, likewise g = 0x65, b = 0x66.
+    // C composeRGBPixel leaves the alpha byte 0.
+    assert_eq!(out.get_pixel(0, 0).unwrap(), 0x6465_6600);
 }


### PR DESCRIPTION
## Why

PR 16 で記録した実装差 23 件目 (`scale_general` が C `pixScaleGeneral` と
異なる) の解消。`pixScale` は `display_tiled_in_*` の scalefactor 経路を
含めて利用箇所が広く、xformbox 2 ペアのブロッカーになっていた。

## What

追跡の過程で **実装差 5 件 (23〜27) を発見・修正** (各 TDD):

| # | 内容 |
| --: | --- |
| 23 | `scale_general` の dispatch と unsharp masking |
| 24 | `unsharp_masking_gray_fast` が全面ブラー |
| 25 | `scale_area_map_2` の 2x2 平均が四捨五入 |
| 26 | 対角 hash の spacing を f32 で計算 |
| 27 | **閾値比較の精度** — C の float→double 昇格 |

### 23: scale_general の C 準拠化

1 bpp は `scale_binary`、それ以外は `convert_to_8_or_32` を通し、**公開
関数** (`scale_area_map` / `scale_gray_li` / `scale_color_li`) を呼ぶよう
にした (これで 1/2 の特別ケースや `(int)(scale*ws + 0.5)` の寸法規約が
効く)。`sharpfract` / `sharpwidth` を実際に使い、縮小は `maxscale > 0.2`、
拡大は `maxscale < 1.4` で unsharp masking を適用する。
`ScaleMethod::Auto` (= C `pixScale`) は sharpfract 0.2/0.4、sharpwidth 1/2
を渡す。あわせて `display_tiled_in_rows` の scale を `Linear` から `Auto`
に修正。

### 24: unsharp masking

C `pixUnsharpMaskingGray2D` 準拠に書き直し: `pixCopyBorder` で halfwidth
幅の border に原画を残し、内部のみ水平→垂直の分離型 box 平均で
`(int)(s + fract*(s-L) + 0.5)` 更新する。

### 27: 閾値比較の精度 (今回の肝)

C は `l_float32` の scale を **double literal** と比較するため float が
昇格し、`0.7f` (= 0.69999998807…) は `< 0.7` と判定される。Rust の f32
同士比較では false になり、0.7 倍のとき dispatch が LI 側に分岐していた。
f64 で比較して再現。

### 結果: xformbox 5 ペア全件 Ok (Ok 143 → 145)

PR 16 で Excluded にしていた 2 件を golden_map に戻し、**transform binary
は Excluded 0 の Ok 25** になった。

## Impact

- ベースライン: **Ok 145 / Mismatch 29 / MissingC 0 / Unmapped 400 /
  Excluded 83**
- **公開 API の挙動変更**: `scale` / `scale_general` が C と同じく既定で
  sharpening を行い dispatch も変わる。`scale_area_map_2` は切り捨て平均・
  alpha 0、`unsharp_masking_gray_fast` は border 保持、対角 hash は 1 画素
  位置が変わる。いずれも C 準拠への修正で、影響する既存 golden を再生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg