### PR TITLE
plan 902 PR 26: paint の colormap 再構成を整列 — 6 ペア全件 Ok

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-17 実測、plan 902 PR 25 後):
+- 現状ベースライン (As of 2026-08-17 実測、plan 902 PR 26 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 222 / Mismatch 29 / MissingC 0 / Unmapped 396 / Excluded 98**
+  **Ok 228 / Mismatch 29 / MissingC 0 / Unmapped 396 / Excluded 98**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -649,7 +649,36 @@ makeCheckerboardCornerPixa)、`src/boxfunc2.c` (boxaExtractCorners)、
   `selaDisplayInPix` / `selMakePlusSign` / `pixDisplaySelectedPixels` が
   未移植で、`find_checkerboard_corners` が中間画像を返さないため
 
-### PR 26 以降: semantic マッピングの漸進追加
+### PR 26: paint の colormap 再構成 (実施済み)
+
+C 版ソース: `src/paintcmap.c` (pixSetMaskedCmap)、`prog/paint_reg.c`。
+
+`paint_reg` の入力は大半が JPEG (lucasta-frag.jpg / lucasta.150.jpg) だが、
+末尾の **colormap 再構成ブロックは weasel2.4c.png / weasel4.11c.png /
+weasel8.240c.png という可逆な cmapped PNG のみ**を使うため bit 一致比較が
+できる。
+
+実施結果:
+
+- 実装差 40 件目: `pix_set_masked_cmap` が色を検索せずに必ず `add_color`
+  し、失敗時は最近傍色へ黙ってフォールバックしていた。C
+  `pixSetMaskedCmap` は `pixcmapGetIndex` で既存色を探して再利用し、
+  無い場合のみ追加、空きが無ければ "no room in cmap" でエラーを返す
+  (最近傍フォールバックは呼び出し側の責務)。深度 {2,4,8} の検証も追加。
+  旧実装では `ReconstructByValue` のように既存 cmap を持つ pix を塗り直す
+  ケースで重複エントリが積まれ index がずれていた
+- paint の C check 24/26/28-31 を 6 ペアマップ — **全件 Ok**
+  (Ok 222 → 228)
+- **C ソースのコメント番号は実 index とずれている**: helper 内の
+  `regTestComparePix` を数えていないため `/* 23 */` 〜 `/* 28 */` は実際には
+  24/26/28〜31。C manifest に 23/25/27 が存在しないことで判明した。
+  以後のマッピングでは manifest の実エントリを正とする
+- **check 18-22 (feyn-fract.tif ブロック) は次段送り**: C
+  `pixColorGrayRegions` / `pixColorGray` は 8bpp gray と cmapped を直接
+  扱い boxa を取るのに対し、Rust 側は 32bpp 専用でシグネチャも異なるため、
+  別 PR で C 準拠に書き換える必要がある
+
+### PR 27 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,20 +54,20 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        |    件数 | 説明                                                                                                                                                |
 | ----------- | ------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **222** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +178)                                                                    |
+| ✅ Ok       | **228** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +184)                                                                    |
 | ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                   |
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                        |
 | 📭 Unmapped | **396** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 400 → 396)                                                                 |
 | 🚫 Excluded |  **98** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 |
 
-合計 745 entries がレポート対象 (As of 2026-08-17、plan 902 PR 25 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **752 entries**。
+合計 751 entries がレポート対象 (As of 2026-08-17、plan 902 PR 26 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **758 entries**。
 
 ## test binary 別の内訳
 
 | Binary      |     Ok | Mismatch | MissingC | Unmapped | Excluded |
 | ----------- | -----: | -------: | -------: | -------: | -------: |
-| `color`     |     45 |        4 |        0 |      108 |        4 |
+| `color`     |     51 |        4 |        0 |      108 |        4 |
 | `core`      |     13 |        0 |        0 |       34 |       12 |
 | `filter`    |      2 |        5 |        0 |       57 |       40 |
 | `io`        |     11 |        2 |        0 |       41 |       13 |

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -377,3 +377,9 @@ transform	checkerboard	0	checkerboard	1	corner pix (checkerboard1.tif, nsels 2)
 transform	checkerboard	2	checkerboard	2	Pta corners dilated 5x5 (checkerboard1.tif)
 transform	checkerboard	3	checkerboard	3	corner pix (checkerboard2.tif, nsels 4)
 transform	checkerboard	5	checkerboard	4	Pta corners dilated 5x5 (checkerboard2.tif)
+color	paint	24	paint_c	2	ReconstructByValue weasel2.4c.png
+color	paint	26	paint_c	4	ReconstructByValue weasel4.11c.png
+color	paint	28	paint_c	6	ReconstructByValue weasel8.240c.png
+color	paint	29	paint_c	7	FakeReconstructByBand weasel2.4c.png
+color	paint	30	paint_c	8	FakeReconstructByBand weasel4.11c.png
+color	paint	31	paint_c	9	FakeReconstructByBand weasel8.240c.png

--- a/src/color/paintcmap.rs
+++ b/src/color/paintcmap.rs
@@ -402,7 +402,12 @@ pub fn pix_set_select_masked_cmap(
 
 /// Set all pixels to a color through a mask in a colormapped image.
 ///
-/// Pixels where the mask is ON are set to `new_color`.
+/// Pixels where the mask is ON, offset by `(x_offset, y_offset)`, are given
+/// the index of `new_color`. As in C the colour is looked up in the colormap
+/// first and only appended when absent, so repainting with a colour that is
+/// already present reuses its entry instead of duplicating it. When the
+/// colormap is full and the colour is not present this is an error — C's
+/// nearest-colour fallback lives one level up, not here.
 ///
 /// # Reference
 ///
@@ -421,14 +426,23 @@ pub fn pix_set_masked_cmap(
         });
     }
     check_colormapped(pix)?;
+    let d = pix.depth();
+    if !matches!(d, PixelDepth::Bit2 | PixelDepth::Bit4 | PixelDepth::Bit8) {
+        return Err(ColorError::UnsupportedDepth {
+            expected: "2, 4 or 8 bpp",
+            actual: d.bits(),
+        });
+    }
 
+    let (r, g, b) = new_color;
     let new_idx = {
         let cmap = pix.colormap_mut().unwrap();
-        match cmap.add_color(RgbaQuad::rgb(new_color.0, new_color.1, new_color.2)) {
-            Ok(idx) => idx as u32,
-            Err(_) => cmap
-                .find_nearest(new_color.0, new_color.1, new_color.2)
-                .unwrap_or(0) as u32,
+        match cmap.get_index(r, g, b) {
+            Some(index) => index as u32,
+            None => cmap
+                .add_color(RgbaQuad::rgb(r, g, b))
+                .map_err(|_| ColorError::InvalidParameters("no room in cmap".into()))?
+                as u32,
         }
     };
 

--- a/tests/color/paint_reg.rs
+++ b/tests/color/paint_reg.rs
@@ -221,7 +221,6 @@ fn paint_reg_colormap() {
 /// unlike the JPEG-driven checks earlier in that program these are
 /// bit-exactly comparable against C.
 #[test]
-#[ignore = "not yet implemented"]
 fn paint_c_compat_reconstruct() {
     use leptonica::Pix;
     use leptonica::color::paintcmap::pix_set_masked_cmap;

--- a/tests/color/paint_reg.rs
+++ b/tests/color/paint_reg.rs
@@ -213,3 +213,80 @@ fn paint_reg_colormap() {
     // pix4 = pixColorGrayRegions(pix2, boxa, L_PAINT_DARK, 230, 255, 0, 0);
     // pixd = ReconstructByValue(rp, "weasel2.4c.png");
 }
+
+/// C-compat: `prog/paint_reg.c` checks 23-28.
+///
+/// The colormap reconstruction block. Its inputs (`weasel2.4c.png`,
+/// `weasel4.11c.png`, `weasel8.240c.png`) are lossless colormapped PNGs, so
+/// unlike the JPEG-driven checks earlier in that program these are
+/// bit-exactly comparable against C.
+#[test]
+#[ignore = "not yet implemented"]
+fn paint_c_compat_reconstruct() {
+    use leptonica::Pix;
+    use leptonica::color::paintcmap::pix_set_masked_cmap;
+    use leptonica::color::{generate_mask_by_band, generate_mask_by_value};
+    use leptonica::core::PixColormap;
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("paint_c");
+
+    const NAMES: [&str; 3] = ["weasel2.4c.png", "weasel4.11c.png", "weasel8.240c.png"];
+
+    // C 23-25: rebuild each cmapped image one colormap index at a time.
+    // pixd starts as a template (same cmap, zeroed data), so every colour is
+    // already present and pixSetMaskedCmap reuses its index.
+    for name in NAMES {
+        let pixs = crate::common::load_test_image(name).expect("load weasel");
+        let n = pixs.colormap().expect("cmapped input").len();
+        let pixd = pixs.create_template();
+        let mut dm = pixd.try_into_mut().unwrap();
+        for i in 0..n {
+            let mask = generate_mask_by_value(&pixs, i as u32).expect("mask by value");
+            let (r, g, b) = pixs.colormap().unwrap().get_rgb(i).expect("cmap entry");
+            pix_set_masked_cmap(&mut dm, &mask, 0, 0, (r, g, b)).expect("set masked cmap");
+        }
+        let pixd: Pix = dm.into();
+        // C: regTestComparePix(rp, pixs, pixd) — the reconstruction is exact.
+        rp.compare_pix(&pixs, &pixd);
+        rp.write_pix_and_check(&pixd, ImageFormat::Png)
+            .expect("check: reconstruct by value");
+    }
+
+    // C 26-28: rebuild with pairs of colormap entries collapsed into their
+    // average colour, into a fresh (initially empty) colormap.
+    for name in NAMES {
+        let pixs = crate::common::load_test_image(name).expect("load weasel");
+        let cmaps = pixs.colormap().expect("cmapped input").clone();
+        let n = cmaps.len();
+        let nbands = n.div_ceil(2);
+        let pixd = pixs.create_template();
+        let mut dm = pixd.try_into_mut().unwrap();
+        dm.set_colormap(Some(
+            PixColormap::new(pixs.depth().bits()).expect("empty cmap"),
+        ))
+        .expect("set empty cmap");
+        for i in 0..nbands {
+            let jlow = 2 * i;
+            let jup = (jlow + 1).min(n - 1);
+            let mask =
+                generate_mask_by_band(&pixs, jlow as u32, jup as u32, true).expect("mask by band");
+            let (r1, g1, b1) = cmaps.get_rgb(jlow).expect("cmap low");
+            let (r2, g2, b2) = cmaps.get_rgb(jup).expect("cmap up");
+            let avg = (
+                ((r1 as u32 + r2 as u32) / 2) as u8,
+                ((g1 as u32 + g2 as u32) / 2) as u8,
+                ((b1 as u32 + b2 as u32) / 2) as u8,
+            );
+            pix_set_masked_cmap(&mut dm, &mask, 0, 0, avg).expect("set masked cmap band");
+        }
+        let pixd: Pix = dm.into();
+        rp.write_pix_and_check(&pixd, ImageFormat::Png)
+            .expect("check: fake reconstruct by band");
+    }
+
+    assert!(rp.cleanup(), "paint C-compat reconstruction test failed");
+}

--- a/tests/color/paintcmap_reg.rs
+++ b/tests/color/paintcmap_reg.rs
@@ -160,7 +160,6 @@ fn paintcmap_set_select_masked() {
 
 /// Test pix_set_masked_cmap: a colour not yet present is appended.
 #[test]
-#[ignore = "not yet implemented"]
 fn paintcmap_set_masked() {
     use leptonica::color::paintcmap::pix_set_masked_cmap;
 
@@ -188,7 +187,6 @@ fn paintcmap_set_masked() {
 /// only appends when it is absent, so repainting with a colour already in
 /// the colormap must reuse its entry rather than duplicate it.
 #[test]
-#[ignore = "not yet implemented"]
 fn paintcmap_set_masked_reuses_existing_color() {
     use leptonica::color::paintcmap::pix_set_masked_cmap;
 
@@ -213,7 +211,6 @@ fn paintcmap_set_masked_reuses_existing_color() {
 /// When the colormap is full and the colour is absent, C returns an error
 /// ("no room in cmap"); the nearest-colour fallback lives one level up.
 #[test]
-#[ignore = "not yet implemented"]
 fn paintcmap_set_masked_full_cmap_is_an_error() {
     use leptonica::color::paintcmap::pix_set_masked_cmap;
 

--- a/tests/color/paintcmap_reg.rs
+++ b/tests/color/paintcmap_reg.rs
@@ -158,8 +158,9 @@ fn paintcmap_set_select_masked() {
     pix_set_select_masked_cmap(&mut pix, &mask, 0, 0, 1, (0, 255, 0)).unwrap();
 }
 
-/// Test pix_set_masked_cmap.
+/// Test pix_set_masked_cmap: a colour not yet present is appended.
 #[test]
+#[ignore = "not yet implemented"]
 fn paintcmap_set_masked() {
     use leptonica::color::paintcmap::pix_set_masked_cmap;
 
@@ -176,4 +177,57 @@ fn paintcmap_set_masked() {
     let mask: Pix = mask.into();
 
     pix_set_masked_cmap(&mut pix, &mask, 0, 0, (255, 128, 0)).unwrap();
+
+    assert_eq!(pix.colormap().unwrap().len(), 3);
+    assert_eq!(pix.get_pixel(3, 3).unwrap(), 2);
+    assert_eq!(pix.get_pixel(7, 7).unwrap(), 2);
+    assert_eq!(pix.get_pixel(0, 0).unwrap(), 0);
+}
+
+/// C `pixSetMaskedCmap` looks the colour up first (`pixcmapGetIndex`) and
+/// only appends when it is absent, so repainting with a colour already in
+/// the colormap must reuse its entry rather than duplicate it.
+#[test]
+#[ignore = "not yet implemented"]
+fn paintcmap_set_masked_reuses_existing_color() {
+    use leptonica::color::paintcmap::pix_set_masked_cmap;
+
+    let mut cmap = PixColormap::new(8).unwrap();
+    cmap.add_color(RgbaQuad::rgb(0, 0, 0)).unwrap();
+    cmap.add_color(RgbaQuad::rgb(128, 128, 128)).unwrap();
+    cmap.add_color(RgbaQuad::rgb(255, 128, 0)).unwrap();
+
+    let mut pix = Pix::new(4, 4, PixelDepth::Bit8).unwrap().to_mut();
+    pix.set_colormap(Some(cmap)).unwrap();
+
+    let mut mask = Pix::new(4, 4, PixelDepth::Bit1).unwrap().to_mut();
+    mask.set_pixel(1, 1, 1).unwrap();
+    let mask: Pix = mask.into();
+
+    pix_set_masked_cmap(&mut pix, &mask, 0, 0, (255, 128, 0)).unwrap();
+
+    assert_eq!(pix.colormap().unwrap().len(), 3);
+    assert_eq!(pix.get_pixel(1, 1).unwrap(), 2);
+}
+
+/// When the colormap is full and the colour is absent, C returns an error
+/// ("no room in cmap"); the nearest-colour fallback lives one level up.
+#[test]
+#[ignore = "not yet implemented"]
+fn paintcmap_set_masked_full_cmap_is_an_error() {
+    use leptonica::color::paintcmap::pix_set_masked_cmap;
+
+    let mut cmap = PixColormap::new(2).unwrap();
+    for v in [0u8, 85, 170, 255] {
+        cmap.add_color(RgbaQuad::rgb(v, v, v)).unwrap();
+    }
+
+    let mut pix = Pix::new(4, 4, PixelDepth::Bit2).unwrap().to_mut();
+    pix.set_colormap(Some(cmap)).unwrap();
+
+    let mut mask = Pix::new(4, 4, PixelDepth::Bit1).unwrap().to_mut();
+    mask.set_pixel(1, 1, 1).unwrap();
+    let mask: Pix = mask.into();
+
+    assert!(pix_set_masked_cmap(&mut pix, &mask, 0, 0, (10, 20, 30)).is_err());
 }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -572,6 +572,12 @@ pageseg_0_segment_regions.08.tif	835acdbc40fdeba6
 pageseg_5_textline_mask.06.tif	4106db3f2927ed7a
 pageseg_6_textblock_mask.04.tif	6fb97f0eb4f12faa
 paint_blend.03.png	ff665ef823d8799c
+paint_c.02.png	c0e915baf97aeb9e
+paint_c.04.png	1891998038f263a7
+paint_c.06.png	ae835cf4d3a91625
+paint_c.07.png	aa54d209f6eab7dd
+paint_c.08.png	ac9b070016cd820c
+paint_c.09.png	8245318adae4fc9f
 paint_cgray.03.png	a25baddae1c7ca55
 paint_cgray.05.png	39f89ad0984edab8
 paint_cgray.07.png	031d54d1e560a67e


### PR DESCRIPTION
## Why

plan 902 の Unmapped 削減。`paint_reg` の入力は大半が JPEG
(lucasta-frag.jpg / lucasta.150.jpg) だが、末尾の **colormap 再構成
ブロックは `weasel2.4c.png` / `weasel4.11c.png` / `weasel8.240c.png`
という可逆な cmapped PNG のみ**を使うため bit 一致比較ができる。

## What

- **実装差異 #40**: `pix_set_masked_cmap` が色を検索せずに必ず
  `add_color` し、失敗時は最近傍色へ黙ってフォールバックしていた。C
  `pixSetMaskedCmap` は

  - `pixcmapGetIndex` で既存色を検索し、見つかればそのまま再利用
  - 無ければ追加し、空きが無ければ `"no room in cmap"` でエラー
    (最近傍フォールバックは呼び出し側の責務)
  - 深度は `{2, 4, 8}` のみ

  という挙動。旧実装では `ReconstructByValue` のように既存 cmap を持つ
  pix を塗り直すケースで重複エントリが積まれ、index がずれていた
- `paint_c_compat_reconstruct` を追加し C check 24/26/28-31 を 6 ペア
  マップ — **全件 Ok**

## Impact

- C 互換ベースライン: **Ok 222 → 228**。Mismatch 29 / Unmapped 396 /
  Excluded 98 は不変。`color` binary の Ok が 45 → 51
- 既存 golden hash に変化なし

### 副産物: C ソースのコメント番号は実 index とずれている

`paint_reg.c` の `/* 23 */` 〜 `/* 28 */` は helper 内の
`regTestComparePix` を数えていないため、実際の regout index は
24/26/28〜31 だった。C manifest に 23/25/27 が存在しないことで判明。
以後のマッピングでは manifest の実エントリを正とする。

### 次段送り

check 18-22 (feyn-fract.tif ブロック) は、C `pixColorGrayRegions` /
`pixColorGray` が 8bpp gray と cmapped を直接扱い boxa を取るのに対し
Rust 側は 32bpp 専用でシグネチャも異なるため、別 PR で C 準拠に
書き換える必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg