### PR TITLE
plan 902 PR 25: checkerboard corner 検出を C 準拠に — 4 ペア全件 Ok

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-17 実測、plan 902 PR 24 後):
+- 現状ベースライン (As of 2026-08-17 実測、plan 902 PR 25 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 218 / Mismatch 29 / MissingC 0 / Unmapped 400 / Excluded 98**
+  **Ok 222 / Mismatch 29 / MissingC 0 / Unmapped 396 / Excluded 98**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -617,7 +617,39 @@ JPEG デコード差 (finding 001) の影響を受けるが、**check 28-39 の 
   writetext_multi / adaptnorm 系の golden を再生成 (いずれも Unmapped で
   C 側 Ok の退行なし)
 
-### PR 25 以降: semantic マッピングの漸進追加
+### PR 25: checkerboard corner 検出 (実施済み)
+
+C 版ソース: `src/checkerboard.c` (pixFindCheckerboardCorners /
+makeCheckerboardCornerPixa)、`src/boxfunc2.c` (boxaExtractCorners)、
+`prog/checkerboard_reg.c`。
+
+`checkerboard_reg` は既に C の構造 (check 0/2/3/5) をそのまま写して
+いたが、入力が可逆な `checkerboard1.tif` / `checkerboard2.tif` にも
+かかわらず 4 件すべて Mismatch だった。
+
+実施結果:
+
+- 実装差 38 件目: corner 検出の hit-miss sel が象限全体を hit/miss で
+  埋める独自構成だった。C `makeCheckerboardCornerPixa` は
+
+  - 2 点 ((1,1) と (size-2, size-2)、cross 系は中央列の 2 点) を立てた
+    1bpp マスクを dilation ブリックで膨張させたものを hit
+  - 同マスクを 90 度時計回りに回転したものを miss
+  - 残りは全て don't-care、原点は中心
+
+  とする**疎な**構成で、対になる sel は hit/miss を入れ替える。
+  `morph::dilate_brick` / `transform::rotate_90` で C の構成を再現した
+- 実装差 39 件目: `Boxa::extract_corners(Center)` が
+  `(left + right) as f32 / 2.0` と浮動小数で計算していた。C
+  `boxaExtractCorners(L_BOX_CENTER)` は l_int32 の `(left + right) / 2`
+  で、偶数幅の box では .5 にならず左上側へ切り捨てられる
+- checkerboard の C check 0/2/3/5 を 4 ペアマップ — **全件 Ok**
+  (Ok 218 → 222、Unmapped 400 → 396)
+- **C check 1/4 (debug pixa の tiled display) は次段送り**:
+  `selaDisplayInPix` / `selMakePlusSign` / `pixDisplaySelectedPixels` が
+  未移植で、`find_checkerboard_corners` が中間画像を返さないため
+
+### PR 26 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,13 +54,13 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        |    件数 | 説明                                                                                                                                                |
 | ----------- | ------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **218** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +174)                                                                    |
+| ✅ Ok       | **222** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +178)                                                                    |
 | ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                   |
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                        |
-| 📭 Unmapped | **400** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 403 → 400)                                                                 |
+| 📭 Unmapped | **396** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 400 → 396)                                                                 |
 | 🚫 Excluded |  **98** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 |
 
-合計 745 entries がレポート対象 (As of 2026-08-17、plan 902 PR 24 後)。
+合計 745 entries がレポート対象 (As of 2026-08-17、plan 902 PR 25 後)。
 Rust manifest (`tests/golden_manifest.tsv`) 全体は **752 entries**。
 
 ## test binary 別の内訳
@@ -74,7 +74,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **752 entries**。
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |     19 |        0 |        0 |       45 |        0 |
 | `region`    | **73** |        2 |        0 |       28 |       29 |
-| `transform` |     25 |        0 |        0 |       78 |        0 |
+| `transform` |     29 |        0 |        0 |       74 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -373,3 +373,7 @@ color	grayquant	36	grayquant_c	9	threshold_to_4bpp 4 levels
 color	grayquant	37	grayquant_c	10	threshold_to_4bpp 3 levels
 color	grayquant	38	grayquant_c	11	threshold_to_4bpp 2 levels
 color	grayquant	39	grayquant_c	12	stacked 8bpp comparison
+transform	checkerboard	0	checkerboard	1	corner pix (checkerboard1.tif, nsels 2)
+transform	checkerboard	2	checkerboard	2	Pta corners dilated 5x5 (checkerboard1.tif)
+transform	checkerboard	3	checkerboard	3	corner pix (checkerboard2.tif, nsels 4)
+transform	checkerboard	5	checkerboard	4	Pta corners dilated 5x5 (checkerboard2.tif)

--- a/src/core/box_/extract.rs
+++ b/src/core/box_/extract.rs
@@ -265,14 +265,15 @@ mod tests {
         assert_eq!(pta.get(0).unwrap(), (39.0, 59.0)); // (10+30-1, 20+40-1)
     }
 
+    /// C computes the centre with l_int32 arithmetic, so a box of even
+    /// extent truncates towards the upper-left instead of landing on .5.
     #[test]
+    #[ignore = "not yet implemented"]
     fn test_extract_corners_center() {
         let boxa = sample_boxa();
         let pta = boxa.extract_corners(CornerLocation::Center);
-        // box(10,20,30,40): center = ((10+39)/2, (20+59)/2) = (24.5, 39.5)
-        let (cx, cy) = pta.get(0).unwrap();
-        assert!((cx - 24.5).abs() < 0.01);
-        assert!((cy - 39.5).abs() < 0.01);
+        // box(10,20,30,40): center = ((10+39)/2, (20+59)/2) = (24, 39)
+        assert_eq!(pta.get(0).unwrap(), (24.0, 39.0));
     }
 
     #[test]

--- a/src/core/box_/extract.rs
+++ b/src/core/box_/extract.rs
@@ -117,7 +117,8 @@ impl Boxa {
     ///
     /// The centre is computed with C's **integer** division
     /// `(left + right) / 2`, so a box of even extent rounds towards the
-    /// upper-left rather than landing on a half-pixel.
+    /// upper-left rather than landing on a half-pixel. The sum is taken in
+    /// `i64` so that boxes near `i32::MAX` cannot overflow.
     ///
     /// C Leptonica equivalent: `boxaExtractCorners`
     pub fn extract_corners(&self, loc: CornerLocation) -> Pta {
@@ -130,8 +131,11 @@ impl Boxa {
                 pta.push(0.0, 0.0);
                 continue;
             }
-            let right = left + w - 1;
-            let bot = top + h - 1;
+            // Widened so that boxes near i32::MAX cannot overflow; the
+            // arithmetic is otherwise identical to C's l_int32 version.
+            let (left, top) = (left as i64, top as i64);
+            let right = left + w as i64 - 1;
+            let bot = top + h as i64 - 1;
             match loc {
                 CornerLocation::UpperLeft => pta.push(left as f32, top as f32),
                 CornerLocation::UpperRight => pta.push(right as f32, top as f32),
@@ -139,7 +143,8 @@ impl Boxa {
                 CornerLocation::LowerRight => pta.push(right as f32, bot as f32),
                 CornerLocation::Center => {
                     // C: ptaAddPt(pta, (left + right) / 2, (top + bot) / 2)
-                    // with l_int32 arithmetic.
+                    // with l_int32 arithmetic; i64 division truncates towards
+                    // zero the same way.
                     pta.push(((left + right) / 2) as f32, ((top + bot) / 2) as f32);
                 }
             }
@@ -279,6 +284,16 @@ mod tests {
         let pta = boxa.extract_corners(CornerLocation::Center);
         // box(10,20,30,40): center = ((10+39)/2, (20+59)/2) = (24, 39)
         assert_eq!(pta.get(0).unwrap(), (24.0, 39.0));
+    }
+
+    /// Coordinates near `i32::MAX` must not overflow the intermediate sum.
+    #[test]
+    fn test_extract_corners_center_near_i32_max() {
+        let mut boxa = Boxa::new();
+        boxa.push(Box::new_unchecked(i32::MAX - 10, i32::MAX - 10, 5, 5));
+        let pta = boxa.extract_corners(CornerLocation::Center);
+        let expected = ((i32::MAX - 10) as i64 + (i32::MAX - 6) as i64) / 2;
+        assert_eq!(pta.get(0).unwrap(), (expected as f32, expected as f32));
     }
 
     #[test]

--- a/src/core/box_/extract.rs
+++ b/src/core/box_/extract.rs
@@ -115,6 +115,10 @@ impl Boxa {
     ///
     /// Invalid boxes (w==0 or h==0) produce (0, 0).
     ///
+    /// The centre is computed with C's **integer** division
+    /// `(left + right) / 2`, so a box of even extent rounds towards the
+    /// upper-left rather than landing on a half-pixel.
+    ///
     /// C Leptonica equivalent: `boxaExtractCorners`
     pub fn extract_corners(&self, loc: CornerLocation) -> Pta {
         let n = self.len();
@@ -134,7 +138,9 @@ impl Boxa {
                 CornerLocation::LowerLeft => pta.push(left as f32, bot as f32),
                 CornerLocation::LowerRight => pta.push(right as f32, bot as f32),
                 CornerLocation::Center => {
-                    pta.push((left + right) as f32 / 2.0, (top + bot) as f32 / 2.0);
+                    // C: ptaAddPt(pta, (left + right) / 2, (top + bot) / 2)
+                    // with l_int32 arithmetic.
+                    pta.push(((left + right) / 2) as f32, ((top + bot) / 2) as f32);
                 }
             }
         }
@@ -268,7 +274,6 @@ mod tests {
     /// C computes the centre with l_int32 arithmetic, so a box of even
     /// extent truncates towards the upper-left instead of landing on .5.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_extract_corners_center() {
         let boxa = sample_boxa();
         let pta = boxa.extract_corners(CornerLocation::Center);

--- a/src/region/checkerboard.rs
+++ b/src/region/checkerboard.rs
@@ -6,9 +6,10 @@
 //! # See also
 //! C Leptonica: `checkerboard.c`
 
-use crate::core::{Boxa, Pix, Pta};
+use crate::core::Pix;
+use crate::core::{CornerLocation, Pta};
 use crate::morph;
-use crate::morph::{MorphOpType, Sel};
+use crate::morph::{MorphOpType, Sel, SelElement};
 use crate::region;
 use crate::region::{ConnectivityType, RegionError, RegionResult};
 
@@ -76,146 +77,84 @@ pub fn find_checkerboard_corners(
     .map_err(|e| RegionError::Core(crate::core::Error::NotSupported(e.to_string())))?;
 
     // Extract center coordinates of each CC
+    // C: boxaExtractCorners(boxa1, L_BOX_CENTER)
     let (boxa, _) = region::conncomp_pixa(&pix3, ConnectivityType::EightWay)?;
-    let pta = boxa_extract_centers(&boxa);
+    let pta = boxa.extract_corners(CornerLocation::Center);
 
     Ok((pix3, pta))
 }
 
-/// Extract center points from bounding boxes
-fn boxa_extract_centers(boxa: &Boxa) -> Pta {
-    let mut pta = Pta::new();
-    for i in 0..boxa.len() {
-        if let Some(b) = boxa.get(i) {
-            pta.push(b.center_x() as f32, b.center_y() as f32);
-        }
-    }
-    pta
-}
-
-/// Generate diagonal hit-miss structuring elements for corner detection
+/// Generate the hit-miss structuring elements for corner detection.
+///
+/// C builds each sel from a *sparse* pair of dilated pixels rather than
+/// filled quadrants: a 1 bpp mask with two set pixels near opposite corners
+/// (or on the mid-line, for the cross sels), dilated by a `dilation` brick,
+/// gives the hits; the same mask rotated 90 degrees gives the misses. The
+/// second sel of each pair swaps the two roles. Everything else in the
+/// `size` x `size` window stays don't-care, and the origin is the centre.
+///
+/// C equivalent: `makeCheckerboardCornerPixa()` + `selCreateFromColorPix()`
+/// in `checkerboard.c` / `sel1.c`
 fn make_checkerboard_corner_sels(size: u32, dilation: u32, nsels: u32) -> RegionResult<Vec<Sel>> {
+    let half = size / 2;
     let mut sels = Vec::with_capacity(nsels as usize);
-    let s = size as usize;
-    let half = s / 2;
 
-    // Sel 1: diagonal pattern (top-left hit, bottom-right hit; top-right miss, bottom-left miss)
-    let sel1 = make_diagonal_sel(s, half, dilation, false)?;
-    sels.push(sel1);
-
-    // Sel 2: opposite diagonal pattern
-    let sel2 = make_diagonal_sel(s, half, dilation, true)?;
-    sels.push(sel2);
+    // Diagonal (negative slope) mask: the UL and LR inset corners.
+    let diag = corner_mask(size, dilation, &[(1, 1), (size - 2, size - 2)])?;
+    let anti = rotate_mask_90(&diag)?;
+    sels.push(sel_from_masks(size, half, &diag, &anti)?);
+    sels.push(sel_from_masks(size, half, &anti, &diag)?);
 
     if nsels == 4 {
-        // Sel 3: cross pattern variant 1
-        let sel3 = make_cross_sel(s, half, dilation, false)?;
-        sels.push(sel3);
-
-        // Sel 4: cross pattern variant 2
-        let sel4 = make_cross_sel(s, half, dilation, true)?;
-        sels.push(sel4);
+        // Vertical mask: two points on the mid-column.
+        let vert = corner_mask(size, dilation, &[(half, 1), (half, size - 2)])?;
+        let horiz = rotate_mask_90(&vert)?;
+        sels.push(sel_from_masks(size, half, &vert, &horiz)?);
+        sels.push(sel_from_masks(size, half, &horiz, &vert)?);
     }
 
     Ok(sels)
 }
 
-/// Make a diagonal corner sel
-fn make_diagonal_sel(size: usize, half: usize, dilation: u32, flipped: bool) -> RegionResult<Sel> {
-    let mut pattern = String::new();
-    let d = dilation as usize;
-
-    for y in 0..size {
-        for x in 0..size {
-            if y == half && x == half {
-                pattern.push('C');
-            } else {
-                let is_hit;
-                let is_miss;
-
-                if !flipped {
-                    // Top-left and bottom-right are hits; top-right and bottom-left are misses
-                    is_hit = (x < half.saturating_sub(d) && y < half.saturating_sub(d))
-                        || (x > half + d && y > half + d);
-                    is_miss = (x > half + d && y < half.saturating_sub(d))
-                        || (x < half.saturating_sub(d) && y > half + d);
-                } else {
-                    // Top-right and bottom-left are hits; top-left and bottom-right are misses
-                    is_hit = (x > half + d && y < half.saturating_sub(d))
-                        || (x < half.saturating_sub(d) && y > half + d);
-                    is_miss = (x < half.saturating_sub(d) && y < half.saturating_sub(d))
-                        || (x > half + d && y > half + d);
-                }
-
-                if is_hit {
-                    pattern.push('x');
-                } else if is_miss {
-                    pattern.push('o');
-                } else {
-                    pattern.push(' ');
-                }
-            }
-        }
-        if y < size - 1 {
-            pattern.push('\n');
-        }
+/// A `size` x `size` 1 bpp mask with `points` set and dilated by a
+/// `dilation` x `dilation` brick (C only dilates when `dilation > 1`).
+fn corner_mask(size: u32, dilation: u32, points: &[(u32, u32)]) -> RegionResult<Pix> {
+    let pix = Pix::new(size, size, crate::core::PixelDepth::Bit1).map_err(RegionError::Core)?;
+    let mut pm = pix.try_into_mut().unwrap();
+    for &(x, y) in points {
+        pm.set_pixel_unchecked(x, y, 1);
     }
+    let pix: Pix = pm.into();
+    if dilation > 1 {
+        morph::dilate_brick(&pix, dilation, dilation)
+            .map_err(|e| RegionError::Core(crate::core::Error::NotSupported(e.to_string())))
+    } else {
+        Ok(pix)
+    }
+}
 
-    Sel::from_string(&pattern, half as u32, half as u32)
+/// C `pixRotate90(pix, 1)`: a clockwise quarter turn.
+fn rotate_mask_90(pix: &Pix) -> RegionResult<Pix> {
+    crate::transform::rotate_90(pix, true)
         .map_err(|e| RegionError::Core(crate::core::Error::NotSupported(e.to_string())))
 }
 
-/// Make a cross corner sel
-fn make_cross_sel(size: usize, half: usize, dilation: u32, flipped: bool) -> RegionResult<Sel> {
-    let mut pattern = String::new();
-    let d = dilation as usize;
-
+/// Combine a hit mask and a miss mask into a sel centred on `half`.
+fn sel_from_masks(size: u32, half: u32, hits: &Pix, misses: &Pix) -> RegionResult<Sel> {
+    let mut sel = Sel::new(size, size)
+        .map_err(|e| RegionError::Core(crate::core::Error::NotSupported(e.to_string())))?;
     for y in 0..size {
         for x in 0..size {
-            if y == half && x == half {
-                pattern.push('C');
-            } else {
-                let is_hit;
-                let is_miss;
-
-                if !flipped {
-                    // Top and bottom center are hits; left and right center are misses
-                    is_hit = (x >= half.saturating_sub(d)
-                        && x <= half + d
-                        && y < half.saturating_sub(d))
-                        || (x >= half.saturating_sub(d) && x <= half + d && y > half + d);
-                    is_miss = (y >= half.saturating_sub(d)
-                        && y <= half + d
-                        && x < half.saturating_sub(d))
-                        || (y >= half.saturating_sub(d) && y <= half + d && x > half + d);
-                } else {
-                    // Left and right center are hits; top and bottom center are misses
-                    is_hit = (y >= half.saturating_sub(d)
-                        && y <= half + d
-                        && x < half.saturating_sub(d))
-                        || (y >= half.saturating_sub(d) && y <= half + d && x > half + d);
-                    is_miss = (x >= half.saturating_sub(d)
-                        && x <= half + d
-                        && y < half.saturating_sub(d))
-                        || (x >= half.saturating_sub(d) && x <= half + d && y > half + d);
-                }
-
-                if is_hit {
-                    pattern.push('x');
-                } else if is_miss {
-                    pattern.push('o');
-                } else {
-                    pattern.push(' ');
-                }
+            if hits.get_pixel_unchecked(x, y) == 1 {
+                sel.set_element(x, y, SelElement::Hit);
+            } else if misses.get_pixel_unchecked(x, y) == 1 {
+                sel.set_element(x, y, SelElement::Miss);
             }
         }
-        if y < size - 1 {
-            pattern.push('\n');
-        }
     }
-
-    Sel::from_string(&pattern, half as u32, half as u32)
-        .map_err(|e| RegionError::Core(crate::core::Error::NotSupported(e.to_string())))
+    sel.set_origin(half, half)
+        .map_err(|e| RegionError::Core(crate::core::Error::NotSupported(e.to_string())))?;
+    Ok(sel)
 }
 
 #[cfg(test)]
@@ -229,7 +168,6 @@ mod tests {
     /// `dilation x dilation` brick, are the hits, and the same mask rotated
     /// 90 degrees gives the misses. Everything else is don't-care.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_corner_sels_are_sparse_like_c() {
         let sels = make_checkerboard_corner_sels(15, 3, 2).unwrap();
         assert_eq!(sels.len(), 2);
@@ -251,7 +189,6 @@ mod tests {
 
     /// Without dilation each role is a single pixel per corner.
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_corner_sels_undilated() {
         let sels = make_checkerboard_corner_sels(15, 1, 4).unwrap();
         assert_eq!(sels.len(), 4);

--- a/src/region/checkerboard.rs
+++ b/src/region/checkerboard.rs
@@ -217,3 +217,57 @@ fn make_cross_sel(size: usize, half: usize, dilation: u32, flipped: bool) -> Reg
     Sel::from_string(&pattern, half as u32, half as u32)
         .map_err(|e| RegionError::Core(crate::core::Error::NotSupported(e.to_string())))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::morph::SelElement;
+
+    /// C builds each corner sel from two *dilated pixels* per role, not from
+    /// filled quadrants: `pixSetPixel(pix2, 1, 1)` and
+    /// `pixSetPixel(pix2, size - 2, size - 2)`, dilated by a
+    /// `dilation x dilation` brick, are the hits, and the same mask rotated
+    /// 90 degrees gives the misses. Everything else is don't-care.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_corner_sels_are_sparse_like_c() {
+        let sels = make_checkerboard_corner_sels(15, 3, 2).unwrap();
+        assert_eq!(sels.len(), 2);
+        for sel in &sels {
+            assert_eq!(sel.width(), 15);
+            assert_eq!(sel.height(), 15);
+            assert_eq!(sel.origin_x(), 7);
+            assert_eq!(sel.origin_y(), 7);
+            // Two 3x3 blocks of hits and two of misses.
+            assert_eq!(sel.hit_count(), 18);
+            assert_eq!(sel.miss_count(), 18);
+        }
+        // The pair swaps hits and misses.
+        assert_eq!(
+            sels[0].get_element(0, 0).unwrap(),
+            sels[1].get_element(14, 0).unwrap()
+        );
+    }
+
+    /// Without dilation each role is a single pixel per corner.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_corner_sels_undilated() {
+        let sels = make_checkerboard_corner_sels(15, 1, 4).unwrap();
+        assert_eq!(sels.len(), 4);
+        for sel in &sels {
+            assert_eq!(sel.hit_count(), 2);
+            assert_eq!(sel.miss_count(), 2);
+        }
+        // Diagonal sel: hits on the negative-slope inset corners.
+        assert_eq!(sels[0].get_element(1, 1).unwrap(), SelElement::Hit);
+        assert_eq!(sels[0].get_element(13, 13).unwrap(), SelElement::Hit);
+        assert_eq!(sels[0].get_element(13, 1).unwrap(), SelElement::Miss);
+        assert_eq!(sels[0].get_element(1, 13).unwrap(), SelElement::Miss);
+        // Cross sel: hits on the mid-column.
+        assert_eq!(sels[2].get_element(7, 1).unwrap(), SelElement::Hit);
+        assert_eq!(sels[2].get_element(7, 13).unwrap(), SelElement::Hit);
+        assert_eq!(sels[2].get_element(1, 7).unwrap(), SelElement::Miss);
+        assert_eq!(sels[2].get_element(13, 7).unwrap(), SelElement::Miss);
+    }
+}

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -154,10 +154,10 @@ bw_alpha.01.png	c3addf40c3faa296
 bw_black.03.png	0333d6ff685a9425
 bw_white.03.png	f6995f80dec29e85
 ccbord_dreyfus1.04.tif	6eea4bcb33f79204
-checkerboard.01.png	9e8a973d0fda7951
-checkerboard.02.png	0bef68227b9fb2f0
-checkerboard.03.png	dc9fb606c6f0454e
-checkerboard.04.png	7e46993a0d79c3ff
+checkerboard.01.png	0eaabb629dcecc61
+checkerboard.02.png	2eca0d318c854fc0
+checkerboard.03.png	cb88ea29a0599d9f
+checkerboard.04.png	4e52b4a5a25fd2ef
 cmapquant.06.png	ba9b70aafb2041b7
 cmapquant_algo_cmp.09.png	7c473800cea8e10c
 colorcontent.07.png	b06bb0eb5a72f121

--- a/tests/transform/checkerboard_reg.rs
+++ b/tests/transform/checkerboard_reg.rs
@@ -16,24 +16,6 @@
 use crate::common::RegParams;
 use leptonica::io::ImageFormat;
 use leptonica::morph::dilate_brick;
-use leptonica::{Pix, PixelDepth};
-
-/// Generate a 1bpp image from Pta coordinates.
-///
-/// Equivalent to C's `pixGenerateFromPta(pta, w, h)`.
-fn generate_pix_from_pta(pta: &leptonica::Pta, w: u32, h: u32) -> Pix {
-    let pix = Pix::new(w, h, PixelDepth::Bit1).expect("create pix for pta");
-    let mut pm = pix.try_into_mut().expect("mutable pix for pta");
-    for i in 0..pta.len() {
-        let (x, y) = pta.get(i).expect("get pta point");
-        let xi = x.round() as u32;
-        let yi = y.round() as u32;
-        if xi < w && yi < h {
-            pm.set_pixel_unchecked(xi, yi, 1);
-        }
-    }
-    pm.into()
-}
 
 /// Helper to run checkerboard corner detection and register results.
 ///
@@ -59,7 +41,8 @@ fn locate_checkerboard_corners(rp: &mut RegParams, fname: &str, nsels: u32) {
 
     // C check 2/5: generate image from Pta + dilate 5x5 (WPAC)
     let (w, h) = (pix1.width(), pix1.height());
-    let pta_pix = generate_pix_from_pta(&pta, w, h);
+    let pta_pix =
+        leptonica::core::pta::graphics::pix_generate_from_pta(&pta, w, h).expect("pta -> pix");
     let dilated = dilate_brick(&pta_pix, 5, 5).unwrap_or_else(|_| {
         panic!("dilate pta_pix for {fname}");
     });


### PR DESCRIPTION
## Why

plan 902 の Unmapped 削減。`checkerboard_reg` は既に C の構造
(check 0/2/3/5) をそのまま写しており、入力も可逆な
`checkerboard1.tif` / `checkerboard2.tif` なのに、マップを試すと
**4 件すべて Mismatch** だった。つまり純粋な実装差異。

## What

- **実装差異 #38**: corner 検出の hit-miss sel が象限全体を hit/miss で
  埋める独自構成だった。C `makeCheckerboardCornerPixa` は

  - 2 点 (`(1,1)` と `(size-2, size-2)`、cross 系は中央列の 2 点) を
    立てた 1bpp マスクを dilation ブリックで膨張させたものを hit
  - 同マスクを 90 度時計回りに回転したものを miss
  - 残りは全て don't-care、原点は中心

  という**疎な**構成で、対になる sel は hit/miss を入れ替える。
  `morph::dilate_brick` / `transform::rotate_90` を使って C の構成
  そのものを再現した
- **実装差異 #39**: `Boxa::extract_corners(Center)` が
  `(left + right) as f32 / 2.0` と浮動小数で計算していた。C
  `boxaExtractCorners(L_BOX_CENTER)` は l_int32 の `(left + right) / 2`
  で、偶数幅の box では .5 にならず左上側へ切り捨てられる
- テスト側の独自 round ベースヘルパをやめ、C `pixGenerateFromPta` 相当の
  `pix_generate_from_pta` を使うようにした

## Impact

- C 互換ベースライン: **Ok 218 → 222**、**Unmapped 400 → 396**。
  Mismatch 29 / Excluded 98 は不変。`transform` binary の Ok が 25 → 29
- sel 構成の修正で corner pix (C check 0/3) が bit 一致し、
  `extract_corners` の修正で Pta 由来の出力 (C check 2/5) も一致した
- **C check 1/4 (debug pixa の tiled display) は次段送り**:
  `selaDisplayInPix` / `selMakePlusSign` / `pixDisplaySelectedPixels` が
  未移植で、`find_checkerboard_corners` が中間画像を返さないため

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg