### PR TITLE
feat(c-compat): lineremoval 整列 — 回転の三角関数精度を C 準拠にして 10 ペア全件 Ok (plan 902 PR 20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 19 後):
+- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 20 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 172 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 83**
+  **Ok 182 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 83**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -442,7 +442,7 @@ C `pixLocalExtrema(pixs, maxmin, minmax, &pixmin, &pixmax)`:
 - grayfill が **27 ペア全件 Ok (Ok 166 → 172)**。grayfill_reg の全 PNG
   出力を完全制覇し、region binary は Ok 73
 
-### PR 20: lineremoval 整列 — recog の lossless パイプライン (IN_PROGRESS)
+### PR 20: lineremoval 整列 — recog の lossless パイプライン (実施済み)
 
 C 版ソース: `prog/lineremoval_reg.c`。
 
@@ -453,6 +453,19 @@ recog は Unmapped 45 で残る大きなプール。lineremoval_reg は入力が
 `threshold_to_value` ×2 → 反転 → `arith_add` → `combine_masked` と、
 gray morphology と算術の主要経路をまとめて検証できる。必要 API は
 すべて移植済み (`find_skew` は `SkewDetectOptions` 経由)。
+
+実施結果:
+
+- skew 角は C と完全一致 (-0.656250) だったが `rotate_am_gray` の出力が
+  3 画素だけずれた。追跡の結果 **実装差 30 件目**: C の
+  `rotateAM{Gray,Color}Low` は `sina = 16.f * sin(angle)` を、sin() が
+  double を返すため double 精度で計算し float に一度だけ丸める。
+  Rust は f32 で三角関数を評価していた。area map 系カーネルが f64 の
+  sin/cos を受け取るよう修正
+- さらにテスト側の `deg2rad` も C は `3.14159 / 180.` を **double 除算**
+  してから float に丸めており、f32 除算では sin が 1 ulp ずれる。
+  C と同じ計算順に揃えて解消
+- lineremoval 10 ペア **全件 Ok (Ok 172 → 182)**。recog binary は Ok 19
 
 ### PR 21 以降: semantic マッピングの漸進追加
 

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -442,7 +442,19 @@ C `pixLocalExtrema(pixs, maxmin, minmax, &pixmin, &pixmax)`:
 - grayfill が **27 ペア全件 Ok (Ok 166 → 172)**。grayfill_reg の全 PNG
   出力を完全制覇し、region binary は Ok 73
 
-### PR 20 以降: semantic マッピングの漸進追加
+### PR 20: lineremoval 整列 — recog の lossless パイプライン (IN_PROGRESS)
+
+C 版ソース: `prog/lineremoval_reg.c`。
+
+recog は Unmapped 45 で残る大きなプール。lineremoval_reg は入力が
+`dave-orig.png` (lossless) の単一直線パイプラインで、全 10 出力が PNG。
+
+閾値化 → skew 検出 → `rotate_am_gray` → gray close/erode/open →
+`threshold_to_value` ×2 → 反転 → `arith_add` → `combine_masked` と、
+gray morphology と算術の主要経路をまとめて検証できる。必要 API は
+すべて移植済み (`find_skew` は `SkewDetectOptions` 経由)。
+
+### PR 21 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,14 +54,14 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        | 件数    | 説明                                                                                                                              |
 | ----------- | ------: | --------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **172** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +128)                                                  |
+| ✅ Ok       | **182** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +138)                                                  |
 | ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
 | ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
 | 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                               |
 | 🚫 Excluded | **83**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + Rust 独自 falsecolor 4               |
 
-合計 684 entries がレポート対象 (As of 2026-08-16、plan 902 PR 19 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **691 entries**。
+合計 694 entries がレポート対象 (As of 2026-08-16、plan 902 PR 20 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **701 entries**。
 
 ## test binary 別の内訳
 
@@ -72,7 +72,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **691 entries**。
 | `filter`    |      2 |        5 |        0 |       57 |       40 |
 | `io`        |      7 |        2 |        0 |       41 |       10 |
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
-| `recog`     |      9 |        0 |        0 |       45 |        0 |
+| `recog`     |     19 |        0 |        0 |       45 |        0 |
 | `region`    | **73** |        2 |        0 |       28 |       29 |
 | `transform` |     25 |        0 |        0 |       78 |        0 |
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -321,3 +321,15 @@ region	grayfill	27	grayfill_c	28	set3 inv fill 4-way
 region	grayfill	29	grayfill_c	30	set3 fwd fill 4-way
 region	grayfill	31	grayfill_c	32	set4 inv fill 8-way
 region	grayfill	33	grayfill_c	34	set4 fwd fill 8-way
+
+# lineremoval_reg.c (plan 902 PR 20): dave-orig.png line removal pipeline
+recog	lineremoval	0	lineremoval_c	1	threshold to binary 170
+recog	lineremoval	1	lineremoval_c	2	rotate_am_gray by detected skew
+recog	lineremoval	2	lineremoval_c	3	close_gray 51x1
+recog	lineremoval	3	lineremoval_c	4	erode_gray 1x5
+recog	lineremoval	4	lineremoval_c	5	threshold_to_value 210 -> 255
+recog	lineremoval	5	lineremoval_c	6	threshold_to_value 200 -> 0
+recog	lineremoval	6	lineremoval_c	7	line mask (threshold 210)
+recog	lineremoval	7	lineremoval_c	8	arith_add with inverted lines
+recog	lineremoval	8	lineremoval_c	9	open_gray 1x9
+recog	lineremoval	9	lineremoval_c	10	combine_masked through line mask

--- a/src/transform/rotate.rs
+++ b/src/transform/rotate.rs
@@ -1026,10 +1026,11 @@ fn rotate_area_map_gray(
     let wm2 = src_w - 2;
     let hm2 = src_h - 2;
 
-    // Scale sin/cos by 16 for sub-pixel precision. C computes
-    // `16.f * sin(angle)` where sin() returns a double, so both the trig
-    // and the scaling happen in double precision and are rounded to float
-    // once; callers therefore hand us f64 sin/cos values.
+    // Scale sin/cos by 16 for sub-pixel precision, rounding to f32 once
+    // after the multiply. C computes `16.f * sin(angle)` where sin()
+    // returns a double, so both the trig and the scaling happen in double
+    // precision; taking f64 here lets callers reproduce that exactly (the
+    // shared dispatcher still widens its own f32 values).
     let sina = (16.0f64 * sin_a) as f32;
     let cosa = (16.0f64 * cos_a) as f32;
 
@@ -1093,10 +1094,11 @@ fn rotate_area_map_color(
     let wm2 = src_w - 2;
     let hm2 = src_h - 2;
 
-    // Scale sin/cos by 16 for sub-pixel precision. C computes
-    // `16.f * sin(angle)` where sin() returns a double, so both the trig
-    // and the scaling happen in double precision and are rounded to float
-    // once; callers therefore hand us f64 sin/cos values.
+    // Scale sin/cos by 16 for sub-pixel precision, rounding to f32 once
+    // after the multiply. C computes `16.f * sin(angle)` where sin()
+    // returns a double, so both the trig and the scaling happen in double
+    // precision; taking f64 here lets callers reproduce that exactly (the
+    // shared dispatcher still widens its own f32 values).
     let sina = (16.0f64 * sin_a) as f32;
     let cosa = (16.0f64 * cos_a) as f32;
 

--- a/src/transform/rotate.rs
+++ b/src/transform/rotate.rs
@@ -975,8 +975,8 @@ fn rotate_area_map_impl(
             rotate_area_map_gray(
                 src,
                 dst,
-                cos_a,
-                sin_a,
+                cos_a as f64,
+                sin_a as f64,
                 cx_src,
                 cy_src,
                 cx_dst,
@@ -986,7 +986,15 @@ fn rotate_area_map_impl(
         }
         PixelDepth::Bit32 => {
             rotate_area_map_color(
-                src, dst, cos_a, sin_a, cx_src, cy_src, cx_dst, cy_dst, fill_value,
+                src,
+                dst,
+                cos_a as f64,
+                sin_a as f64,
+                cx_src,
+                cy_src,
+                cx_dst,
+                cy_dst,
+                fill_value,
             );
         }
         _ => {
@@ -1003,8 +1011,8 @@ fn rotate_area_map_impl(
 fn rotate_area_map_gray(
     src: &Pix,
     dst: &mut PixMut,
-    cos_a: f32,
-    sin_a: f32,
+    cos_a: f64,
+    sin_a: f64,
     cx_src: f32,
     cy_src: f32,
     cx_dst: f32,
@@ -1018,9 +1026,12 @@ fn rotate_area_map_gray(
     let wm2 = src_w - 2;
     let hm2 = src_h - 2;
 
-    // Scale sin/cos by 16 for sub-pixel precision
-    let sina = 16.0 * sin_a;
-    let cosa = 16.0 * cos_a;
+    // Scale sin/cos by 16 for sub-pixel precision. C computes
+    // `16.f * sin(angle)` where sin() returns a double, so both the trig
+    // and the scaling happen in double precision and are rounded to float
+    // once; callers therefore hand us f64 sin/cos values.
+    let sina = (16.0f64 * sin_a) as f32;
+    let cosa = (16.0f64 * cos_a) as f32;
 
     for i in 0..dst_h {
         let ydif = cy_dst - i as f32;
@@ -1067,8 +1078,8 @@ fn rotate_area_map_gray(
 fn rotate_area_map_color(
     src: &Pix,
     dst: &mut PixMut,
-    cos_a: f32,
-    sin_a: f32,
+    cos_a: f64,
+    sin_a: f64,
     cx_src: f32,
     cy_src: f32,
     cx_dst: f32,
@@ -1082,9 +1093,12 @@ fn rotate_area_map_color(
     let wm2 = src_w - 2;
     let hm2 = src_h - 2;
 
-    // Scale sin/cos by 16 for sub-pixel precision
-    let sina = 16.0 * sin_a;
-    let cosa = 16.0 * cos_a;
+    // Scale sin/cos by 16 for sub-pixel precision. C computes
+    // `16.f * sin(angle)` where sin() returns a double, so both the trig
+    // and the scaling happen in double precision and are rounded to float
+    // once; callers therefore hand us f64 sin/cos values.
+    let sina = (16.0f64 * sin_a) as f32;
+    let cosa = (16.0f64 * cos_a) as f32;
 
     for i in 0..dst_h {
         let ydif = cy_dst - i as f32;
@@ -1251,8 +1265,8 @@ pub fn rotate_am_color_corner(pix: &Pix, angle: f32, fill: RotateFill) -> Transf
     let out_pix = Pix::new(w, h, PixelDepth::Bit32)?;
     let mut out_mut = out_pix.try_into_mut().unwrap();
 
-    let cos_a = angle.cos();
-    let sin_a = angle.sin();
+    let cos_a = (angle as f64).cos();
+    let sin_a = (angle as f64).sin();
     rotate_area_map_color(
         pix,
         &mut out_mut,
@@ -1292,9 +1306,17 @@ pub fn rotate_am_gray_corner(pix: &Pix, angle: f32, fill: RotateFill) -> Transfo
     let out_pix = Pix::new(w, h, PixelDepth::Bit8)?;
     let mut out_mut = out_pix.try_into_mut().unwrap();
 
-    let cos_a = angle.cos();
-    let sin_a = angle.sin();
-    rotate_area_map_gray(pix, &mut out_mut, cos_a, sin_a, 0.0, 0.0, 0.0, 0.0, grayval);
+    rotate_area_map_gray(
+        pix,
+        &mut out_mut,
+        (angle as f64).cos(),
+        (angle as f64).sin(),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        grayval,
+    );
 
     Ok(out_mut.into())
 }
@@ -1499,7 +1521,17 @@ pub fn rotate_with_alpha(
 
     let alpha_out_pix = Pix::new(w, h, PixelDepth::Bit8)?;
     let mut alpha_out = alpha_out_pix.try_into_mut().unwrap();
-    rotate_area_map_gray(alpha, &mut alpha_out, cos_a, sin_a, cx, cy, cx, cy, 255);
+    rotate_area_map_gray(
+        alpha,
+        &mut alpha_out,
+        cos_a as f64,
+        sin_a as f64,
+        cx,
+        cy,
+        cx,
+        cy,
+        255,
+    );
     let rotated_alpha: Pix = alpha_out.into();
 
     // Set alpha channel in rotated RGB result
@@ -1620,7 +1652,17 @@ pub fn rotate_binary_nice(pix: &Pix, angle: f32, fill: RotateFill) -> TransformR
     let cy = h as f32 / 2.0;
     let rot_pix = Pix::new(w, h, PixelDepth::Bit8)?;
     let mut rot_mut = rot_pix.try_into_mut().unwrap();
-    rotate_area_map_gray(&blurred, &mut rot_mut, cos_a, sin_a, cx, cy, cx, cy, fill_8);
+    rotate_area_map_gray(
+        &blurred,
+        &mut rot_mut,
+        cos_a as f64,
+        sin_a as f64,
+        cx,
+        cy,
+        cx,
+        cy,
+        fill_8,
+    );
     let rotated: Pix = rot_mut.into();
 
     // Step 4: Threshold back to 1bpp (threshold at 128)
@@ -1794,8 +1836,8 @@ pub fn rotate_am_color(pix: &Pix, angle: f32, fill: RotateFill) -> TransformResu
     rotate_area_map_color(
         pix,
         &mut out_mut,
-        angle.cos(),
-        angle.sin(),
+        (angle as f64).cos(),
+        (angle as f64).sin(),
         cx,
         cy,
         cx,
@@ -1828,8 +1870,8 @@ pub fn rotate_am_gray(pix: &Pix, angle: f32, fill: RotateFill) -> TransformResul
     rotate_area_map_gray(
         pix,
         &mut out_mut,
-        angle.cos(),
-        angle.sin(),
+        (angle as f64).cos(),
+        (angle as f64).sin(),
         cx,
         cy,
         cx,

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -493,6 +493,16 @@ label_color.04.png	37a15882b4e4de36
 label_color.05.png	8d44f91be67bd7c2
 label_color.06.png	2279f937e200daaf
 lineremoval_arith.07.png	8d99f24d54367565
+lineremoval_c.01.png	a629c332e7bee375
+lineremoval_c.02.png	5927b97930b9e030
+lineremoval_c.03.png	99e426adf8eb44b4
+lineremoval_c.04.png	df7ff2bd83d9cb0e
+lineremoval_c.05.png	4d75e24b6064d83d
+lineremoval_c.06.png	93f9a2df0ce46cf7
+lineremoval_c.07.png	3d59516a088e77a4
+lineremoval_c.08.png	6bc88e682feac7e1
+lineremoval_c.09.png	f1a08de495af342c
+lineremoval_c.10.png	e75256e1d138b4a6
 lineremoval_morph.03.png	75e5ba2f861cdc3e
 lineremoval_morph.06.png	fc8919170aa50eab
 lineremoval_pipe.03.png	c8d9ac4cf5a3e493

--- a/tests/recog/lineremoval_reg.rs
+++ b/tests/recog/lineremoval_reg.rs
@@ -176,3 +176,104 @@ fn lineremoval_reg_pipeline() {
 
     assert!(rp.cleanup(), "lineremoval pipeline test failed");
 }
+
+/// C-comparable line removal pipeline (plan 902 PR 20).
+///
+/// Mirrors C lineremoval_reg exactly: dave-orig.png thresholded, skew
+/// detected and corrected with `rotate_am_gray`, lines isolated with
+/// gray close/erode and two `threshold_to_value` steps, then merged back
+/// with `arith_add` and `combine_masked`. All ten outputs are PNG.
+#[test]
+fn lineremoval_c_compat() {
+    use leptonica::morph::{close_gray, erode_gray, open_gray};
+    use leptonica::recog::skew::{SkewDetectOptions, find_skew};
+    use leptonica::transform::{RotateFill, rotate_am_gray};
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("lineremoval_c");
+
+    let pixs = crate::common::load_test_image("dave-orig.png").expect("load dave-orig.png");
+    let deg2rad = 3.14159f32 / 180.0;
+
+    // C 0: threshold to binary at 170
+    let pix1 = threshold_to_binary(&pixs, 170).expect("threshold 170");
+    rp.write_pix_and_check(&pix1, ImageFormat::Png)
+        .expect("check 0");
+
+    // C 1: deskew the grayscale original by the detected angle
+    let skew = find_skew(&pix1, &SkewDetectOptions::default()).expect("find_skew");
+    let pix2 =
+        rotate_am_gray(&pixs, deg2rad * skew.angle, RotateFill::White).expect("rotate_am_gray");
+    rp.write_pix_and_check(&pix2, ImageFormat::Png)
+        .expect("check 1");
+
+    // C 2-3: isolate horizontal lines
+    let pix3 = close_gray(&pix2, 51, 1).expect("close_gray 51x1");
+    rp.write_pix_and_check(&pix3, ImageFormat::Png)
+        .expect("check 2");
+    let pix4 = erode_gray(&pix3, 1, 5).expect("erode_gray 1x5");
+    rp.write_pix_and_check(&pix4, ImageFormat::Png)
+        .expect("check 3");
+
+    // C 4-5: flatten the background, then the lines
+    let pix5 = pix4
+        .threshold_to_value(210, 255)
+        .expect("threshold_to_value 210");
+    rp.write_pix_and_check(&pix5, ImageFormat::Png)
+        .expect("check 4");
+    let pix6 = pix5
+        .threshold_to_value(200, 0)
+        .expect("threshold_to_value 200");
+    rp.write_pix_and_check(&pix6, ImageFormat::Png)
+        .expect("check 5");
+
+    // C 6: line mask
+    let pix7 = threshold_to_binary(&pix6, 210).expect("threshold 210");
+    rp.write_pix_and_check(&pix7, ImageFormat::Png)
+        .expect("check 6");
+
+    // C 7: add the inverted line image back to the deskewed original
+    let pix6_inv = pix6.invert();
+    let pix8 = pix2.arith_add(&pix6_inv).expect("arith_add");
+    rp.write_pix_and_check(&pix8, ImageFormat::Png)
+        .expect("check 7");
+
+    // C 8-9: vertical opening, then paste it back through the line mask
+    let pix9 = open_gray(&pix8, 1, 9).expect("open_gray 1x9");
+    rp.write_pix_and_check(&pix9, ImageFormat::Png)
+        .expect("check 8");
+    let merged = {
+        let mut m = pix8.deep_clone().to_mut();
+        m.combine_masked(&pix9, &pix7).expect("combine_masked");
+        let p: leptonica::Pix = m.into();
+        p
+    };
+    rp.write_pix_and_check(&merged, ImageFormat::Png)
+        .expect("check 9");
+
+    assert!(rp.cleanup(), "lineremoval c-compat test failed");
+}
+
+/// Area-map rotation must derive sin/cos like C (plan 902 PR 20).
+///
+/// C `rotateAMGrayLow` computes `sina = 16.f * sin(angle)` where `sin()`
+/// returns a double, so the scaling happens in double precision and is
+/// rounded to float once. Computing `angle.sin()` in f32 and scaling in
+/// f32 shifts a few sub-pixel positions across a truncation boundary.
+#[test]
+#[ignore = "not yet implemented: rotate_am_gray scales sin/cos in f32"]
+fn lineremoval_rotate_am_gray_matches_c() {
+    use leptonica::transform::{RotateFill, rotate_am_gray};
+
+    let pixs = crate::common::load_test_image("dave-orig.png").expect("load dave-orig.png");
+    let deg2rad = 3.14159f32 / 180.0;
+    let out = rotate_am_gray(&pixs, deg2rad * -0.656250, RotateFill::White).expect("rotate");
+
+    // Pixels where the f32 scaling picks the neighbouring source sample.
+    // Values here come from the C reference (pixRotateAMGray on the same
+    // input and angle).
+    assert_eq!(out.get_pixel(491, 246).unwrap(), 254);
+}

--- a/tests/recog/lineremoval_reg.rs
+++ b/tests/recog/lineremoval_reg.rs
@@ -196,7 +196,10 @@ fn lineremoval_c_compat() {
     let mut rp = RegParams::new("lineremoval_c");
 
     let pixs = crate::common::load_test_image("dave-orig.png").expect("load dave-orig.png");
-    let deg2rad = 3.14159f32 / 180.0;
+    // C: `l_float32 deg2rad = 3.14159 / 180.` — a double division
+    // rounded once to float.
+    #[allow(clippy::approx_constant)] // C hard-codes this truncated pi
+    let deg2rad = (3.14159f64 / 180.0) as f32;
 
     // C 0: threshold to binary at 170
     let pix1 = threshold_to_binary(&pixs, 170).expect("threshold 170");
@@ -264,12 +267,14 @@ fn lineremoval_c_compat() {
 /// rounded to float once. Computing `angle.sin()` in f32 and scaling in
 /// f32 shifts a few sub-pixel positions across a truncation boundary.
 #[test]
-#[ignore = "not yet implemented: rotate_am_gray scales sin/cos in f32"]
 fn lineremoval_rotate_am_gray_matches_c() {
     use leptonica::transform::{RotateFill, rotate_am_gray};
 
     let pixs = crate::common::load_test_image("dave-orig.png").expect("load dave-orig.png");
-    let deg2rad = 3.14159f32 / 180.0;
+    // C: `l_float32 deg2rad = 3.14159 / 180.` — a double division
+    // rounded once to float.
+    #[allow(clippy::approx_constant)] // C hard-codes this truncated pi
+    let deg2rad = (3.14159f64 / 180.0) as f32;
     let out = rotate_am_gray(&pixs, deg2rad * -0.656250, RotateFill::White).expect("rotate");
 
     // Pixels where the f32 scaling picks the neighbouring source sample.

--- a/tests/recog/lineremoval_reg.rs
+++ b/tests/recog/lineremoval_reg.rs
@@ -185,8 +185,6 @@ fn lineremoval_reg_pipeline() {
 /// with `arith_add` and `combine_masked`. All ten outputs are PNG.
 #[test]
 fn lineremoval_c_compat() {
-    use leptonica::morph::{close_gray, erode_gray, open_gray};
-    use leptonica::recog::skew::{SkewDetectOptions, find_skew};
     use leptonica::transform::{RotateFill, rotate_am_gray};
 
     if crate::common::is_display_mode() {


### PR DESCRIPTION
## Why

recog は Unmapped 45 で残る大きなプール。lineremoval_reg は入力が
`dave-orig.png` (lossless) の単一直線パイプラインで全 10 出力が PNG のため、
gray morphology と算術の主要経路をまとめて検証できる。

## What

### 実装差 30 件目: area map 回転の三角関数精度

skew 角は C と完全一致 (-0.656250) だったのに `rotate_am_gray` の出力が
**3 画素だけ**ずれた。追跡すると:

- C `rotateAM{Gray,Color}Low` は `sina = 16.f * sin(angle)` を計算する。
  `sin()` は **double** を返すため、三角関数もスケーリングも double 精度で
  行われ、float に丸められるのは一度だけ
- Rust は `angle.sin()` を f32 で評価し f32 でスケールしていたため、
  `sina` が 1 ulp ずれ、サブピクセル位置が切り捨て境界をまたいでいた

area map 系カーネルが f64 の sin/cos を受け取るよう修正した。

あわせて**テスト側**にも同種の問題があった: C の `deg2rad = 3.14159 / 180.`
は **double 除算**の結果を float に丸めるが、Rust で `3.14159f32 / 180.0` と
書くと f32 除算になり、そこから求めた `sin` が 1 ulp ずれる。C と同じ計算順に
揃えて解消した。

### C 互換ペア 10 件追加 — 全件 Ok (Ok 172 → 182)

`dave-orig.png` → 閾値化 → skew 検出 → `rotate_am_gray` → gray
close/erode/open → `threshold_to_value` ×2 → 反転 → `arith_add` →
`combine_masked` の全段が bit 一致。

## Impact

- ベースライン: **Ok 182 / Mismatch 29 / MissingC 0 / Unmapped 400 /
  Excluded 83**。recog binary は Ok 9 → 19
- 公開 API の挙動変更なし (回転結果がごく一部の画素で C 準拠に変わるのみ、
  既存 golden への影響もなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg