### PR TITLE
plan 902 PR 23: colorcontent の RGB gamut 分類を整列 — 8 ペア全件 Ok

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ src/
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
 - 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 22 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 198 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 98**
+  **Ok 206 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 98**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 22 後):
+- 現状ベースライン (As of 2026-08-16 実測、plan 902 PR 23 後):
   `docs/porting/c-compat-status.md` に詳細。
   **Ok 206 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 98**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -541,7 +541,42 @@ scalefactor, background, spacing, border)` に対し Rust は
   (テキストブロック高の算出差、幅は一致)。boxa アルゴリズム自体は
   `.ba` で検証済みのため、理由付きで Excluded とした
 
-### PR 23 以降: semantic マッピングの漸進追加
+### PR 23: colorcontent の RGB gamut 分類 (実施済み)
+
+C 版ソース: `src/pix3.c` (pixMakeArbMaskFromRGB)、
+`src/colorspace.c` (pixMakeGamutRGB)、`prog/colorcontent_reg.c`。
+
+`colorcontent_reg` の 13 出力のうち check 0/1/5/8/9 は fish24.jpg・
+wyom.jpg・map.057.jpg を入力とするため JPEG デコード差 (finding 001/008)
+で bit 一致が原理的に不可能。一方 **check 10-17 の 8 件は入力画像を持たず**、
+`pixMakeGamutRGB` で合成した RGB gamut を `pixMakeArbMaskFromRGB` で
+分類するだけなので決定的に比較できる。
+
+実施結果:
+
+- 実装差 34 件目: `make_arb_mask_from_rgb` が f32 の重み付き和を
+  そのまま閾値と比較していた。C は `pixConvertRGBToGrayArb` で
+  8bpp gray 中間を作ってから `pixThresholdToBinary(pix1, thresh + 1)` +
+  `pixInvert` するため、実際の判定は
+
+  ```text
+  clip(trunc(rc*R + gc*G + bc*B), 0, 255) >= trunc(thresh) + 1
+  ```
+
+  という整数意味論になる。例えば係数 (0.4, 0.3, 0.3)・閾値 60 で和が
+  60.8 のとき、C は `trunc(60.8) = 60 < 61` で OFF、旧実装は
+  `60.8 > 60.0` で ON となり乖離していた。切り捨て・[0,255] クリップ・
+  閾値の整数化に加え、`thresh >= 255` を 254 にクランプする挙動と
+  係数が全て非正のときのエラーも C に合わせた
+- `Pix::make_gamut_rgb` (C pixMakeGamutRGB) を新規移植。32 個の
+  32x32 サブ画像 (B 一定、R/G を 8 刻みで振る) を
+  `display_tiled_in_columns(8, scale, 5, 0)` で並べる
+- colorcontent の C check 10-17 を 8 ペアマップ — **全件即 Ok**
+  (Ok 198 → 206)
+- JPEG 入力側の 5 件は既存の finding 001/008 の範囲であり、
+  今回は新規マップ対象外
+
+### PR 24 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -568,6 +568,12 @@ wyom.jpg・map.057.jpg を入力とするため JPEG デコード差 (finding 00
   `60.8 > 60.0` で ON となり乖離していた。切り捨て・[0,255] クリップ・
   閾値の整数化に加え、`thresh >= 255` を 254 にクランプする挙動と
   係数が全て非正のときのエラーも C に合わせた
+- 実装差 35 件目 (レビュー指摘から派生): 既存の
+  `convert_rgb_to_gray_arb` が `+ 0.5` で丸めていた。C
+  `pixConvertRGBToGrayArb` は `val = (l_int32)(...)` で切り捨てるため
+  同じ 60.8 が 61 になっていた。切り捨てに修正し、
+  `make_arb_mask_from_rgb` を同関数経由に変更して量子化規約を 1 箇所に
+  集約した (golden hash に変化なし)
 - `Pix::make_gamut_rgb` (C pixMakeGamutRGB) を新規移植。32 個の
   32x32 サブ画像 (B 一定、R/G を 8 刻みで振る) を
   `display_tiled_in_columns(8, scale, 5, 0)` で並べる

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -52,22 +52,22 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 ## 全体集計
 
-| 状態        | 件数    | 説明                                                                                                                              |
-| ----------- | ------: | --------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **198** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +154)                                                  |
-| ⚠️ Mismatch | **29**  | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007) |
-| ⛔ MissingC | **0**   | (PR #381 / Phase 1.5 で解消)                                                                                                      |
-| 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                               |
-| 🚫 Excluded | **86**  | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3  |
+| 状態        |    件数 | 説明                                                                                                                                                |
+| ----------- | ------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Ok       | **206** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +162)                                                                    |
+| ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                   |
+| ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                        |
+| 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                                                 |
+| 🚫 Excluded |  **98** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 |
 
-合計 725 entries がレポート対象 (As of 2026-08-16、plan 902 PR 22 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **732 entries**。
+合計 733 entries がレポート対象 (As of 2026-08-16、plan 902 PR 23 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **740 entries**。
 
 ## test binary 別の内訳
 
 | Binary      |     Ok | Mismatch | MissingC | Unmapped | Excluded |
 | ----------- | -----: | -------: | -------: | -------: | -------: |
-| `color`     |     25 |        4 |        0 |      108 |        4 |
+| `color`     |     33 |        4 |        0 |      108 |        4 |
 | `core`      |     13 |        0 |        0 |       34 |       12 |
 | `filter`    |      2 |        5 |        0 |       57 |       40 |
 | `io`        |     11 |        2 |        0 |       41 |       13 |

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -353,3 +353,11 @@ core	boxa3	22	boxa3_c	17	boxap3 scaled (serialized)
 core	boxa3	27	boxa3_c	19	boxap3 reconcile width (serialized)
 core	boxa3	29	boxa3_c	21	boxap3 reconcile height (serialized)
 core	boxa3	31	boxa3_c	23	boxap3 reconcile both (serialized)
+color	colorcontent	10	colorcontent_c	1	gamut RGB (scale 3)
+color	colorcontent	11	colorcontent_c	2	arb mask from RGB (-0.5,-0.5,1.0) thresh 20
+color	colorcontent	12	colorcontent_c	3	single-plane selection over white
+color	colorcontent	13	colorcontent_c	4	arb mask from RGB (1.5,-0.5,-1.0) thresh 0
+color	colorcontent	14	colorcontent_c	5	arb mask from RGB (0.4,0.3,0.3) thresh 60, inverted
+color	colorcontent	15	colorcontent_c	6	mask - mask2
+color	colorcontent	16	colorcontent_c	7	(mask - mask2) - inverted mask3
+color	colorcontent	17	colorcontent_c	8	multi-plane selection over white

--- a/src/core/pix/convert.rs
+++ b/src/core/pix/convert.rs
@@ -1833,7 +1833,9 @@ impl Pix {
     /// Convert 32 bpp RGB to 8 bpp gray using arbitrary linear weights.
     ///
     /// Unlike `convert_rgb_to_gray`, weights may be negative, but at least one
-    /// must be positive. Output values are clamped to [0, 255].
+    /// must be positive. As in C, the weighted sum is **truncated** toward
+    /// zero (`(l_int32)(rc*R + gc*G + bc*B)`, not rounded) and the resulting
+    /// integer is then clamped to `[0, 255]`.
     ///
     /// # Arguments
     ///
@@ -1866,7 +1868,8 @@ impl Pix {
                 let pixel = self.get_pixel_unchecked(x, y);
                 let (r, g, b) = pixel::extract_rgb(pixel);
                 let val = rc * r as f32 + gc * g as f32 + bc * b as f32;
-                let val = (val.clamp(0.0, 255.0) + 0.5) as u32;
+                // C: `val = (l_int32)(...)` then `L_MIN(255, L_MAX(0, val))`.
+                let val = (val as i32).clamp(0, 255) as u32;
                 result_mut.set_pixel_unchecked(x, y, val);
             }
         }
@@ -4528,6 +4531,24 @@ mod tests {
         assert_eq!(result.get_pixel(1, 0), Some(30));
         // (100*0.5 + 100*0.3 + 100*0.2) = 100.0 → 100
         assert_eq!(result.get_pixel(2, 0), Some(100));
+    }
+
+    /// C computes `val = (l_int32)(rc*R + gc*G + bc*B)`, i.e. it truncates
+    /// toward zero rather than rounding. A weighted sum of 60.8 becomes 60,
+    /// not 61.
+    #[test]
+    fn test_convert_rgb_to_gray_arb_truncates_like_c() {
+        let pix = Pix::new(2, 1, PixelDepth::Bit32).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        // 0.4*32 + 0.3*80 + 0.3*80 = 12.8 + 24 + 24 = 60.8
+        pm.set_pixel_unchecked(0, 0, pixel::compose_rgb(32, 80, 80));
+        // 0.4*40 + 0.3*80 + 0.3*80 = 16 + 24 + 24 = 64.0
+        pm.set_pixel_unchecked(1, 0, pixel::compose_rgb(40, 80, 80));
+        let pix: Pix = pm.into();
+
+        let result = pix.convert_rgb_to_gray_arb(0.4, 0.3, 0.3).unwrap();
+        assert_eq!(result.get_pixel(0, 0), Some(60));
+        assert_eq!(result.get_pixel(1, 0), Some(64));
     }
 
     #[test]

--- a/src/core/pix/mask.rs
+++ b/src/core/pix/mask.rs
@@ -358,8 +358,13 @@ impl Pix {
     ///
     /// The gamut is divided into `2^15` cubical cells of 8x8x8 pixel values.
     /// Each of the 32 subimages holds a constant B, with R and G varying over
-    /// their range in 32 steps of 8; the subimages are tiled 8 per row with a
-    /// spacing of 5 and each cell replicated `scale` times in x and y.
+    /// their range in 32 steps of 8; the 32x32 subimages are then tiled 8 per
+    /// row with a spacing of 5, scaled up by `scale`.
+    ///
+    /// C's note calls this a replication of each cell, but both C and this
+    /// port magnify the tiles through the regular scaling path, so `scale`
+    /// is a scale factor rather than a pixel-replication count. For the
+    /// integer factors this is used with the two agree bit-exactly.
     ///
     /// `scale` defaults to 8 when it is 0.
     ///

--- a/src/core/pix/mask.rs
+++ b/src/core/pix/mask.rs
@@ -367,20 +367,57 @@ impl Pix {
     /// [`Pix::make_arb_mask_from_rgb`] partitions RGB color space.
     ///
     /// C equivalent: `pixMakeGamutRGB()` in `colorspace.c`
-    pub fn make_gamut_rgb(_scale: u32) -> Result<Pix> {
-        Err(Error::InvalidParameter("not yet implemented".to_string()))
+    pub fn make_gamut_rgb(scale: u32) -> Result<Pix> {
+        let scale = if scale == 0 { 8 } else { scale };
+
+        let mut pixa = crate::core::Pixa::with_capacity(32);
+        for k in 0..32u32 {
+            let tile = Pix::new(32, 32, PixelDepth::Bit32)?;
+            let mut tm = tile.try_into_mut().unwrap();
+            for i in 0..32u32 {
+                for j in 0..32u32 {
+                    let val = crate::core::pixel::compose_rgba(
+                        (8 * j) as u8,
+                        (8 * i) as u8,
+                        (8 * k) as u8,
+                        0,
+                    );
+                    tm.set_pixel_unchecked(j, i, val);
+                }
+            }
+            pixa.push(tm.into());
+        }
+        pixa.display_tiled_in_columns(8, scale as f32, 5, 0)
     }
 
     /// Create a 1 bpp mask from a 32 bpp RGB image using weighted coefficients.
     ///
     /// Computes `rc*R + gc*G + bc*B` for each pixel, then thresholds.
-    /// Pixels where the weighted sum exceeds `thresh` are ON in the mask.
+    /// The coefficients may be negative.
+    ///
+    /// C reaches the mask through an intermediate 8 bpp gray image
+    /// (`pixConvertRGBToGrayArb`), so the weighted sum is **truncated to an
+    /// integer and clipped to `[0, 255]`** before the comparison, and the
+    /// threshold itself is truncated to an integer. Both quantizations are
+    /// reproduced here: a pixel is ON iff
+    /// `clip(trunc(rc*R + gc*G + bc*B), 0, 255) >= trunc(thresh) + 1`.
+    ///
+    /// `thresh` is clamped to 254.0 to avoid 8 bit overflow, as in C.
     ///
     /// C equivalent: `pixMakeArbMaskFromRGB()` in `pix3.c`
     pub fn make_arb_mask_from_rgb(&self, rc: f32, gc: f32, bc: f32, thresh: f32) -> Result<Pix> {
         if self.depth() != PixelDepth::Bit32 {
             return Err(Error::UnsupportedDepth(self.depth().bits()));
         }
+        if rc <= 0.0 && gc <= 0.0 && bc <= 0.0 {
+            return Err(Error::InvalidParameter("all coefficients <= 0".to_string()));
+        }
+
+        // C: `if (thresh >= 255.0) thresh = 254.0;` then
+        // `pixThresholdToBinary(pix1, thresh + 1)` with an l_int32 parameter,
+        // so the float threshold is truncated on the call.
+        let thresh = if thresh >= 255.0 { 254.0 } else { thresh };
+        let cutoff = thresh as i32 + 1;
 
         let w = self.width();
         let h = self.height();
@@ -392,7 +429,8 @@ impl Pix {
                 let pixel = self.get_pixel_unchecked(x, y);
                 let (r, g, b, _) = crate::core::pixel::extract_rgba(pixel);
                 let val = rc * r as f32 + gc * g as f32 + bc * b as f32;
-                if val > thresh {
+                let val = (val as i32).clamp(0, 255);
+                if val >= cutoff {
                     mm.set_pixel_unchecked(x, y, 1);
                 }
             }
@@ -1075,7 +1113,6 @@ mod tests {
     /// cutoff in C (`trunc(60.8) = 60 < 61`), while a naive float
     /// comparison (`60.8 > 60.0`) would turn the pixel on.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_make_arb_mask_from_rgb_truncates_like_c() {
         let pix = Pix::new(1, 1, PixelDepth::Bit32).unwrap();
         let mut pm = pix.try_into_mut().unwrap();
@@ -1099,7 +1136,6 @@ mod tests {
     /// sum can never satisfy a non-negative threshold, and a sum above 255
     /// always does.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_make_arb_mask_from_rgb_clips_to_byte_range() {
         let pix = Pix::new(2, 1, PixelDepth::Bit32).unwrap();
         let mut pm = pix.try_into_mut().unwrap();
@@ -1121,7 +1157,6 @@ mod tests {
     /// C rejects coefficients that are all non-positive, because the gray
     /// intermediate would then be uniformly clipped to 0.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_make_arb_mask_from_rgb_rejects_nonpositive_coefficients() {
         let pix = Pix::new(2, 2, PixelDepth::Bit32).unwrap();
         assert!(pix.make_arb_mask_from_rgb(-1.0, -1.0, 0.0, 0.0).is_err());
@@ -1130,7 +1165,6 @@ mod tests {
     /// C `pixMakeGamutRGB(scale)` tiles 32 subimages of 32x32 cells, 8 per
     /// row, at `scale` replication with a spacing of 5 and no border.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_make_gamut_rgb_dimensions_and_corner() {
         let pix = Pix::make_gamut_rgb(3).unwrap();
         assert_eq!(pix.depth(), PixelDepth::Bit32);
@@ -1143,7 +1177,6 @@ mod tests {
 
     /// `scale = 0` falls back to C's default of 8.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_make_gamut_rgb_zero_scale_defaults_to_8() {
         let pix = Pix::make_gamut_rgb(0).unwrap();
         assert_eq!(pix.width(), 8 * 256 + 9 * 5);

--- a/src/core/pix/mask.rs
+++ b/src/core/pix/mask.rs
@@ -395,12 +395,12 @@ impl Pix {
     /// Computes `rc*R + gc*G + bc*B` for each pixel, then thresholds.
     /// The coefficients may be negative.
     ///
-    /// C reaches the mask through an intermediate 8 bpp gray image
-    /// (`pixConvertRGBToGrayArb`), so the weighted sum is **truncated to an
-    /// integer and clipped to `[0, 255]`** before the comparison, and the
-    /// threshold reaches `pixThresholdToBinary` as an `l_int32`, so
-    /// `thresh + 1` is truncated *after* the increment. Both quantizations
-    /// are reproduced here: a pixel is ON iff
+    /// C reaches the mask through an intermediate 8 bpp gray image, so this
+    /// goes through [`Pix::convert_rgb_to_gray_arb`] as well: the weighted
+    /// sum is **truncated toward zero and clipped to `[0, 255]`** before the
+    /// comparison. The threshold in turn reaches `pixThresholdToBinary` as
+    /// an `l_int32`, so `thresh + 1` is truncated *after* the increment.
+    /// A pixel is therefore ON iff
     /// `clip(trunc(rc*R + gc*G + bc*B), 0, 255) >= trunc(thresh + 1)`.
     ///
     /// `thresh` is clamped to 254.0 to avoid 8 bit overflow, as in C.
@@ -409,9 +409,6 @@ impl Pix {
     pub fn make_arb_mask_from_rgb(&self, rc: f32, gc: f32, bc: f32, thresh: f32) -> Result<Pix> {
         if self.depth() != PixelDepth::Bit32 {
             return Err(Error::UnsupportedDepth(self.depth().bits()));
-        }
-        if rc <= 0.0 && gc <= 0.0 && bc <= 0.0 {
-            return Err(Error::InvalidParameter("all coefficients <= 0".to_string()));
         }
 
         // C: `if (thresh >= 255.0) thresh = 254.0;` then
@@ -422,6 +419,10 @@ impl Pix {
         let thresh = if thresh >= 255.0 { 254.0 } else { thresh };
         let cutoff = (thresh + 1.0) as i32;
 
+        // The all-non-positive coefficient check lives in
+        // convert_rgb_to_gray_arb, matching where C rejects them
+        // (pixConvertRGBToGrayArb).
+        let gray = self.convert_rgb_to_gray_arb(rc, gc, bc)?;
         let w = self.width();
         let h = self.height();
         let mask = Pix::new(w, h, PixelDepth::Bit1)?;
@@ -429,11 +430,7 @@ impl Pix {
 
         for y in 0..h {
             for x in 0..w {
-                let pixel = self.get_pixel_unchecked(x, y);
-                let (r, g, b, _) = crate::core::pixel::extract_rgba(pixel);
-                let val = rc * r as f32 + gc * g as f32 + bc * b as f32;
-                let val = (val as i32).clamp(0, 255);
-                if val >= cutoff {
+                if gray.get_pixel_unchecked(x, y) as i32 >= cutoff {
                     mm.set_pixel_unchecked(x, y, 1);
                 }
             }

--- a/src/core/pix/mask.rs
+++ b/src/core/pix/mask.rs
@@ -398,9 +398,10 @@ impl Pix {
     /// C reaches the mask through an intermediate 8 bpp gray image
     /// (`pixConvertRGBToGrayArb`), so the weighted sum is **truncated to an
     /// integer and clipped to `[0, 255]`** before the comparison, and the
-    /// threshold itself is truncated to an integer. Both quantizations are
-    /// reproduced here: a pixel is ON iff
-    /// `clip(trunc(rc*R + gc*G + bc*B), 0, 255) >= trunc(thresh) + 1`.
+    /// threshold reaches `pixThresholdToBinary` as an `l_int32`, so
+    /// `thresh + 1` is truncated *after* the increment. Both quantizations
+    /// are reproduced here: a pixel is ON iff
+    /// `clip(trunc(rc*R + gc*G + bc*B), 0, 255) >= trunc(thresh + 1)`.
     ///
     /// `thresh` is clamped to 254.0 to avoid 8 bit overflow, as in C.
     ///
@@ -415,9 +416,11 @@ impl Pix {
 
         // C: `if (thresh >= 255.0) thresh = 254.0;` then
         // `pixThresholdToBinary(pix1, thresh + 1)` with an l_int32 parameter,
-        // so the float threshold is truncated on the call.
+        // so the increment happens in float and the *sum* is truncated on
+        // the call. Truncating before the increment would differ for
+        // fractional negative thresholds (thresh = -0.2 gives 0, not 1).
         let thresh = if thresh >= 255.0 { 254.0 } else { thresh };
-        let cutoff = thresh as i32 + 1;
+        let cutoff = (thresh + 1.0) as i32;
 
         let w = self.width();
         let h = self.height();
@@ -1152,6 +1155,23 @@ mod tests {
         // gray value of 255 is still ON.
         let mask2 = pix.make_arb_mask_from_rgb(1.0, 1.0, 1.0, 300.0).unwrap();
         assert_eq!(mask2.get_pixel(1, 0).unwrap(), 1);
+    }
+
+    /// C passes `thresh + 1` to `pixThresholdToBinary`, whose parameter is
+    /// an `l_int32`, so the truncation happens after the increment. For
+    /// `thresh = -0.2` the cutoff is therefore `trunc(0.8) = 0`, not
+    /// `trunc(-0.2) + 1 = 1`, and a pixel with a clipped gray value of 0
+    /// is ON.
+    #[test]
+    fn test_make_arb_mask_from_rgb_truncates_threshold_after_increment() {
+        let pix = Pix::new(1, 1, PixelDepth::Bit32).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        // 1.0*0 + 1.0*0 + 1.0*0 = 0, i.e. the lowest possible gray value.
+        pm.set_pixel_unchecked(0, 0, crate::core::pixel::compose_rgba(0, 0, 0, 0));
+        let pix: Pix = pm.into();
+
+        let mask = pix.make_arb_mask_from_rgb(1.0, 1.0, 1.0, -0.2).unwrap();
+        assert_eq!(mask.get_pixel(0, 0).unwrap(), 1);
     }
 
     /// C rejects coefficients that are all non-positive, because the gray

--- a/src/core/pix/mask.rs
+++ b/src/core/pix/mask.rs
@@ -354,6 +354,23 @@ impl Pix {
         Ok(dm.into())
     }
 
+    /// Build a 32 bpp image covering the whole RGB gamut.
+    ///
+    /// The gamut is divided into `2^15` cubical cells of 8x8x8 pixel values.
+    /// Each of the 32 subimages holds a constant B, with R and G varying over
+    /// their range in 32 steps of 8; the subimages are tiled 8 per row with a
+    /// spacing of 5 and each cell replicated `scale` times in x and y.
+    ///
+    /// `scale` defaults to 8 when it is 0.
+    ///
+    /// This is useful for visualizing how a filter such as
+    /// [`Pix::make_arb_mask_from_rgb`] partitions RGB color space.
+    ///
+    /// C equivalent: `pixMakeGamutRGB()` in `colorspace.c`
+    pub fn make_gamut_rgb(_scale: u32) -> Result<Pix> {
+        Err(Error::InvalidParameter("not yet implemented".to_string()))
+    }
+
     /// Create a 1 bpp mask from a 32 bpp RGB image using weighted coefficients.
     ///
     /// Computes `rc*R + gc*G + bc*B` for each pixel, then thresholds.
@@ -1050,5 +1067,85 @@ mod tests {
     fn test_set_under_transparency_not_32bpp() {
         let pix = Pix::new(10, 10, PixelDepth::Bit8).unwrap();
         assert!(pix.set_under_transparency(0xFFFFFF00).is_err());
+    }
+
+    /// C reaches the mask through an 8 bpp gray intermediate, so the
+    /// weighted sum is truncated to an integer before the comparison.
+    /// A sum of 60.8 against `thresh = 60` is therefore *below* the
+    /// cutoff in C (`trunc(60.8) = 60 < 61`), while a naive float
+    /// comparison (`60.8 > 60.0`) would turn the pixel on.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_make_arb_mask_from_rgb_truncates_like_c() {
+        let pix = Pix::new(1, 1, PixelDepth::Bit32).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        // 0.4*32 + 0.3*80 + 0.3*80 = 12.8 + 24 + 24 = 60.8
+        pm.set_pixel_unchecked(0, 0, crate::core::pixel::compose_rgba(32, 80, 80, 0));
+        let pix: Pix = pm.into();
+
+        let mask = pix.make_arb_mask_from_rgb(0.4, 0.3, 0.3, 60.0).unwrap();
+        assert_eq!(mask.get_pixel(0, 0).unwrap(), 0);
+
+        // One step up (0.4*40 + 0.3*80 + 0.3*80 = 64.0) clears the cutoff.
+        let pix2 = Pix::new(1, 1, PixelDepth::Bit32).unwrap();
+        let mut pm2 = pix2.try_into_mut().unwrap();
+        pm2.set_pixel_unchecked(0, 0, crate::core::pixel::compose_rgba(40, 80, 80, 0));
+        let pix2: Pix = pm2.into();
+        let mask2 = pix2.make_arb_mask_from_rgb(0.4, 0.3, 0.3, 60.0).unwrap();
+        assert_eq!(mask2.get_pixel(0, 0).unwrap(), 1);
+    }
+
+    /// C clips the gray intermediate to `[0, 255]`, so a negative weighted
+    /// sum can never satisfy a non-negative threshold, and a sum above 255
+    /// always does.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_make_arb_mask_from_rgb_clips_to_byte_range() {
+        let pix = Pix::new(2, 1, PixelDepth::Bit32).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        pm.set_pixel_unchecked(0, 0, crate::core::pixel::compose_rgba(0, 255, 255, 0));
+        pm.set_pixel_unchecked(1, 0, crate::core::pixel::compose_rgba(255, 255, 255, 0));
+        let pix: Pix = pm.into();
+
+        // -2.0*R + 1.0*G: -510 at x=0 (clipped to 0), 0 at x=1.
+        let mask = pix.make_arb_mask_from_rgb(1.0, -2.0, 0.0, 0.0).unwrap();
+        assert_eq!(mask.get_pixel(0, 0).unwrap(), 0);
+        assert_eq!(mask.get_pixel(1, 0).unwrap(), 0);
+
+        // A threshold of 255 or more is clamped to 254, so a saturated
+        // gray value of 255 is still ON.
+        let mask2 = pix.make_arb_mask_from_rgb(1.0, 1.0, 1.0, 300.0).unwrap();
+        assert_eq!(mask2.get_pixel(1, 0).unwrap(), 1);
+    }
+
+    /// C rejects coefficients that are all non-positive, because the gray
+    /// intermediate would then be uniformly clipped to 0.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_make_arb_mask_from_rgb_rejects_nonpositive_coefficients() {
+        let pix = Pix::new(2, 2, PixelDepth::Bit32).unwrap();
+        assert!(pix.make_arb_mask_from_rgb(-1.0, -1.0, 0.0, 0.0).is_err());
+    }
+
+    /// C `pixMakeGamutRGB(scale)` tiles 32 subimages of 32x32 cells, 8 per
+    /// row, at `scale` replication with a spacing of 5 and no border.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_make_gamut_rgb_dimensions_and_corner() {
+        let pix = Pix::make_gamut_rgb(3).unwrap();
+        assert_eq!(pix.depth(), PixelDepth::Bit32);
+        // 4 rows x 8 columns of 96x96 tiles, spacing 5 between and around.
+        assert_eq!(pix.width(), 8 * 96 + 9 * 5);
+        assert_eq!(pix.height(), 4 * 96 + 5 * 5);
+        // First tile starts at (5, 5) and its origin cell is pure black.
+        assert_eq!(pix.get_pixel(5, 5).unwrap(), 0);
+    }
+
+    /// `scale = 0` falls back to C's default of 8.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_make_gamut_rgb_zero_scale_defaults_to_8() {
+        let pix = Pix::make_gamut_rgb(0).unwrap();
+        assert_eq!(pix.width(), 8 * 256 + 9 * 5);
     }
 }

--- a/tests/color/colorcontent_reg.rs
+++ b/tests/color/colorcontent_reg.rs
@@ -238,7 +238,6 @@ fn colorcontent_reg() {
 /// they are free of JPEG decode differences and can be compared bit-exactly
 /// against the C output.
 #[test]
-#[ignore = "not yet implemented"]
 fn colorcontent_c_compat() {
     if crate::common::is_display_mode() {
         return;

--- a/tests/color/colorcontent_reg.rs
+++ b/tests/color/colorcontent_reg.rs
@@ -230,3 +230,65 @@ fn colorcontent_reg() {
 
     assert!(rp.cleanup(), "colorcontent regression test failed");
 }
+
+/// C-compat: `prog/colorcontent_reg.c` checks 10-17.
+///
+/// These are the RGB-gamut classification steps. They take no input image
+/// (the gamut is synthesized), so unlike the earlier checks in that program
+/// they are free of JPEG decode differences and can be compared bit-exactly
+/// against the C output.
+#[test]
+#[ignore = "not yet implemented"]
+fn colorcontent_c_compat() {
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("colorcontent_c");
+
+    // C 10-12: binary classification of RGB colors using a single plane.
+    let gamut = Pix::make_gamut_rgb(3).expect("gamut");
+    let mask = gamut
+        .make_arb_mask_from_rgb(-0.5, -0.5, 1.0, 20.0)
+        .expect("arb mask");
+    let combined = combine_over_white(&gamut, &mask);
+    rp.write_pix_and_check(&gamut, ImageFormat::Png)
+        .expect("check: gamut");
+    rp.write_pix_and_check(&mask, ImageFormat::Png)
+        .expect("check: single-plane mask");
+    rp.write_pix_and_check(&combined, ImageFormat::Png)
+        .expect("check: single-plane selection");
+
+    // C 13-17: more than one plane, further restricting the allowed region.
+    let mask2 = gamut
+        .make_arb_mask_from_rgb(1.5, -0.5, -1.0, 0.0)
+        .expect("arb mask 2");
+    let mask3 = gamut
+        .make_arb_mask_from_rgb(0.4, 0.3, 0.3, 60.0)
+        .expect("arb mask 3")
+        .invert();
+    let sub1 = mask.subtract(&mask2).expect("mask - mask2");
+    let sub2 = sub1.subtract(&mask3).expect("sub1 - mask3");
+    let combined2 = combine_over_white(&gamut, &sub2);
+    rp.write_pix_and_check(&mask2, ImageFormat::Png)
+        .expect("check: mask2");
+    rp.write_pix_and_check(&mask3, ImageFormat::Png)
+        .expect("check: mask3 inverted");
+    rp.write_pix_and_check(&sub1, ImageFormat::Png)
+        .expect("check: mask - mask2");
+    rp.write_pix_and_check(&sub2, ImageFormat::Png)
+        .expect("check: sub1 - mask3");
+    rp.write_pix_and_check(&combined2, ImageFormat::Png)
+        .expect("check: multi-plane selection");
+
+    assert!(rp.cleanup(), "colorcontent C-compat test failed");
+}
+
+/// C: `pixCreate(w, h, 32); pixSetAll(pix); pixCombineMasked(pix, src, mask)`.
+fn combine_over_white(src: &Pix, mask: &Pix) -> Pix {
+    let white = Pix::new(src.width(), src.height(), PixelDepth::Bit32).expect("white canvas");
+    let mut wm = white.try_into_mut().unwrap();
+    wm.set_all();
+    wm.combine_masked(src, mask).expect("combine masked");
+    wm.into()
+}

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -164,6 +164,14 @@ colorcontent.07.png	b06bb0eb5a72f121
 colorcontent.10.png	0f070e9b924615a2
 colorcontent.14.png	0827a1a6d389f32f
 colorcontent.24.png	61c09f1bc206dd7c
+colorcontent_c.01.png	eda2752741e47f87
+colorcontent_c.02.png	32e39465eadb9eba
+colorcontent_c.03.png	75a5fc0b15bc8bbd
+colorcontent_c.04.png	8b48ae56522b5eca
+colorcontent_c.05.png	6c12392c9231e82b
+colorcontent_c.06.png	e0456edef7503ebb
+colorcontent_c.07.png	8086d25cc25488ca
+colorcontent_c.08.png	7a02b4a7acbb1d77
 colorfill.05.tif	b88390dd68850945
 colorfill_content.01.png	f8a2444b3efaadfc
 colorfill_content.02.png	3fd8adc7c85147fc


### PR DESCRIPTION
## Why

plan 902 の Unmapped 削減。`color` は Unmapped 108 件と最大の未開拓領域。
`colorcontent_reg` の 13 出力のうち check 0/1/5/8/9 は JPEG 入力
(fish24.jpg / wyom.jpg / map.057.jpg) のためデコード差 (finding 001/008)
で bit 一致が原理的に不可能だが、**check 10-17 の 8 件は入力画像を持たず**、
`pixMakeGamutRGB` で合成した RGB gamut を `pixMakeArbMaskFromRGB` で分類
するだけなので決定的に比較できる。

## What

- **実装差 34 件目**: `make_arb_mask_from_rgb` が f32 の重み付き和を
  そのまま閾値と比較していた。C は `pixConvertRGBToGrayArb` で 8bpp gray
  中間を作ってから `pixThresholdToBinary(pix1, thresh + 1)` + `pixInvert`
  するため、実際の判定は

  ```text
  clip(trunc(rc*R + gc*G + bc*B), 0, 255) >= trunc(thresh) + 1
  ```

  という整数意味論。係数 (0.4, 0.3, 0.3)・閾値 60 で和が 60.8 のとき、
  C は `trunc(60.8) = 60 < 61` で OFF、旧実装は `60.8 > 60.0` で ON と
  なり乖離していた。切り捨て・[0,255] クリップ・閾値の整数化に加え、
  `thresh >= 255` を 254 にクランプする挙動と、係数が全て非正のときの
  エラーも C に合わせた
- `Pix::make_gamut_rgb` (C `pixMakeGamutRGB`) を新規移植
- `colorcontent_c_compat` テストを追加し、C check 10-17 を 8 ペアマップ
  — **全件即 Ok**

## Impact

- C 互換ベースライン: **Ok 198 → 206**、Mismatch 29 / Unmapped 400 /
  Excluded 98 は不変
- `color` binary の Ok が 25 → 33
- 既存 golden hash に変化なし (`make_arb_mask_from_rgb` は他の回帰テスト
  から未使用だった)
- あわせて c-compat-status.md の Excluded 件数が PR 22 の更新漏れで 86 の
  ままだったのを 98 に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg