### PR TITLE
plan 902 PR 28: filter 系を初めて整列 — 5 ペア全件 Ok

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-18 実測、plan 902 PR 27 後):
+- 現状ベースライン (As of 2026-08-18 実測、plan 902 PR 28 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 233 / Mismatch 29 / MissingC 0 / Unmapped 396 / Excluded 98**
+  **Ok 238 / Mismatch 29 / MissingC 0 / Unmapped 393 / Excluded 98**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -715,7 +715,44 @@ FNV-1a ハッシュを突き合わせて 3 箇所の乖離を切り分けた。
   入力を拒否するようになった。テスト側で C の呼び出し順どおり
   colormap を外してから畳み込むよう修正した
 
-### PR 28 以降: semantic マッピングの漸進追加
+### PR 28: filter 系の最初の整列 (実施済み)
+
+C 版ソース: `src/convolve.c` (pixBlocksum / blocksumLow /
+pixBlockconvAccum)、`src/adaptmap.c` (pixFillMapHoles)、
+`src/enhance.c` (numaGammaTRC)、`prog/convolve_reg.c` /
+`prog/adaptmap_reg.c`。
+
+`filter` は Ok 2 件と最も未開拓なバイナリだった。lossless 入力を持つ
+ブロックを探し、`convolve_reg` の check 2-4 (test1.png の
+`pixBlockrank`) と `adaptmap_reg` の check 14-15 (weasel8.png と 3x3
+合成マップの `pixFillMapHoles`) を対象にした。
+
+実施結果:
+
+- 実装差 44 件目: `blocksum` の正規化が 1 パスの f64 丸めだった。C
+  `blocksumLow` は
+
+  1. 全カーネル面積の `norm = 255/(fwc*fhc)` で正規化し、f32 の積を
+     byte に切り捨てる
+  2. 境界の行・列を、**切り捨て済みの byte** に対して `fhc/hn`・
+     `fwc/wn` で再スケールし、また切り捨てる
+
+  という 2 パス構成。理想値を 1 回丸めるのとは多くの画素で 1 ずれ、
+  全 ON 画像でも角が 252 になる。accumulator も C 同様 1bpp を
+  「ON 画素数」で積算するよう `blockconv_accum` を 1bpp 対応にした
+- 実装差 45 件目: `fill_map_holes` が `filltype` を取らず
+  `L_FILL_BLACK` 固定だった。C は
+  `valtest = (filltype == L_FILL_WHITE) ? 255 : 0` で穴の値を切り替える。
+  `MapFillType` を導入
+- 実装差 46 件目: `gamma_trc` の LUT が
+  `255. * powf(x, invgamma) + 0.5` を f32 で評価していた。C の `255.` は
+  double リテラルのため倍精度評価になり、.5 境界に乗る値が 1 ずれる
+  (maxval 270 で入力 153 が C 144 に対し 145)。**PR 27 の #41 / #43 と
+  同種の「C の double リテラルによる評価精度」問題**で、この
+  キャンペーンで繰り返し現れるパターン
+- 5 ペアマップ — **全件 Ok** (Ok 233 → 238、filter binary の Ok が 2 → 7)
+
+### PR 29 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,14 +54,14 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        |    件数 | 説明                                                                                                                                                |
 | ----------- | ------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **233** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +189)                                                                    |
+| ✅ Ok       | **238** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +194)                                                                    |
 | ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                   |
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                        |
-| 📭 Unmapped | **396** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 400 → 396)                                                                 |
+| 📭 Unmapped | **393** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 396 → 393)                                                                 |
 | 🚫 Excluded |  **98** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 |
 
-合計 756 entries がレポート対象 (As of 2026-08-18、plan 902 PR 27 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **765 entries**。
+合計 758 entries がレポート対象 (As of 2026-08-18、plan 902 PR 28 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **767 entries**。
 
 ## test binary 別の内訳
 
@@ -69,7 +69,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **765 entries**。
 | ----------- | -----: | -------: | -------: | -------: | -------: |
 | `color`     |     56 |        4 |        0 |      108 |        4 |
 | `core`      |     13 |        0 |        0 |       34 |       12 |
-| `filter`    |      2 |        5 |        0 |       57 |       40 |
+| `filter`    |      7 |        5 |        0 |       55 |       40 |
 | `io`        |     11 |        2 |        0 |       41 |       13 |
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |     19 |        0 |        0 |       45 |        0 |

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -388,3 +388,8 @@ color	paint	19	paint_cg	2	threshold_on_8bpp 10 levels
 color	paint	20	paint_cg	3	color_gray_regions on cmapped
 color	paint	21	paint_cg	4	color_gray on 8bpp gray
 color	paint	22	paint_cg	5	color_gray on cmapped
+filter	convolve	2	convolve_blockrank	1	blockrank 4x4 rank 0.25 (test1.png)
+filter	convolve	3	convolve_blockrank	2	blockrank 4x4 rank 0.50
+filter	convolve	4	convolve_blockrank	3	blockrank 4x4 rank 0.75
+filter	adaptmap	14	adaptmap_c	1	fill_map_holes on weasel8.png (L_FILL_WHITE)
+filter	adaptmap	15	adaptmap_c	2	fill_map_holes 3x3 (L_FILL_BLACK)

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -534,8 +534,12 @@ impl MapFillType {
     }
 }
 
-/// Fill 0-valued holes in an 8 bpp tile-resolution map by C-aligned
-/// column-major replication.
+/// Fill holes in an 8 bpp tile-resolution map by C-aligned column-major
+/// replication.
+///
+/// A *hole* is a pixel whose value equals the extreme selected by
+/// `filltype` — 0 for [`MapFillType::Black`], 255 for
+/// [`MapFillType::White`] — and every other pixel counts as valid data.
 ///
 /// `nx` and `ny` are the number of fully-covered tile columns / rows; the
 /// rightmost column and bottommost row of `pix` may correspond to partial
@@ -547,7 +551,7 @@ impl MapFillType {
 ///
 /// Mirrors C `pixFillMapHoles(pix, nx, ny, filltype)` in
 /// `reference/leptonica/src/adaptmap.c`. The algorithm has three phases:
-/// 1. For each column `j in 0..nx`, find the first non-zero pixel in
+/// 1. For each column `j in 0..nx`, find the first valid (non-hole) pixel in
 ///    rows `0..ny`. Replicate that value upward, then sweep downward
 ///    through `0..h` propagating the most recent valid value into holes.
 /// 2. For columns with no valid pixel, replicate from the nearest valid
@@ -556,7 +560,7 @@ impl MapFillType {
 ///    last partial-tile column.
 ///
 /// Returns `Err(FilterError::InvalidParameters)` if no column carries any
-/// non-zero data (matches the C `nmiss == nx` warning path).
+/// valid data (matches the C `nmiss == nx` warning path).
 pub fn fill_map_holes(pix: &Pix, nx: u32, ny: u32, filltype: MapFillType) -> FilterResult<Pix> {
     if pix.depth() != PixelDepth::Bit8 {
         return Err(FilterError::UnsupportedDepth {
@@ -1042,7 +1046,7 @@ fn fill_map_holes_inner(pix: &Pix, nx: u32, ny: u32, filltype: MapFillType) -> F
     let mut nmiss: u32 = 0;
 
     // Phase 1: vertical fill within each tile column.
-    // Search for the first non-zero pixel in rows 0..ny (the data origin
+    // Search for the first non-hole pixel in rows 0..ny (the data origin
     // is bounded to the full-tile region). Then replicate that value up
     // to row 0 and propagate the most-recent valid value downward through
     // the entire column height (0..h) so partial-tile rows are filled too.

--- a/src/filter/adaptmap.rs
+++ b/src/filter/adaptmap.rs
@@ -489,7 +489,7 @@ pub fn get_foreground_gray_map(
     // Fill holes in fg by propagation
     let valid_x = (w / sx).min(pixt2.width());
     let valid_y = (h / sy).min(pixt2.height());
-    let pixt2_filled = fill_map_holes(&pixt2, valid_x, valid_y)?;
+    let pixt2_filled = fill_map_holes(&pixt2, valid_x, valid_y, MapFillType::Black)?;
 
     // Smooth with 17x17 kernel (blockconv half-width 8)
     let pixt3 = blockconv(&pixt2_filled, 8, 8)?;
@@ -514,6 +514,25 @@ pub fn get_foreground_gray_map(
 
     Ok(pixd_mut.into())
 }
+/// Which extreme value marks a hole in a background map.
+///
+/// C equivalent: `L_FILL_BLACK` / `L_FILL_WHITE` in `adaptmap.c`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MapFillType {
+    /// Holes are 0-valued pixels.
+    Black,
+    /// Holes are 255-valued pixels.
+    White,
+}
+
+impl MapFillType {
+    fn hole_value(self) -> u32 {
+        match self {
+            MapFillType::Black => 0,
+            MapFillType::White => 255,
+        }
+    }
+}
 
 /// Fill 0-valued holes in an 8 bpp tile-resolution map by C-aligned
 /// column-major replication.
@@ -522,7 +541,11 @@ pub fn get_foreground_gray_map(
 /// rightmost column and bottommost row of `pix` may correspond to partial
 /// tiles when `pix.width() > nx` or `pix.height() > ny`.
 ///
-/// Mirrors C `pixFillMapHoles(pix, nx, ny, L_FILL_BLACK)` in
+/// `filltype` selects which value marks a hole: [`MapFillType::Black`] treats
+/// 0 as a hole and [`MapFillType::White`] treats 255 as one, matching C's
+/// `valtest = (filltype == L_FILL_WHITE) ? 255 : 0`.
+///
+/// Mirrors C `pixFillMapHoles(pix, nx, ny, filltype)` in
 /// `reference/leptonica/src/adaptmap.c`. The algorithm has three phases:
 /// 1. For each column `j in 0..nx`, find the first non-zero pixel in
 ///    rows `0..ny`. Replicate that value upward, then sweep downward
@@ -534,7 +557,7 @@ pub fn get_foreground_gray_map(
 ///
 /// Returns `Err(FilterError::InvalidParameters)` if no column carries any
 /// non-zero data (matches the C `nmiss == nx` warning path).
-pub fn fill_map_holes(pix: &Pix, nx: u32, ny: u32) -> FilterResult<Pix> {
+pub fn fill_map_holes(pix: &Pix, nx: u32, ny: u32, filltype: MapFillType) -> FilterResult<Pix> {
     if pix.depth() != PixelDepth::Bit8 {
         return Err(FilterError::UnsupportedDepth {
             expected: "8 bpp",
@@ -554,7 +577,7 @@ pub fn fill_map_holes(pix: &Pix, nx: u32, ny: u32) -> FilterResult<Pix> {
              (nx={nx}, ny={ny}, w={w}, h={h})"
         )));
     }
-    fill_map_holes_inner(pix, nx, ny)
+    fill_map_holes_inner(pix, nx, ny, filltype)
 }
 
 /// Generate inverted background map for normalization.
@@ -885,7 +908,7 @@ fn get_background_gray_map_inner(
     let map_pix = map_mut.into();
 
     // Fill holes in the map (tiles with value 0)
-    fill_map_holes_inner(&map_pix, nx, ny)
+    fill_map_holes_inner(&map_pix, nx, ny, MapFillType::Black)
 }
 
 /// Generate background maps for each RGB channel from a single 32 bpp
@@ -997,15 +1020,17 @@ fn get_background_rgb_map_inner(
     let pixmg: Pix = mg_mut.into();
     let pixmb: Pix = mb_mut.into();
 
-    let pixmr = fill_map_holes_inner(&pixmr, nx, ny)?;
-    let pixmg = fill_map_holes_inner(&pixmg, nx, ny)?;
-    let pixmb = fill_map_holes_inner(&pixmb, nx, ny)?;
+    let pixmr = fill_map_holes_inner(&pixmr, nx, ny, MapFillType::Black)?;
+    let pixmg = fill_map_holes_inner(&pixmg, nx, ny, MapFillType::Black)?;
+    let pixmb = fill_map_holes_inner(&pixmb, nx, ny, MapFillType::Black)?;
 
     Ok((pixmr, pixmg, pixmb))
 }
 
 /// Fill holes (zero values) in the map by propagating from neighbors
-fn fill_map_holes_inner(pix: &Pix, nx: u32, ny: u32) -> FilterResult<Pix> {
+fn fill_map_holes_inner(pix: &Pix, nx: u32, ny: u32, filltype: MapFillType) -> FilterResult<Pix> {
+    // C: `valtest = (filltype == L_FILL_WHITE) ? 255 : 0;`
+    let valtest = filltype.hole_value();
     let w = pix.width();
     let h = pix.height();
 
@@ -1024,7 +1049,7 @@ fn fill_map_holes_inner(pix: &Pix, nx: u32, ny: u32) -> FilterResult<Pix> {
     for j in 0..nx {
         let mut first: Option<u32> = None;
         for i in 0..ny {
-            if out_mut.get_pixel_unchecked(j, i) != 0 {
+            if out_mut.get_pixel_unchecked(j, i) != valtest {
                 first = Some(i);
                 break;
             }
@@ -1043,7 +1068,7 @@ fn fill_map_holes_inner(pix: &Pix, nx: u32, ny: u32) -> FilterResult<Pix> {
                 let mut lastval = out_mut.get_pixel_unchecked(j, 0);
                 for i in 1..h {
                     let v = out_mut.get_pixel_unchecked(j, i);
-                    if v == 0 {
+                    if v == valtest {
                         out_mut.set_pixel_unchecked(j, i, lastval);
                     } else {
                         lastval = v;
@@ -1385,8 +1410,8 @@ fn min_max_tiles(
     let (pix_min, pix_max) = set_low_contrast(pix_min, pix_max, min_diff)?;
 
     // Step 5: fill the holes.
-    let pix_min = fill_map_holes_inner(&pix_min, map_w, map_h)?;
-    let pix_max = fill_map_holes_inner(&pix_max, map_w, map_h)?;
+    let pix_min = fill_map_holes_inner(&pix_min, map_w, map_h, MapFillType::Black)?;
+    let pix_max = fill_map_holes_inner(&pix_max, map_w, map_h, MapFillType::Black)?;
 
     // Step 6: smooth (matches C `pixBlockconv`). C clamps smooth half-widths
     // to (map_w-1)/2 and (map_h-1)/2 to keep the kernel inside the map.
@@ -1742,7 +1767,7 @@ pub fn get_background_gray_map_morph(
     // Fill holes in the map
     let nx = pix.width() / reduction;
     let ny = pix.height() / reduction;
-    let filled = fill_map_holes_inner(&pix3, nx, ny)?;
+    let filled = fill_map_holes_inner(&pix3, nx, ny, MapFillType::Black)?;
 
     Ok(filled)
 }
@@ -1808,7 +1833,7 @@ fn get_background_single_channel_morph(
     let pix1 = scale_rgb_to_gray_fast(pix, reduction, shift)?;
     let pix2 = crate::morph::close_gray(&pix1, size, size)?;
     let pix3 = extend_by_replication(&pix2, 1, 1)?;
-    fill_map_holes_inner(&pix3, nx, ny)
+    fill_map_holes_inner(&pix3, nx, ny, MapFillType::Black)
 }
 
 /// Fast downscaling of a single RGB channel to 8bpp grayscale.
@@ -2682,7 +2707,7 @@ mod tests {
 
         let pix = pix_mut.into();
 
-        let filled = fill_map_holes_inner(&pix, 5, 5).unwrap();
+        let filled = fill_map_holes_inner(&pix, 5, 5, MapFillType::Black).unwrap();
 
         // Check that holes are filled
         for y in 0..5 {

--- a/src/filter/block_conv.rs
+++ b/src/filter/block_conv.rs
@@ -23,10 +23,12 @@ fn check_8bpp(pix: &Pix) -> FilterResult<()> {
     Ok(())
 }
 
-/// Build an integral image (summed area table) from an 8 bpp grayscale image.
+/// Build an integral image (summed area table) from a 1 or 8 bpp image.
 ///
 /// Each pixel in the output 32 bpp image contains the sum of all source
-/// pixel values in the rectangle from (0,0) to (x,y) inclusive.
+/// pixel values in the rectangle from (0,0) to (x,y) inclusive. A 1 bpp
+/// source contributes its **bit** (0 or 1) per pixel, as in C, so the
+/// accumulator holds ON-pixel counts rather than 0/255 sums.
 ///
 /// The recursion is: `a(i,j) = v(i,j) + a(i-1,j) + a(i,j-1) - a(i-1,j-1)`
 ///
@@ -34,7 +36,9 @@ fn check_8bpp(pix: &Pix) -> FilterResult<()> {
 ///
 /// C Leptonica: `pixBlockconvAccum()` in `convolve.c`
 pub fn blockconv_accum(pix: &Pix) -> FilterResult<Pix> {
-    check_8bpp(pix)?;
+    if pix.depth() != PixelDepth::Bit1 {
+        check_8bpp(pix)?;
+    }
 
     let w = pix.width();
     let h = pix.height();

--- a/src/filter/convolve.rs
+++ b/src/filter/convolve.rs
@@ -422,26 +422,25 @@ pub fn add_gaussian_noise(pix: &Pix, stdev: f32) -> FilterResult<Pix> {
 
     Ok(pixd_mut.into())
 }
-
-/// Block sum for binary images
+/// Block sum of a 1 bpp image, normalized to 8 bpp.
 ///
-/// Computes the sum of ON pixels in (2*wc+1) × (2*hc+1) blocks centered at
-/// each pixel of a 1-bit binary image. The output is an 8-bit image where
-/// each pixel value is normalized to 0-255 range based on block size.
+/// Each output pixel is `255 * (ON pixels in the (2*wc+1) x (2*hc+1) block)
+/// / (block area)`.
 ///
-/// # Arguments
+/// C computes this in two passes and both are reproduced here, because the
+/// intermediate truncation is visible in the output:
 ///
-/// * `pix` - Input 1-bit binary image
-/// * `wc` - Half-width of block
-/// * `hc` - Half-height of block
+/// 1. every pixel is normalized by the **full** block area, with the
+///    accumulator differences taken at C's clamped indices, and the f32
+///    product truncated to a byte;
+/// 2. the border rows and columns are then rescaled by `fhc / hn` and
+///    `fwc / wn` **on the already-truncated byte**, and truncated again.
 ///
-/// # Returns
-///
-/// 8-bit image with normalized block sums
+/// Rounding the ideal value once instead would differ by 1 on many pixels.
 ///
 /// # See also
 ///
-/// C Leptonica: `pixBlocksum()` in `convolve.c`
+/// C Leptonica: `pixBlocksum()` and `blocksumLow()` in `convolve.c`
 pub fn blocksum(pix: &Pix, wc: u32, hc: u32) -> FilterResult<Pix> {
     if pix.depth() != PixelDepth::Bit1 {
         return Err(FilterError::UnsupportedDepth {
@@ -457,69 +456,92 @@ pub fn blocksum(pix: &Pix, wc: u32, hc: u32) -> FilterResult<Pix> {
         return Ok(pix.deep_clone());
     }
 
-    // Reduce kernel if necessary
-    let wc = wc.min((w - 1) / 2);
-    let hc = hc.min((h - 1) / 2);
-
+    // C: reduce the kernel when it does not fit.
+    let (wc, hc) = if w < 2 * wc + 1 || h < 2 * hc + 1 {
+        (wc.min((w - 1) / 2), hc.min((h - 1) / 2))
+    } else {
+        (wc, hc)
+    };
     if wc == 0 || hc == 0 {
-        // Return 8bpp version even for degenerate kernel (documented output is 8bpp)
         return Ok(pix.convert_1_to_8(0, 255)?);
     }
+    if w <= wc || h <= hc {
+        return Err(FilterError::InvalidParameters("wc >= w || hc >= h".into()));
+    }
 
-    // Convert 1bpp to 8bpp (0→0, 1→255) for integral image computation
-    let pix8 = pix.convert_1_to_8(0, 255)?;
+    // C: pixBlockconvAccum on the 1 bpp source, i.e. ON-pixel counts.
+    let acc = crate::filter::block_conv::blockconv_accum(pix)?;
 
-    // Compute integral image using blockconv_accum
-    let acc = crate::filter::block_conv::blockconv_accum(&pix8)?;
+    let fwc = 2 * wc + 1;
+    let fhc = 2 * hc + 1;
+    // C: norm = 255. / ((l_float32)fwc * fhc), stored in an l_float32.
+    let norm = (255.0f64 / ((fwc as f32 * fhc as f32) as f64)) as f32;
 
-    // Compute block sums using integral image
-    let pixd = Pix::new(w, h, PixelDepth::Bit8)?;
-    let mut pixd_mut = pixd.try_into_mut().unwrap();
+    let out = Pix::new(w, h, PixelDepth::Bit8)?;
+    let mut om = out.try_into_mut().unwrap();
 
-    let fwc = (2 * wc + 1) as f64;
-    let fhc = (2 * hc + 1) as f64;
-    let norm = 1.0 / (fwc * fhc);
-
+    // Pass 1: full-kernel normalization at C's clamped accumulator indices.
     for y in 0..h {
-        let ymin = if y > hc { y - hc - 1 } else { 0 };
-        let ymax = (y + hc).min(h - 1);
-        let hn = if y > hc {
-            (ymax - ymin) as f64
-        } else {
-            (ymax + 1) as f64
-        };
-
+        let imin = y.saturating_sub(hc + 1);
+        let imax = (y + hc).min(h - 1);
         for x in 0..w {
-            let xmin = if x > wc { x - wc - 1 } else { 0 };
-            let xmax = (x + wc).min(w - 1);
-            let wn = if x > wc {
-                (xmax - xmin) as f64
-            } else {
-                (xmax + 1) as f64
-            };
-
-            // Four-corner lookup on integral image
-            let mut val = acc.get_pixel_unchecked(xmax, ymax) as i64;
-            if y > hc {
-                val -= acc.get_pixel_unchecked(xmax, ymin) as i64;
-            }
-            if x > wc {
-                val -= acc.get_pixel_unchecked(xmin, ymax) as i64;
-            }
-            if y > hc && x > wc {
-                val += acc.get_pixel_unchecked(xmin, ymin) as i64;
-            }
-
-            // Normalize: output = val / (actual_area) = val * norm * fwc/wn * fhc/hn
-            // Since input was scaled 0→0, 1→255, the sum is already in terms of 255*count
-            // We need to normalize by the actual area, not the full kernel area
-            let result = (norm * val as f64 * fwc / wn * fhc / hn + 0.5) as u32;
-            let result = result.min(255);
-            pixd_mut.set_pixel_unchecked(x, y, result);
+            let jmin = x.saturating_sub(wc + 1);
+            let jmax = (x + wc).min(w - 1);
+            // C computes this in l_uint32, so the intermediate wraps exactly
+            // as the C expression does.
+            let val = acc
+                .get_pixel_unchecked(jmax, imax)
+                .wrapping_sub(acc.get_pixel_unchecked(jmin, imax))
+                .wrapping_sub(acc.get_pixel_unchecked(jmax, imin))
+                .wrapping_add(acc.get_pixel_unchecked(jmin, imin));
+            om.set_pixel_unchecked(x, y, ((norm * val as f32) as u32) & 0xff);
         }
     }
 
-    Ok(pixd_mut.into())
+    // Pass 2: rescale the borders, byte in / byte out, as C does.
+    let wmwc = w - wc;
+    let hmhc = h - hc;
+    let rescale = |om: &mut crate::core::PixMut, x: u32, y: u32, f: f32| {
+        let val = om.get_pixel_unchecked(x, y) as f32;
+        om.set_pixel_unchecked(x, y, ((val * f) as u32) & 0xff);
+    };
+
+    let fix_row = |om: &mut crate::core::PixMut, y: u32, normh: f32| {
+        for x in 0..=wc {
+            let wn = wc + x;
+            let normw = fwc as f32 / wn as f32;
+            rescale(om, x, y, normh * normw);
+        }
+        for x in (wc + 1)..wmwc {
+            rescale(om, x, y, normh);
+        }
+        for x in wmwc..w {
+            let wn = wc + w - x;
+            let normw = fwc as f32 / wn as f32;
+            rescale(om, x, y, normh * normw);
+        }
+    };
+
+    for y in 0..=hc {
+        let hn = hc + y;
+        fix_row(&mut om, y, fhc as f32 / hn as f32);
+    }
+    for y in hmhc..h {
+        let hn = hc + h - y;
+        fix_row(&mut om, y, fhc as f32 / hn as f32);
+    }
+    for y in (hc + 1)..hmhc {
+        for x in 0..=wc {
+            let wn = wc + x;
+            rescale(&mut om, x, y, fwc as f32 / wn as f32);
+        }
+        for x in wmwc..w {
+            let wn = wc + w - x;
+            rescale(&mut om, x, y, fwc as f32 / wn as f32);
+        }
+    }
+
+    Ok(om.into())
 }
 
 /// Block rank for binary images
@@ -1259,7 +1281,6 @@ mod tests {
     /// borders in a second pass that works on the already-truncated byte, so
     /// the corners and edges lose up to 3 counts. These are the values C
     /// produces for a 10x10 all-ON image with wc = hc = 1.
-    #[ignore = "not yet implemented"]
     fn test_blocksum_all_one() {
         let pix = Pix::new(10, 10, PixelDepth::Bit1).unwrap();
         let mut pix_mut = pix.try_into_mut().unwrap();

--- a/src/filter/convolve.rs
+++ b/src/filter/convolve.rs
@@ -438,6 +438,10 @@ pub fn add_gaussian_noise(pix: &Pix, stdev: f32) -> FilterResult<Pix> {
 ///
 /// Rounding the ideal value once instead would differ by 1 on many pixels.
 ///
+/// A degenerate kernel (`wc == 0 || hc == 0`, either as given or after the
+/// reduction below) makes this a no-op: C returns `pixCopy(NULL, pixs)`, so
+/// the result is the **1 bpp input unchanged** rather than an 8 bpp image.
+///
 /// # See also
 ///
 /// C Leptonica: `pixBlocksum()` and `blocksumLow()` in `convolve.c`
@@ -463,7 +467,7 @@ pub fn blocksum(pix: &Pix, wc: u32, hc: u32) -> FilterResult<Pix> {
         (wc, hc)
     };
     if wc == 0 || hc == 0 {
-        return Ok(pix.convert_1_to_8(0, 255)?);
+        return Ok(pix.deep_clone());
     }
     if w <= wc || h <= hc {
         return Err(FilterError::InvalidParameters("wc >= w || hc >= h".into()));

--- a/src/filter/convolve.rs
+++ b/src/filter/convolve.rs
@@ -1255,8 +1255,12 @@ mod tests {
     }
 
     #[test]
+    /// An all-ON image does **not** come out uniformly 255: C normalizes the
+    /// borders in a second pass that works on the already-truncated byte, so
+    /// the corners and edges lose up to 3 counts. These are the values C
+    /// produces for a 10x10 all-ON image with wc = hc = 1.
+    #[ignore = "not yet implemented"]
     fn test_blocksum_all_one() {
-        // All-one image should produce all-255 output
         let pix = Pix::new(10, 10, PixelDepth::Bit1).unwrap();
         let mut pix_mut = pix.try_into_mut().unwrap();
 
@@ -1270,9 +1274,26 @@ mod tests {
         let result = blocksum(&pix, 1, 1).unwrap();
 
         assert_eq!(result.depth(), PixelDepth::Bit8);
-        for y in 0..10 {
-            for x in 0..10 {
-                assert_eq!(result.get_pixel_unchecked(x, y), 255);
+        #[rustfmt::skip]
+        let expected: [[u32; 10]; 10] = [
+            [252, 252, 255, 255, 255, 255, 255, 255, 255, 252],
+            [252, 254, 255, 255, 255, 255, 255, 255, 255, 254],
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+            [252, 254, 255, 255, 255, 255, 255, 255, 255, 254],
+        ];
+        for y in 0..10u32 {
+            for x in 0..10u32 {
+                assert_eq!(
+                    result.get_pixel_unchecked(x, y),
+                    expected[y as usize][x as usize],
+                    "at ({x}, {y})"
+                );
             }
         }
     }

--- a/src/filter/enhance.rs
+++ b/src/filter/enhance.rs
@@ -55,7 +55,12 @@ pub fn gamma_trc(gamma: f32, minval: i32, maxval: i32) -> FilterResult<TrcLut> {
             255
         } else {
             let x = (i - minval) as f32 / range;
-            let mapped = 255.0 * x.powf(inv_gamma) + 0.5;
+            // C: `val = (l_int32)(255. * powf(x, invgamma) + 0.5)`. The
+            // `255.` literal is a double, so the product and the rounding
+            // are evaluated in double precision even though `x` and `powf`
+            // are single. Doing it all in f32 shifts values that land near
+            // a .5 boundary by one (e.g. 153 with maxval 270: 144 vs 145).
+            let mapped = 255.0f64 * x.powf(inv_gamma) as f64 + 0.5;
             (mapped as i32).clamp(0, 255)
         };
         lut[i as usize] = val as u8;

--- a/tests/filter/adaptmap_bg_reg.rs
+++ b/tests/filter/adaptmap_bg_reg.rs
@@ -160,7 +160,9 @@ fn test_fill_map_holes_public() {
     pm.set_pixel_unchecked(4, 4, 180);
     let pix: Pix = pm.into();
 
-    let filled = adaptmap::fill_map_holes(&pix, 5, 5).unwrap();
+    let filled =
+        adaptmap::fill_map_holes(&pix, 5, 5, leptonica::filter::adaptmap::MapFillType::Black)
+            .unwrap();
 
     // All holes should be filled
     for y in 0..5 {

--- a/tests/filter/adaptmap_c_parity.rs
+++ b/tests/filter/adaptmap_c_parity.rs
@@ -33,7 +33,8 @@ fn c_parity_simple_3x3() {
     input.set_pixel(1, 0, 128).expect("set pixel");
     let pix: Pix = input.into();
 
-    let filled = fill_map_holes(&pix, 3, 3).expect("fill_map_holes 3x3");
+    let filled = fill_map_holes(&pix, 3, 3, leptonica::filter::adaptmap::MapFillType::Black)
+        .expect("fill_map_holes 3x3");
 
     let mut grid = [[0u32; 3]; 3];
     for y in 0..3 {
@@ -90,7 +91,13 @@ fn c_parity_weasel() {
         }
     }
     let pix_with_holes: Pix = m.into();
-    let filled = fill_map_holes(&pix_with_holes, w, h).expect("fill weasel");
+    let filled = fill_map_holes(
+        &pix_with_holes,
+        w,
+        h,
+        leptonica::filter::adaptmap::MapFillType::Black,
+    )
+    .expect("fill weasel");
     assert_eq!(
         pixel_content_hash(&filled),
         EXPECTED_C_WEASEL_HASH,

--- a/tests/filter/adaptmap_reg.rs
+++ b/tests/filter/adaptmap_reg.rs
@@ -712,7 +712,6 @@ fn sample_min_max(pix: &leptonica::Pix) -> (u32, u32) {
 /// lossless `weasel8.png` and a synthetic 3x3 map, so they are bit-exactly
 /// comparable against C.
 #[test]
-#[ignore = "not yet implemented"]
 fn adaptmap_c_compat_fill_map_holes() {
     use leptonica::PixelDepth;
     use leptonica::core::Pixa;

--- a/tests/filter/adaptmap_reg.rs
+++ b/tests/filter/adaptmap_reg.rs
@@ -291,7 +291,13 @@ fn adaptmap_reg_fill_map_holes_weasel() {
     let pix_with_holes: leptonica::Pix = pix_holes.into();
 
     // Apply fill_map_holes: Rust fills 0-valued holes by propagating non-zero neighbors.
-    let filled = fill_map_holes(&pix_with_holes, w, h).expect("fill_map_holes weasel");
+    let filled = fill_map_holes(
+        &pix_with_holes,
+        w,
+        h,
+        leptonica::filter::adaptmap::MapFillType::Black,
+    )
+    .expect("fill_map_holes weasel");
     rp.compare_values(w as f64, filled.width() as f64, 0.0);
     rp.compare_values(h as f64, filled.height() as f64, 0.0);
     rp.compare_values(8.0, filled.depth().bits() as f64, 0.0);
@@ -326,7 +332,13 @@ fn adaptmap_reg_fill_map_holes_simple() {
     let pix_sparse: leptonica::Pix = pix3.into();
 
     // Apply fill_map_holes: should propagate the value at (1,0) to neighbors
-    let filled = fill_map_holes(&pix_sparse, 3, 3).expect("fill_map_holes 3x3");
+    let filled = fill_map_holes(
+        &pix_sparse,
+        3,
+        3,
+        leptonica::filter::adaptmap::MapFillType::Black,
+    )
+    .expect("fill_map_holes 3x3");
     rp.compare_values(3.0, filled.width() as f64, 0.0);
     rp.compare_values(3.0, filled.height() as f64, 0.0);
     rp.compare_values(8.0, filled.depth().bits() as f64, 0.0);
@@ -691,4 +703,78 @@ fn sample_min_max(pix: &leptonica::Pix) -> (u32, u32) {
     }
 
     (min_val, max_val)
+}
+
+/// C-compat: `prog/adaptmap_reg.c` checks 14-15.
+///
+/// The `pixFillMapHoles` demonstrations. Unlike the background-normalization
+/// checks earlier in that program (which read `wet-day.jpg`), these use the
+/// lossless `weasel8.png` and a synthetic 3x3 map, so they are bit-exactly
+/// comparable against C.
+#[test]
+#[ignore = "not yet implemented"]
+fn adaptmap_c_compat_fill_map_holes() {
+    use leptonica::PixelDepth;
+    use leptonica::core::Pixa;
+    use leptonica::core::pix::RopOp;
+    use leptonica::filter::adaptmap::{MapFillType, fill_map_holes};
+    use leptonica::filter::gamma_trc_pix;
+    use leptonica::io::ImageFormat;
+    use leptonica::transform::expand_replicate;
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("adaptmap_c");
+
+    // C 14: weasel8.png as a map, darkened, with white stripes punched in as
+    // holes, then filled with L_FILL_WHITE.
+    let mut pixa = Pixa::new();
+    let pix1 = load_test_image("weasel8.png").expect("load weasel8.png");
+    let pix1 = gamma_trc_pix(&pix1, 1.0, 0, 270).expect("gamma trc");
+    pixa.push(pix1.clone());
+
+    let (w, h) = (pix1.width(), pix1.height());
+    let mut pm = pix1.to_mut();
+    // C: pixRasterop(pix1, x, y, bw, bh, PIX_SET, NULL, 0, 0) — white holes.
+    for &(x, y, bw, bh) in &[
+        (0, 0, 5, h),
+        (20, 0, 2, h),
+        (40, 0, 3, h),
+        (0, 0, w, 3),
+        (0, 15, w, 3),
+        (0, 35, w, 2),
+    ] {
+        pm.rop_region_inplace(x, y, bw, bh, RopOp::Set, &pix1, 0, 0)
+            .expect("punch hole");
+    }
+    let holed: leptonica::Pix = pm.into();
+    pixa.push(holed.clone());
+
+    let filled = fill_map_holes(&holed, w, h, MapFillType::White).expect("fill map holes white");
+    pixa.push(filled);
+    let tiled = pixa
+        .display_tiled_in_columns(3, 1.0, 20, 1)
+        .expect("tile weasel maps");
+    rp.write_pix_and_check(&tiled, ImageFormat::Png)
+        .expect("check: fill_map_holes on weasel8");
+
+    // C 15: a 3x3 map with a single non-zero pixel, filled with L_FILL_BLACK.
+    let mut pixa = Pixa::new();
+    let small = leptonica::Pix::new(3, 3, PixelDepth::Bit8).expect("3x3 map");
+    let mut sm = small.try_into_mut().unwrap();
+    sm.set_pixel_unchecked(1, 0, 128);
+    let small: leptonica::Pix = sm.into();
+    pixa.push(expand_replicate(&small, 25).expect("expand before"));
+    let small_filled =
+        fill_map_holes(&small, 3, 3, MapFillType::Black).expect("fill map holes black");
+    pixa.push(expand_replicate(&small_filled, 25).expect("expand after"));
+    let tiled = pixa
+        .display_tiled_in_columns(2, 1.0, 20, 0)
+        .expect("tile small maps");
+    rp.write_pix_and_check(&tiled, ImageFormat::Png)
+        .expect("check: fill_map_holes 3x3");
+
+    assert!(rp.cleanup(), "adaptmap C-compat fill_map_holes test failed");
 }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -7,7 +7,9 @@ adaptmap_bg_gray.04.png	d2b87b21855eca7a
 adaptmap_bg_gray.07.png	d9d4519c14d60d6f
 adaptmap_bg_gray.10.png	381701b66c0701a9
 adaptmap_bg_highlevel.04.jpg	e92ded554268fc68
-adaptmap_bg_highlevel.07.jpg	c87ff5e3b8003874
+adaptmap_bg_highlevel.07.jpg	60447324b0a7bdfe
+adaptmap_c.01.png	b37736e4dfd0b075
+adaptmap_c.02.png	8e7f94c187e3fc3c
 adaptmap_color_pipeline.04.png	282968097de6e6a1
 adaptmap_color_pipeline.05.png	a13c9e129b3ee5cb
 adaptmap_color_pipeline.06.png	ecb533cfece32862
@@ -15,7 +17,7 @@ adaptmap_color_pipeline.07.png	cee6ccd6c2ef2f05
 adaptmap_color_pipeline.08.png	2b86c84d447ecc84
 adaptmap_color_pipeline.09.png	71bc6aee3b8dbe02
 adaptmap_color_pipeline.13.jpg	ba42ce6877a88d19
-adaptmap_color_pipeline.17.jpg	65eb47ae1aae298a
+adaptmap_color_pipeline.17.jpg	cb20306aa3bbe242
 adaptmap_contrast.04.png	4992e5c92e6cfa52
 adaptmap_contrast.07.png	4a3a5bde66f5626c
 adaptmap_contrast.10.png	bd849974cba5cc28
@@ -26,7 +28,7 @@ adaptmap_gamma_trc_masked.04.png	fe88fb0ac4cf1360
 adaptmap_gray_pipeline.02.png	c8f358ec89a76db9
 adaptmap_gray_pipeline.05.png	901f54a7ba5fa4ec
 adaptmap_gray_pipeline.09.jpg	fa5e9bbe629a9436
-adaptmap_gray_pipeline.13.jpg	0e459aff6600b353
+adaptmap_gray_pipeline.13.jpg	839b4b0a47701b90
 adaptmap_params.04.png	d2b87b21855eca7a
 adaptnorm_bg.01.jpg	c17c2c7dcfdc5ce8
 adaptnorm_bg.04.jpg	e516012621acfdfc
@@ -241,10 +243,10 @@ conversion_from_8bpp.05.png	8ef9102efc7e88f0
 convolve_blockconv_32bpp.01.jpg	d88bf13111d25d4e
 convolve_blockconv_8bpp.01.jpg	109a1bd29a030a27
 convolve_blockconv_gray.01.jpg	152b8dec435a055f
-convolve_blockrank.01.png	08ef2579e30ff5c9
-convolve_blockrank.02.png	3469074cab457119
-convolve_blockrank.03.png	72f59473ecadbf58
-convolve_blocksum.01.jpg	a972fca15e16cb52
+convolve_blockrank.01.png	b173d5f15da336d8
+convolve_blockrank.02.png	495529d3716bc9b9
+convolve_blockrank.03.png	656b11b3e8c178f9
+convolve_blocksum.01.jpg	a1d7f33f95291995
 convolve_census_transform.01.png	f08b3676c6e0f074
 convolve_custom_kernel.01.jpg	87ac73ab98d09b94
 convolve_custom_kernel.02.jpg	41b867cb94d5f064
@@ -642,7 +644,7 @@ rankhisto_color.03.png	1742fb16ecbdc787
 rankhisto_color.05.png	0d637539b0a1c0d3
 rankhisto_color.07.png	ae37cde14024f812
 rankhisto_gamma.01.png	0fb3e479b69c95e9
-rankhisto_gamma.04.png	fb7fcbedb9605ae0
+rankhisto_gamma.04.png	26d19b946f72da34
 rankhisto_gamma.06.png	1da0405aa04bdda5
 rotate1.03.tif	0d56437220b15f6e
 rotate1.08.tif	b62634d02b31de1e


### PR DESCRIPTION
## Why

plan 902 の Unmapped 削減。`filter` は **Ok 2 件**と最も未開拓な
バイナリだった。lossless 入力を持つブロックを探し、`convolve_reg` の
check 2-4 (`test1.png` の `pixBlockrank`) と `adaptmap_reg` の
check 14-15 (`weasel8.png` と 3x3 合成マップの `pixFillMapHoles`) を
対象にした。

## What

- **実装差異 #44**: `blocksum` の正規化が 1 パスの f64 丸めだった。
  C `blocksumLow` は

  1. 全カーネル面積の `norm = 255/(fwc*fhc)` で正規化し、f32 の積を
     byte に**切り捨てる**
  2. 境界の行・列を、**切り捨て済みの byte** に対して `fhc/hn`・
     `fwc/wn` で再スケールし、また切り捨てる

  という 2 パス構成。理想値を 1 回丸めるのとは多くの画素で 1 ずれ、
  全 ON 画像でも角が 252 になる。accumulator も C 同様 1bpp を
  「ON 画素数」で積算するよう `blockconv_accum` を 1bpp 対応にした
- **実装差異 #45**: `fill_map_holes` が `filltype` を取らず
  `L_FILL_BLACK` 固定だった。C は
  `valtest = (filltype == L_FILL_WHITE) ? 255 : 0` で穴の値を切り替える。
  `MapFillType` を導入
- **実装差異 #46**: `gamma_trc` の LUT が
  `255. * powf(x, invgamma) + 0.5` を f32 で評価していた。C の `255.` は
  double リテラルのため倍精度評価になり、.5 境界に乗る値が 1 ずれる
  (maxval 270 で入力 153 が C 144 に対し 145)
- `adaptmap_c_compat_fill_map_holes` を追加し、convolve check 2-4 と
  adaptmap check 14-15 を **5 ペアマップ — 全件 Ok**

## Impact

- C 互換ベースライン: **Ok 233 → 238**、**Unmapped 396 → 393**。
  Mismatch 29 / Excluded 98 は不変。`filter` binary の Ok が **2 → 7**
- blocksum / gamma_trc の修正で adaptmap 系・rankhisto・convolve_blocksum
  の golden を再生成。いずれも Unmapped で **C 側 Ok の退行はなし**
- API 変更 (破壊的): `fill_map_holes` が `MapFillType` を取る
- 全 ON 画像で角が 252 になるのは C の実挙動。旧ユニットテストは理想値
  (一様 255) を期待していたため、C の実値に更新した

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg