### PR TITLE
plan 902 PR 36: rotate2 を整列 — 8 ペア全件 Ok (実装変更なし)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-19 実測、plan 902 PR 35 後):
+- 現状ベースライン (As of 2026-08-19 実測、plan 902 PR 36 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 363 / Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100**
+  **Ok 371 / Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -972,7 +972,30 @@ pixRotateBySampling)、`src/rotateam.c` (pixRotateAMCorner)、
 cmapped 画像の背景色 (index か生値か) は横断的に効く論点で、他の
 fill 系関数にも同じ確認が要る。
 
-### PR 36 以降: semantic マッピングの漸進追加
+### PR 36: rotate2 の全 PNG 出力 (実施済み)
+
+C 版ソース: `prog/rotate2_reg.c`。
+
+PR 35 で整列した rotate1 と同系統。PNG 出力 8 件は同じ 4 枚の可逆入力から
+作られ、1 枚あたり 2 出力 (shear の 8 変種 = 2 角度 x 2 fill x 埋め込み
+有無、および sampling 4 変種 + area map 4 変種) を並べたもの。
+
+実施結果:
+
+- **実装変更なしで 8 ペア全件 Ok** (Ok 363 → 371、transform binary の
+  Ok が 114 → 122)。PR 35 の `pixRotate` パイプライン化がそのまま効いた
+- 1bpp では area map ブロックの前に `pixScaleToGray2` を挟む点、
+  `L_BRING_IN_BLACK` と埋め込み無し (C の `0, 0`) の組み合わせも
+  テストで再現した
+- `rotateorth_reg` は `regTestComparePix` のみでファイル出力が無いため
+  マップ対象が存在しない (C manifest のエントリも 0)
+
+**次段送り**: `warper_reg` の 8 件 (feyn-word.tif、可逆) は C が
+`srand(seed)` + glibc `rand()` で歪みパラメータを作る。PR 31 の
+`GlibcRand` と同じ手が使えるが、ライブラリ側の乱数生成そのものを
+glibc 互換にする必要があるため別 PR とする。
+
+### PR 37 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。
 優先順位はバイナリ別の未開拓度で決める:

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,14 +54,14 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        |    件数 | 説明                                                                                                                                                                          |
 | ----------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **363** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +319)                                                                                              |
+| ✅ Ok       | **371** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +327)                                                                                              |
 | ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                                             |
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                                                  |
 | 📭 Unmapped | **389** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 393 → 389)                                                                                           |
 | 🚫 Excluded | **100** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 + newspaper random cmap 2 |
 
-合計 881 entries がレポート対象 (As of 2026-08-19、plan 902 PR 35 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **888 entries**。
+合計 889 entries がレポート対象 (As of 2026-08-19、plan 902 PR 36 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **896 entries**。
 
 ## test binary 別の内訳
 
@@ -74,7 +74,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **888 entries**。
 | `morph`     | **30** |   **16** |        0 |        9 |        0 |
 | `recog`     |     49 |        0 |        0 |       41 |        2 |
 | `region`    | **73** |        2 |        0 |       28 |       29 |
-| `transform` |    114 |        0 |        0 |       74 |        0 |
+| `transform` |    122 |        0 |        0 |       74 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -518,3 +518,11 @@ transform	rotate1	28	rotate1_c	29	weasel4.16g areamap x11
 transform	rotate1	29	rotate1_c	30	weasel4.16g areamap x22
 transform	rotate1	30	rotate1_c	31	weasel4.16g amcorner x11
 transform	rotate1	31	rotate1_c	32	weasel4.16g amcorner x22
+transform	rotate2	0	rotate2_c	1	test1 shear variants
+transform	rotate2	1	rotate2_c	2	test1 sampling + area map variants
+transform	rotate2	2	rotate2_c	3	weasel2.4c shear variants
+transform	rotate2	3	rotate2_c	4	weasel2.4c sampling + area map variants
+transform	rotate2	4	rotate2_c	5	weasel4.11c shear variants
+transform	rotate2	5	rotate2_c	6	weasel4.11c sampling + area map variants
+transform	rotate2	6	rotate2_c	7	weasel4.16g shear variants
+transform	rotate2	7	rotate2_c	8	weasel4.16g sampling + area map variants

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -770,6 +770,14 @@ rotate1_shear.03.tif	e7cb905208d45338
 rotate2.02.png	31264a34c140339f
 rotate2.06.png	3324a6ebf4973257
 rotate2.15.png	ebc5fc04b5dabc36
+rotate2_c.01.png	4acc73173b390c75
+rotate2_c.02.png	71d613e603849cd8
+rotate2_c.03.png	fe387b76f549fd79
+rotate2_c.04.png	3c2b20583733f717
+rotate2_c.05.png	ccd3d5b264c23acd
+rotate2_c.06.png	ec11674693cb768c
+rotate2_c.07.png	20b97959cc865339
+rotate2_c.08.png	a4cda5f38a30779a
 rotateorth.04.tif	0d56437220b15f6e
 rotateorth.16.png	4e0162ba6433c1f6
 rotateorth.28.png	bcc1922c2afc4e9a

--- a/tests/transform/rotate2_reg.rs
+++ b/tests/transform/rotate2_reg.rs
@@ -152,7 +152,7 @@ fn rotate2_c_compat() {
         let fit = RotateEmbed::Explicit(w, h);
         let none = RotateEmbed::None;
 
-        // C write 1: eight shear rotations, two angles x two fills x embed/no.
+        // C write #1: eight shear rotations, two angles x two fills x embed/no.
         let mut pixa = Pixa::new();
         for angle in [ANGLE1, ANGLE2] {
             for embed in [fit, none] {
@@ -170,7 +170,7 @@ fn rotate2_c_compat() {
         rp.write_pix_and_check(&tiled, ImageFormat::Png)
             .expect("check: shear variants");
 
-        // C write 2: four sampling rotations then four area-map ones. For a
+        // C write #2: four sampling rotations then four area-map ones. For a
         // 1 bpp source the area-map block runs on pixScaleToGray2 output.
         let mut pixa = Pixa::new();
         for embed in [fit, none] {

--- a/tests/transform/rotate2_reg.rs
+++ b/tests/transform/rotate2_reg.rs
@@ -105,3 +105,101 @@ fn rotate2_reg() {
 
     assert!(rp.cleanup(), "rotate2 regression test failed");
 }
+
+/// C-compat: `prog/rotate2_reg.c`, every PNG output.
+///
+/// `RotateTest` writes PNG only when the depth is neither 8 nor 32 bpp, so
+/// the four lossless 1/2/4 bpp inputs account for all 8 PNG outputs.
+#[test]
+fn rotate2_c_compat() {
+    use leptonica::Pix;
+    use leptonica::core::Pixa;
+    use leptonica::io::ImageFormat;
+    use leptonica::transform::{
+        RotateEmbed, RotateFill, RotateMethod, RotateOptions, rotate, scale_to_gray_2,
+    };
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    // C uses the literal 3.14159265, not M_PI.
+    #[allow(clippy::approx_constant)]
+    const ANGLE1: f32 = (3.141_592_65 / 30.0) as f32;
+    #[allow(clippy::approx_constant)]
+    const ANGLE2: f32 = (3.141_592_65 / 7.0) as f32;
+    const IMAGES: [&str; 4] = [
+        "test1.png",
+        "weasel2.4c.png",
+        "weasel4.11c.png",
+        "weasel4.16g.png",
+    ];
+
+    let mut rp = RegParams::new("rotate2_c");
+
+    for name in IMAGES {
+        let pixs = crate::common::load_test_image(name).expect("load rotate input");
+        let (w, h) = (pixs.width(), pixs.height());
+
+        let opts = |method: RotateMethod, fill: RotateFill, embed: RotateEmbed| RotateOptions {
+            method,
+            fill,
+            center_x: None,
+            center_y: None,
+            embed,
+        };
+        // C passes either (w, h) — embed — or (0, 0) — no embedding.
+        let fit = RotateEmbed::Explicit(w, h);
+        let none = RotateEmbed::None;
+
+        // C write 1: eight shear rotations, two angles x two fills x embed/no.
+        let mut pixa = Pixa::new();
+        for angle in [ANGLE1, ANGLE2] {
+            for embed in [fit, none] {
+                for fill in [RotateFill::White, RotateFill::Black] {
+                    pixa.push(
+                        rotate(&pixs, angle, &opts(RotateMethod::Shear, fill, embed))
+                            .expect("shear rotate"),
+                    );
+                }
+            }
+        }
+        let tiled = pixa
+            .display_tiled_in_columns(2, 1.0, 20, 0)
+            .expect("tile shear");
+        rp.write_pix_and_check(&tiled, ImageFormat::Png)
+            .expect("check: shear variants");
+
+        // C write 2: four sampling rotations then four area-map ones. For a
+        // 1 bpp source the area-map block runs on pixScaleToGray2 output.
+        let mut pixa = Pixa::new();
+        for embed in [fit, none] {
+            for fill in [RotateFill::White, RotateFill::Black] {
+                pixa.push(
+                    rotate(&pixs, ANGLE2, &opts(RotateMethod::Sampling, fill, embed))
+                        .expect("sampling rotate"),
+                );
+            }
+        }
+        let am_src: Pix = if pixs.depth() == leptonica::PixelDepth::Bit1 {
+            scale_to_gray_2(&pixs).expect("scale to gray 2")
+        } else {
+            pixs.clone()
+        };
+        for embed in [fit, none] {
+            for fill in [RotateFill::White, RotateFill::Black] {
+                pixa.push(
+                    rotate(&am_src, ANGLE2, &opts(RotateMethod::AreaMap, fill, embed))
+                        .expect("area map rotate"),
+                );
+            }
+        }
+        let tiled = pixa
+            .display_tiled_in_columns(2, 1.0, 20, 0)
+            .expect("tile sampling/areamap");
+        rp.write_pix_and_check(&tiled, ImageFormat::Png)
+            .expect("check: sampling and area map variants");
+    }
+
+    assert!(rp.cleanup(), "rotate2 C-compat test failed");
+}


### PR DESCRIPTION
## Why

plan 902 の Unmapped 削減。PR 35 で整列した `rotate1` と同系統の
`rotate2_reg`。PNG 出力 8 件は同じ 4 枚の可逆入力から作られ、1 枚あたり
2 出力 (shear の 8 変種 = 2 角度 x 2 fill x 埋め込み有無、および
sampling 4 変種 + area map 4 変種) を並べたもの。

## What

- `rotate2_c_compat` を追加し、PNG 出力 **8 ペアをマップ — 全件即 Ok**
- **実装変更は無い**。PR 35 の `pixRotate` パイプライン化がそのまま効いた
- 1bpp では area map ブロックの前に `pixScaleToGray2` を挟む点、
  `L_BRING_IN_BLACK` と埋め込み無し (C の `0, 0`) の組み合わせも
  テストで再現した

振る舞いの変更が無いため RED/GREEN サイクルは行わず、テスト追加と
マッピング追加の 2 コミットに分けている。

## Impact

- C 互換ベースライン: **Ok 363 → 371**。Mismatch 29 / Unmapped 389 /
  Excluded 100 は不変。`transform` binary の Ok が **114 → 122**
- 既存 golden に変化なし

### 調査メモ

- `rotateorth_reg` は `regTestComparePix` のみでファイル出力が無いため、
  マップ対象が存在しない (C manifest のエントリも 0)
- `warper_reg` の 8 件 (feyn-word.tif、可逆) は C が `srand(seed)` +
  glibc `rand()` で歪みパラメータを作る。PR 31 の `GlibcRand` と同じ手が
  使えるが、ライブラリ側の乱数生成そのものを glibc 互換にする必要が
  あるため別 PR とする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg