### PR TITLE
feat(c-compat): binmorph6 と skew の 14 ペアをマップ — skew 探索を C 準拠に書き換え (Ok 371 → 385)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-19 実測、plan 902 PR 36 後):
+- 現状ベースライン (As of 2026-08-19 実測、plan 902 PR 37 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 371 / Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100**
+  **Ok 385 / Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -995,6 +995,50 @@ PR 35 で整列した rotate1 と同系統。PNG 出力 8 件は同じ 4 枚の�
 `GlibcRand` と同じ手が使えるが、ライブラリ側の乱数生成そのものを
 glibc 互換にする必要があるため別 PR とする。
 
+### PR 37: binmorph6 と skew の全 PNG 出力 (実施済み)
+
+C 版ソース: `prog/binmorph6_reg.c`、`prog/skew_reg.c`。
+
+どちらも入力は可逆 (`feyn-fract.tif` / `feyn.tif`) で、C の出力は全て
+PNG なので pixel hash で完全比較できる。
+
+実施結果:
+
+- **binmorph6 は実装変更なしで 7 ペア全件 Ok**。`selCreateFromPix` で
+  作った hit-only sel での dilate / open / close_safe を検証した
+- **skew は 7 ペア全件 Ok**。ただし C 準拠にするために skew 探索の
+  ほぼ全体を書き換えた (実装差 12 件)。index 2/4/5 が探索結果の角度に
+  依存するため、アルゴリズムがずれていると hash が一致しない
+- Ok 371 → 385 (morph 30 → 37、recog 49 → 56)
+
+skew で見つかった主な実装差:
+
+| 箇所 | 旧実装 | C |
+| --- | --- | --- |
+| center pivot | 中央 1/4 を切り出す | `pixVShearCenter` で支点を変えるだけ |
+| sweep 用縮小 | 元画像から縮小 | search 用縮小画像をさらに縮小 |
+| 縮小方法 | サブサンプリング | `pixReduceRankBinaryCascade` |
+| シア | 画像を拡大 | 同サイズに書き込み、はみ出しは捨てる |
+| スコア累算 | f64 | l_float32 (仮数部飽和で argmax が変わる) |
+| confidence 分母 | sweep 分も含む | 二分探索のスコアのみ |
+| confidence 閾値 | 元画像の寸法 | redsearch 縮小後の寸法 |
+| sweep 端の最大 | 扱いなし | 警告して angle = conf = 0 |
+| 直交探索 | `rotate_by_angle` + `+90` | `pixRotateOrth(1)` + `-90 + angle2` |
+| sweep 単独版 | raw argmax | `numaFitMax` の放物線補間 |
+| 差分二乗和 | `n < 2*nskip + 2` で 0 | 1 項だけでも加算。`0.05 * w` は double |
+| deskew の回転 | embed して拡大 | `pixRotate(.., AREA_MAP, WHITE, 0, 0)` |
+
+Rust 独自の `skew_reg` は index 5 (deskew 結果) の出力が変わるため
+manifest を再生成した。
+
+**次段送り**: 非 JPEG 入力で未マップかつ 5 件以上のプログラムのうち、
+`watershed` (22 件) は C の `L_WSHED` 優先度キュー実装の移植、
+`ptra1` (18 件) は `Ptra` 型と `lucasta.1.300.tif` の追加、
+`ccbord` (14 件) は CCBORDA パイプライン、`circle` (13 件) は
+`circles.pa` の pixa シリアライズ読み込みがそれぞれ必要。
+`multitype` (17 件) は `test8.jpg` / `marge.jpg` を含むため原理的に
+一致不可 (finding 001/008)。
+
 ### PR 37 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,14 +54,14 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        |    件数 | 説明                                                                                                                                                                          |
 | ----------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **371** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +327)                                                                                              |
+| ✅ Ok       | **385** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +341)                                                                                              |
 | ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                                             |
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                                                  |
 | 📭 Unmapped | **389** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 393 → 389)                                                                                           |
 | 🚫 Excluded | **100** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 + newspaper random cmap 2 |
 
-合計 889 entries がレポート対象 (As of 2026-08-19、plan 902 PR 36 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **896 entries**。
+合計 903 entries がレポート対象 (As of 2026-08-19、plan 902 PR 37 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **910 entries**。
 
 ## test binary 別の内訳
 
@@ -69,10 +69,10 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **896 entries**。
 | ----------- | -----: | -------: | -------: | -------: | -------: |
 | `color`     |     56 |        4 |        0 |      108 |        4 |
 | `core`      |     23 |        0 |        0 |       34 |       12 |
-| `filter`    |      7 |        5 |        0 |       55 |       40 |
+| `filter`    |      7 |        5 |        0 |       54 |       40 |
 | `io`        |     11 |        2 |        0 |       41 |       13 |
-| `morph`     | **30** |   **16** |        0 |        9 |        0 |
-| `recog`     |     49 |        0 |        0 |       41 |        2 |
+| `morph`     | **37** |   **16** |        0 |        9 |        0 |
+| `recog`     |     56 |        0 |        0 |       41 |        2 |
 | `region`    | **73** |        2 |        0 |       28 |       29 |
 | `transform` |    122 |        0 |        0 |       74 |        0 |
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -533,3 +533,10 @@ morph	binmorph6	3	binmorph6_c	4	close_safe with sel
 morph	binmorph6	4	binmorph6_c	5	dilate - source
 morph	binmorph6	5	binmorph6_c	6	source - close
 morph	binmorph6	6	binmorph6_c	7	tiled summary
+recog	skew	0	skew_c	1	reduced source
+recog	skew	1	skew_c	2	rotated 40 deg
+recog	skew	2	skew_c	3	deskewed via sweep+search
+recog	skew	3	skew_c	4	rotated 37 deg
+recog	skew	4	skew_c	5	orthogonally deskewed
+recog	skew	5	skew_c	6	recentered
+recog	skew	6	skew_c	7	tiled summary

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -526,3 +526,10 @@ transform	rotate2	4	rotate2_c	5	weasel4.11c shear variants
 transform	rotate2	5	rotate2_c	6	weasel4.11c sampling + area map variants
 transform	rotate2	6	rotate2_c	7	weasel4.16g shear variants
 transform	rotate2	7	rotate2_c	8	weasel4.16g sampling + area map variants
+morph	binmorph6	0	binmorph6_c	1	sel template clip
+morph	binmorph6	1	binmorph6_c	2	dilate with sel
+morph	binmorph6	2	binmorph6_c	3	open with sel
+morph	binmorph6	3	binmorph6_c	4	close_safe with sel
+morph	binmorph6	4	binmorph6_c	5	dilate - source
+morph	binmorph6	5	binmorph6_c	6	source - close
+morph	binmorph6	6	binmorph6_c	7	tiled summary

--- a/src/recog/skew.rs
+++ b/src/recog/skew.rs
@@ -479,6 +479,14 @@ fn sweep_and_search_pivot(
             "redsearch must not exceed redsweep".to_string(),
         ));
     }
+    // C does not validate these, but a non-positive delta is unbounded here:
+    // `sweepdelta = 0` makes `nangles` saturate to i32::MAX, and
+    // `minbsdelta <= 0` never terminates the halving loop below.
+    if sweeprange <= 0.0 || sweepdelta <= 0.0 || minbsdelta <= 0.0 {
+        return Err(RecogError::InvalidParameter(
+            "sweeprange, sweepdelta and minbsdelta must be positive".to_string(),
+        ));
+    }
 
     // Reduced image for the binary search, and a further reduced one for
     // the sweep. C derives the sweep image from the search image, not from
@@ -1062,5 +1070,16 @@ mod tests {
         let r_center = find_skew_sweep_and_search_score_pivot(&pix, &opts, SkewPivot::Center);
         assert!(r_corner.is_ok());
         assert!(r_center.is_ok());
+    }
+
+    #[test]
+    fn test_orthogonal_range_rejects_non_positive_deltas() {
+        // These must fail fast: sweepdelta = 0 saturates the angle count and
+        // minbsdelta = 0 makes the binary search halve forever.
+        let pix = create_horizontal_lines_image(200, 200, 20);
+        assert!(find_skew_orthogonal_range(&pix, 2, 1, 47.0, 0.0, 0.03, 0.0).is_err());
+        assert!(find_skew_orthogonal_range(&pix, 2, 1, 47.0, 1.0, 0.0, 0.0).is_err());
+        assert!(find_skew_orthogonal_range(&pix, 2, 1, 0.0, 1.0, 0.03, 0.0).is_err());
+        assert!(find_skew_orthogonal_range(&pix, 2, 1, 47.0, 1.0, 0.03, 0.0).is_ok());
     }
 }

--- a/src/recog/skew.rs
+++ b/src/recog/skew.rs
@@ -216,7 +216,15 @@ pub fn find_skew_and_deskew(
 /// * `angle` - Rotation angle in degrees (positive = counterclockwise)
 ///
 /// # Returns
-/// The deskewed image
+///
+/// The deskewed image, always with the source dimensions.
+///
+/// The depth can change: this asks for area-map rotation, as C
+/// `pixDeskewGeneral` does, and C's `pixRotateAM` promotes anything below
+/// 8 bpp to 8 bpp. 1 bpp is the exception — `pixRotate` overrides the
+/// request to shear (or sampling past ~6 degrees) before that, so a 1 bpp
+/// input stays 1 bpp. In short: 1 bpp in, 1 bpp out; 2 or 4 bpp in, 8 bpp
+/// out.
 pub fn deskew_by_angle(pix: &Pix, angle: f32) -> RecogResult<Pix> {
     if angle.abs() < 0.001 {
         return Ok(pix.deep_clone());
@@ -225,7 +233,8 @@ pub fn deskew_by_angle(pix: &Pix, angle: f32) -> RecogResult<Pix> {
     // C `pixDeskewGeneral` finishes with
     // `pixRotate(pixs, deg2rad * angle, L_ROTATE_AREA_MAP, L_BRING_IN_WHITE, 0, 0)`.
     // Passing 0 for width/height means "do not embed", so the deskewed image
-    // keeps the source dimensions.
+    // keeps the source dimensions. See the depth note above for what the
+    // area-map request does to sub-8-bpp inputs.
     let options = RotateOptions {
         method: RotateMethod::AreaMap,
         fill: RotateFill::White,
@@ -1070,6 +1079,22 @@ mod tests {
         let r_center = find_skew_sweep_and_search_score_pivot(&pix, &opts, SkewPivot::Center);
         assert!(r_corner.is_ok());
         assert!(r_center.is_ok());
+    }
+
+    #[test]
+    fn test_deskew_by_angle_depth_contract() {
+        // C forces shear for 1 bpp before area mapping can promote it, but
+        // `pixRotateAM` converts anything else below 8 bpp to 8 bpp.
+        for (input, expected) in [
+            (PixelDepth::Bit1, PixelDepth::Bit1),
+            (PixelDepth::Bit4, PixelDepth::Bit8),
+            (PixelDepth::Bit8, PixelDepth::Bit8),
+        ] {
+            let pix = Pix::new(100, 100, input).unwrap();
+            let out = deskew_by_angle(&pix, 2.0).unwrap();
+            assert_eq!(out.depth(), expected, "input {input:?}");
+            assert_eq!((out.width(), out.height()), (100, 100), "input {input:?}");
+        }
     }
 
     #[test]

--- a/src/recog/skew.rs
+++ b/src/recog/skew.rs
@@ -538,6 +538,12 @@ fn sweep_and_search_pivot(
     )?)?;
     let mut bs_scores = vec![scores[2], scores[0], scores[4]];
 
+    // C reuses the single `maxscore` variable for both phases: it still holds
+    // the sweep maximum here (skew.c:774) and is only overwritten inside the
+    // loop body (skew.c:868). So when `minbsdelta > 0.5 * sweepdelta` and the
+    // loop never runs, the confidence below is computed from the sweep score.
+    // That mixes scales (the sweep runs on `pixsw`, the search on `pixsch`),
+    // but it is C's behaviour and callers depend on the same numbers.
     let mut delta = 0.5 * sweepdelta;
     while delta >= minbsdelta {
         let leftcenterangle = centerangle - delta;

--- a/src/recog/skew.rs
+++ b/src/recog/skew.rs
@@ -16,9 +16,12 @@
 //!    differential square sum of row pixel counts is computed. Text lines
 //!    produce maximum score when horizontal.
 
-use crate::core::{Pix, PixelDepth};
+use crate::core::{Numa, Pix, PixelDepth};
 use crate::recog::{RecogError, RecogResult};
-use crate::transform::rotate_by_angle;
+use crate::transform::{
+    RotateEmbed, RotateFill, RotateMethod, RotateOptions, ShearFill, reduce_rank_binary_cascade,
+    rotate, rotate_orth, v_shear_center, v_shear_corner,
+};
 
 /// Options for skew detection
 #[derive(Debug, Clone)]
@@ -138,8 +141,8 @@ pub struct SkewResult {
 }
 
 // Constants for confidence calculation
-const MIN_VALID_MAX_SCORE: f64 = 10000.0;
-const MIN_SCORE_THRESH_FACTOR: f64 = 0.000002;
+const MIN_VALID_MAX_SCORE: f32 = 10000.0;
+const MIN_SCORE_THRESH_FACTOR: f32 = 0.000002;
 const MIN_DESKEW_ANGLE: f32 = 0.1;
 const MIN_ALLOWED_CONFIDENCE: f32 = 3.0;
 
@@ -167,53 +170,18 @@ pub fn find_skew(pix: &Pix, options: &SkewDetectOptions) -> RecogResult<SkewResu
     // Convert to 1bpp if necessary
     let binary_pix = ensure_binary(pix)?;
 
-    // Check for empty image
-    if is_image_empty(&binary_pix) {
-        return Err(RecogError::NoContent(
-            "image is empty or all white".to_string(),
-        ));
-    }
-
-    // Reduce image for sweep
-    let sweep_pix = reduce_image(&binary_pix, options.sweep_reduction)?;
-
-    // Reduce image for binary search (may be same as sweep)
-    let search_pix = if options.bs_reduction == options.sweep_reduction {
-        sweep_pix.deep_clone()
-    } else {
-        reduce_image(&binary_pix, options.bs_reduction)?
-    };
-
-    // Phase 1: Coarse sweep
-    let (best_angle, _best_score) = sweep_angles(
-        &sweep_pix,
-        -options.sweep_range,
+    let (angle, confidence, _) = sweep_and_search_pivot(
+        &binary_pix,
+        options.sweep_reduction,
+        options.bs_reduction,
+        0.0,
         options.sweep_range,
-        options.sweep_delta,
-    )?;
-
-    // Phase 2: Binary search refinement
-    let (refined_angle, max_score, min_score) = binary_search_angle(
-        &search_pix,
-        best_angle,
         options.sweep_delta,
         options.min_bs_delta,
+        SkewPivot::Corner,
     )?;
 
-    // Calculate confidence
-    let confidence = calculate_confidence(
-        &search_pix,
-        max_score,
-        min_score,
-        refined_angle,
-        options.sweep_range,
-        options.sweep_delta,
-    );
-
-    Ok(SkewResult {
-        angle: refined_angle,
-        confidence,
-    })
+    Ok(SkewResult { angle, confidence })
 }
 
 /// Detect skew and deskew the image
@@ -254,9 +222,18 @@ pub fn deskew_by_angle(pix: &Pix, angle: f32) -> RecogResult<Pix> {
         return Ok(pix.deep_clone());
     }
 
-    // Rotate by the detected angle to correct skew
-    let rotated = rotate_by_angle(pix, angle)?;
-    Ok(rotated)
+    // C `pixDeskewGeneral` finishes with
+    // `pixRotate(pixs, deg2rad * angle, L_ROTATE_AREA_MAP, L_BRING_IN_WHITE, 0, 0)`.
+    // Passing 0 for width/height means "do not embed", so the deskewed image
+    // keeps the source dimensions.
+    let options = RotateOptions {
+        method: RotateMethod::AreaMap,
+        fill: RotateFill::White,
+        center_x: None,
+        center_y: None,
+        embed: RotateEmbed::None,
+    };
+    Ok(rotate(pix, DEG2RAD * angle, &options)?)
 }
 
 /// Options for the deskew high-level interface
@@ -419,53 +396,201 @@ pub fn find_skew_sweep_and_search_score_pivot(
     options.validate()?;
 
     let binary_pix = ensure_binary(pix)?;
-    if is_image_empty(&binary_pix) {
+    sweep_and_search_pivot(
+        &binary_pix,
+        options.sweep_reduction,
+        options.bs_reduction,
+        0.0,
+        options.sweep_range,
+        options.sweep_delta,
+        options.min_bs_delta,
+        pivot,
+    )
+}
+
+/// Degrees-to-radians factor. C Leptonica hardcodes this literal (not `M_PI`)
+/// in every skew function, and the sweep angles are sensitive to it.
+#[allow(clippy::approx_constant, clippy::excessive_precision)]
+const DEG2RAD: f32 = 3.1415926535 / 180.0;
+
+/// C `pixReduceRankBinaryCascade` cascade for a requested reduction factor.
+///
+/// C uses `(1, 0, 0, 0)` for 2x, `(1, 1, 0, 0)` for 4x and `(1, 1, 2, 0)` for
+/// 8x. A trailing 0 terminates the cascade.
+fn reduce_for_search(pix: &Pix, reduction: u32) -> RecogResult<Pix> {
+    let levels: &[u8] = match reduction {
+        1 => return Ok(pix.clone()),
+        2 => &[1],
+        4 => &[1, 1],
+        8 => &[1, 1, 2],
+        _ => {
+            return Err(RecogError::InvalidParameter(
+                "reduction must be 1, 2, 4, or 8".to_string(),
+            ));
+        }
+    };
+    Ok(reduce_rank_binary_cascade(pix, levels)?)
+}
+
+/// C's second cascade, applied to the already-reduced search image to get the
+/// sweep image: `(1, 0, 0, 0)`, `(1, 2, 0, 0)` or `(1, 2, 2, 0)`.
+fn reduce_for_sweep(pix: &Pix, ratio: u32) -> RecogResult<Pix> {
+    let levels: &[u8] = match ratio {
+        1 => return Ok(pix.clone()),
+        2 => &[1],
+        4 => &[1, 2],
+        _ => &[1, 2, 2],
+    };
+    Ok(reduce_rank_binary_cascade(pix, levels)?)
+}
+
+/// Vertical shear about the pivot, as C's sweep and binary search do it.
+fn shear_about_pivot(pix: &Pix, theta_deg: f32, pivot: SkewPivot) -> RecogResult<Pix> {
+    let radang = DEG2RAD * theta_deg;
+    Ok(match pivot {
+        SkewPivot::Corner => v_shear_corner(pix, radang, ShearFill::White)?,
+        SkewPivot::Center => v_shear_center(pix, radang, ShearFill::White)?,
+    })
+}
+
+/// C `pixFindSkewSweepAndSearchScorePivot`.
+///
+/// Returns `(angle_deg, confidence, end_score)`. When the sweep maximum lands
+/// on either end of the sweep range, C warns and returns zeros; this does the
+/// same rather than reporting an untrustworthy angle.
+#[allow(clippy::too_many_arguments)]
+fn sweep_and_search_pivot(
+    pixs: &Pix,
+    redsweep: u32,
+    redsearch: u32,
+    sweepcenter: f32,
+    sweeprange: f32,
+    sweepdelta: f32,
+    minbsdelta: f32,
+    pivot: SkewPivot,
+) -> RecogResult<(f32, f32, f32)> {
+    if !matches!(redsweep, 1 | 2 | 4 | 8) || !matches!(redsearch, 1 | 2 | 4 | 8) {
+        return Err(RecogError::InvalidParameter(
+            "reductions must be 1, 2, 4, or 8".to_string(),
+        ));
+    }
+    if redsearch > redsweep {
+        return Err(RecogError::InvalidParameter(
+            "redsearch must not exceed redsweep".to_string(),
+        ));
+    }
+
+    // Reduced image for the binary search, and a further reduced one for
+    // the sweep. C derives the sweep image from the search image, not from
+    // the source, so the cascades compose.
+    let pixsch = reduce_for_search(pixs, redsearch)?;
+    if is_image_empty(&pixsch) {
         return Err(RecogError::NoContent(
             "image is empty or all white".to_string(),
         ));
     }
+    let pixsw = reduce_for_sweep(&pixsch, redsweep / redsearch)?;
 
-    // For center pivot, crop to the central half of the image so the sweep
-    // is anchored to the center rather than the top-left corner.
-    let work_pix = if pivot == SkewPivot::Center {
-        let w = binary_pix.width();
-        let h = binary_pix.height();
-        binary_pix.clip_rectangle(w / 4, h / 4, w / 2, h / 2)?
+    // C: nangles = (l_int32)((2. * sweeprange) / sweepdelta + 1), in double.
+    let nangles = ((2.0_f64 * sweeprange as f64) / sweepdelta as f64 + 1.0) as i32;
+    if nangles <= 0 {
+        return Err(RecogError::InvalidParameter(
+            "sweep range and delta yield no angles".to_string(),
+        ));
+    }
+
+    // Sweep.
+    let rangeleft = sweepcenter - sweeprange;
+    let mut maxscore = f32::MIN;
+    let mut maxindex = 0i32;
+    let mut maxangle = 0.0f32;
+    for i in 0..nangles {
+        let theta = rangeleft + i as f32 * sweepdelta;
+        let sheared = shear_about_pivot(&pixsw, theta, pivot)?;
+        let sum = find_differential_square_sum(&sheared)?;
+        if sum > maxscore {
+            maxscore = sum;
+            maxindex = i;
+            maxangle = theta;
+        }
+    }
+
+    // C warns and bails out when the maximum is at a sweep edge.
+    if maxindex == 0 || maxindex == nangles - 1 {
+        return Ok((0.0, 0.0, 0.0));
+    }
+
+    // Binary search. `scores` holds C's bsearchscore[5]; `bs_scores` collects
+    // every score evaluated here, which is what the confidence minimum uses
+    // (the sweep scores are discarded first).
+    let mut centerangle = maxangle;
+    let mut scores = [0.0f32; 5];
+    scores[2] = find_differential_square_sum(&shear_about_pivot(&pixsch, centerangle, pivot)?)?;
+    scores[0] = find_differential_square_sum(&shear_about_pivot(
+        &pixsch,
+        centerangle - sweepdelta,
+        pivot,
+    )?)?;
+    scores[4] = find_differential_square_sum(&shear_about_pivot(
+        &pixsch,
+        centerangle + sweepdelta,
+        pivot,
+    )?)?;
+    let mut bs_scores = vec![scores[2], scores[0], scores[4]];
+
+    let mut delta = 0.5 * sweepdelta;
+    while delta >= minbsdelta {
+        let leftcenterangle = centerangle - delta;
+        scores[1] =
+            find_differential_square_sum(&shear_about_pivot(&pixsch, leftcenterangle, pivot)?)?;
+        bs_scores.push(scores[1]);
+
+        let rightcenterangle = centerangle + delta;
+        scores[3] =
+            find_differential_square_sum(&shear_about_pivot(&pixsch, rightcenterangle, pivot)?)?;
+        bs_scores.push(scores[3]);
+
+        // The maximum must be one of the middle three, not an end value.
+        maxscore = scores[1];
+        let mut bsindex = 1usize;
+        for (i, &score) in scores.iter().enumerate().take(4).skip(2) {
+            if score > maxscore {
+                maxscore = score;
+                bsindex = i;
+            }
+        }
+
+        let lefttemp = scores[bsindex - 1];
+        let righttemp = scores[bsindex + 1];
+        scores[2] = maxscore;
+        scores[0] = lefttemp;
+        scores[4] = righttemp;
+
+        centerangle += delta * (bsindex as f32 - 2.0);
+        delta *= 0.5;
+    }
+    let endscore = scores[2];
+
+    // Confidence: max/min score ratio, distrusted when the minimum is too
+    // small for the image dimensions, when the angle sits at the edge of the
+    // sweep range, or when the maximum score itself is tiny.
+    let minscore = bs_scores.iter().copied().fold(f32::MAX, f32::min);
+    let width = pixsch.width() as f32;
+    let height = pixsch.height() as f32;
+    let minthresh = MIN_SCORE_THRESH_FACTOR * width * width * height;
+    let mut conf = if minscore > minthresh {
+        maxscore / minscore
     } else {
-        binary_pix
+        0.0
     };
+    if centerangle > rangeleft + 2.0 * sweeprange - sweepdelta
+        || centerangle < rangeleft + sweepdelta
+        || maxscore < MIN_VALID_MAX_SCORE
+    {
+        conf = 0.0;
+    }
 
-    let sweep_pix = reduce_image(&work_pix, options.sweep_reduction)?;
-    let search_pix = if options.bs_reduction == options.sweep_reduction {
-        sweep_pix.deep_clone()
-    } else {
-        reduce_image(&work_pix, options.bs_reduction)?
-    };
-
-    let (best_angle, _) = sweep_angles(
-        &sweep_pix,
-        -options.sweep_range,
-        options.sweep_range,
-        options.sweep_delta,
-    )?;
-
-    let (refined_angle, max_score, min_score) = binary_search_angle(
-        &search_pix,
-        best_angle,
-        options.sweep_delta,
-        options.min_bs_delta,
-    )?;
-
-    let confidence = calculate_confidence(
-        &search_pix,
-        max_score,
-        min_score,
-        refined_angle,
-        options.sweep_range,
-        options.sweep_delta,
-    );
-
-    Ok((refined_angle, confidence, max_score as f32))
+    Ok((centerangle, conf, endscore))
 }
 
 /// Ensure image is binary (1 bpp)
@@ -565,279 +690,6 @@ fn is_image_empty(pix: &Pix) -> bool {
     true
 }
 
-/// Reduce image by factor (simple subsampling for binary images)
-fn reduce_image(pix: &Pix, factor: u32) -> RecogResult<Pix> {
-    if factor == 1 {
-        return Ok(pix.deep_clone());
-    }
-
-    let w = pix.width();
-    let h = pix.height();
-    let new_w = w / factor;
-    let new_h = h / factor;
-
-    if new_w == 0 || new_h == 0 {
-        return Err(RecogError::ImageTooSmall {
-            min_width: factor,
-            min_height: factor,
-            actual_width: w,
-            actual_height: h,
-        });
-    }
-
-    let reduced = Pix::new(new_w, new_h, pix.depth())?;
-    let mut reduced_mut = reduced.try_into_mut().unwrap();
-
-    // For binary images, use OR reduction (any black pixel makes output black)
-    for ny in 0..new_h {
-        for nx in 0..new_w {
-            let mut has_black = false;
-            for dy in 0..factor {
-                for dx in 0..factor {
-                    let sx = nx * factor + dx;
-                    let sy = ny * factor + dy;
-                    if sx < w && sy < h {
-                        let val = pix.get_pixel_unchecked(sx, sy);
-                        if val != 0 {
-                            has_black = true;
-                            break;
-                        }
-                    }
-                }
-                if has_black {
-                    break;
-                }
-            }
-            let out_val = if has_black { 1 } else { 0 };
-            reduced_mut.set_pixel_unchecked(nx, ny, out_val);
-        }
-    }
-
-    Ok(reduced_mut.into())
-}
-
-/// Sweep through angles and find the one with maximum score
-fn sweep_angles(
-    pix: &Pix,
-    start_angle: f32,
-    end_angle: f32,
-    delta: f32,
-) -> RecogResult<(f32, f64)> {
-    let mut best_angle = 0.0f32;
-    let mut best_score = f64::MIN;
-
-    let mut angle = start_angle;
-    while angle <= end_angle {
-        let sheared = vertical_shear(pix, angle)?;
-        let score = compute_differential_square_sum(&sheared);
-
-        if score > best_score {
-            best_score = score;
-            best_angle = angle;
-        }
-
-        angle += delta;
-    }
-
-    Ok((best_angle, best_score))
-}
-
-/// Binary search to refine angle
-#[allow(clippy::needless_range_loop)]
-fn binary_search_angle(
-    pix: &Pix,
-    center_angle: f32,
-    initial_delta: f32,
-    min_delta: f32,
-) -> RecogResult<(f32, f64, f64)> {
-    let mut center = center_angle;
-    let mut delta = initial_delta / 2.0;
-
-    // Initial scores at center and neighbors
-    let sheared_center = vertical_shear(pix, center)?;
-    let mut scores = [0.0f64; 5];
-    scores[2] = compute_differential_square_sum(&sheared_center);
-
-    let sheared_left = vertical_shear(pix, center - initial_delta)?;
-    scores[0] = compute_differential_square_sum(&sheared_left);
-
-    let sheared_right = vertical_shear(pix, center + initial_delta)?;
-    scores[4] = compute_differential_square_sum(&sheared_right);
-
-    let mut max_score = scores[0].max(scores[2]).max(scores[4]);
-    let mut min_score = scores[0].min(scores[2]).min(scores[4]);
-
-    while delta >= min_delta {
-        // Compute left intermediate
-        let left_angle = center - delta;
-        let sheared_left = vertical_shear(pix, left_angle)?;
-        scores[1] = compute_differential_square_sum(&sheared_left);
-
-        // Compute right intermediate
-        let right_angle = center + delta;
-        let sheared_right = vertical_shear(pix, right_angle)?;
-        scores[3] = compute_differential_square_sum(&sheared_right);
-
-        // Find maximum among center three
-        let mut max_idx = 1;
-        let mut max_val = scores[1];
-        for i in 2..4 {
-            if scores[i] > max_val {
-                max_val = scores[i];
-                max_idx = i;
-            }
-        }
-
-        // Update tracking
-        max_score = max_score.max(max_val);
-        min_score = min_score.min(scores[1]).min(scores[3]);
-
-        // Update for next iteration
-        let left_temp = scores[max_idx - 1];
-        let right_temp = scores[max_idx + 1];
-        scores[2] = max_val;
-        scores[0] = left_temp;
-        scores[4] = right_temp;
-
-        center += delta * (max_idx as f32 - 2.0);
-        delta *= 0.5;
-    }
-
-    Ok((center, max_score, min_score))
-}
-
-/// Vertical shear transformation
-/// This is a key operation for skew detection - it shears the image
-/// vertically by an amount proportional to the x-coordinate
-fn vertical_shear(pix: &Pix, angle_deg: f32) -> RecogResult<Pix> {
-    if angle_deg.abs() < 0.001 {
-        return Ok(pix.deep_clone());
-    }
-
-    let w = pix.width();
-    let h = pix.height();
-    let angle_rad = angle_deg.to_radians();
-    let tan_a = angle_rad.tan();
-
-    // Calculate new height needed to contain sheared image
-    let max_shear = (w as f32 * tan_a.abs()).ceil() as u32;
-    let new_h = h + max_shear;
-
-    let sheared = Pix::new(w, new_h, pix.depth())?;
-    let mut sheared_mut = sheared.try_into_mut().unwrap();
-
-    // Apply vertical shear: y' = y + x * tan(angle)
-    let y_offset = if tan_a < 0.0 { max_shear } else { 0 };
-
-    for y in 0..h {
-        for x in 0..w {
-            let val = pix.get_pixel_unchecked(x, y);
-            if val != 0 {
-                let shear_amount = (x as f32 * tan_a).round() as i32;
-                let new_y = y as i32 + shear_amount + y_offset as i32;
-                if new_y >= 0 && (new_y as u32) < new_h {
-                    sheared_mut.set_pixel_unchecked(x, new_y as u32, val);
-                }
-            }
-        }
-    }
-
-    Ok(sheared_mut.into())
-}
-
-/// Compute differential square sum score
-/// This measures how well text lines are aligned horizontally
-fn compute_differential_square_sum(pix: &Pix) -> f64 {
-    let h = pix.height();
-
-    // Count pixels per row
-    let mut row_sums: Vec<u32> = Vec::with_capacity(h as usize);
-    if pix.depth() == PixelDepth::Bit1 {
-        let w = pix.width();
-        let wpl = pix.wpl() as usize;
-        let bits_used = w % 32;
-        let full_words = (w / 32) as usize;
-        let end_mask = if bits_used == 0 {
-            0xFFFF_FFFF
-        } else {
-            !((1u32 << (32 - bits_used)) - 1)
-        };
-        for y in 0..h {
-            let line = pix.row_data(y);
-            let mut sum = 0u32;
-            for &word in &line[..full_words] {
-                sum += word.count_ones();
-            }
-            if bits_used != 0 && full_words < wpl {
-                sum += (line[full_words] & end_mask).count_ones();
-            }
-            row_sums.push(sum);
-        }
-    } else {
-        let w = pix.width();
-        for y in 0..h {
-            let mut sum = 0u32;
-            for x in 0..w {
-                if pix.get_pixel_unchecked(x, y) != 0 {
-                    sum += 1;
-                }
-            }
-            row_sums.push(sum);
-        }
-    }
-
-    // Skip some rows at top and bottom to avoid edge effects
-    let w = pix.width();
-    let skip_h = ((w as f32 * 0.05) as u32).max(1);
-    let skip = (h / 10).min(skip_h);
-    let n_skip = (skip / 2).max(1) as usize;
-
-    if row_sums.len() <= 2 * n_skip {
-        return 0.0;
-    }
-
-    // Compute sum of squared differences
-    let mut sum = 0.0f64;
-    for i in n_skip..(row_sums.len() - n_skip) {
-        let diff = row_sums[i] as f64 - row_sums[i - 1] as f64;
-        sum += diff * diff;
-    }
-
-    sum
-}
-
-/// Calculate confidence score
-fn calculate_confidence(
-    pix: &Pix,
-    max_score: f64,
-    min_score: f64,
-    angle: f32,
-    sweep_range: f32,
-    sweep_delta: f32,
-) -> f32 {
-    let w = pix.width() as f64;
-    let h = pix.height() as f64;
-
-    // Minimum threshold based on image dimensions
-    let min_thresh = MIN_SCORE_THRESH_FACTOR * w * w * h;
-
-    // Check if scores are valid
-    if max_score < MIN_VALID_MAX_SCORE {
-        return 0.0;
-    }
-
-    if min_score <= min_thresh {
-        return 0.0;
-    }
-
-    // Check if angle is at edge of sweep range
-    if angle.abs() > sweep_range - sweep_delta {
-        return 0.0;
-    }
-
-    (max_score / min_score) as f32
-}
-
 /// Finds the skew angle using only the sweep phase (no binary search).
 ///
 /// This is a low-level function that does a single pass through the angle
@@ -870,16 +722,27 @@ pub fn find_skew_sweep(
     }
 
     let binary_pix = ensure_binary(pix)?;
-    if is_image_empty(&binary_pix) {
+    let reduced = reduce_for_search(&binary_pix, reduction)?;
+    if is_image_empty(&reduced) {
         return Err(RecogError::NoContent(
             "image is empty or all white".to_string(),
         ));
     }
 
-    let reduced = reduce_image(&binary_pix, reduction)?;
+    let nangles = ((2.0_f64 * sweep_range as f64) / sweep_delta as f64 + 1.0) as i32;
+    let mut nascore = Numa::new();
+    let mut natheta = Numa::new();
+    for i in 0..nangles {
+        let theta = -sweep_range + i as f32 * sweep_delta;
+        let sheared = shear_about_pivot(&reduced, theta, SkewPivot::Corner)?;
+        nascore.push(find_differential_square_sum(&sheared)?);
+        natheta.push(theta);
+    }
 
-    let (best_angle, _) = sweep_angles(&reduced, -sweep_range, sweep_range, sweep_delta)?;
-    Ok(best_angle)
+    // C interpolates a parabola through the maximum rather than taking the
+    // raw argmax, so the returned angle can lie between two sweep steps.
+    let (_, maxangle) = nascore.fit_max(Some(&natheta))?;
+    Ok(maxangle)
 }
 
 /// Finds the skew angle by searching in two orthogonal directions.
@@ -911,29 +774,36 @@ pub fn find_skew_orthogonal_range(
     minbs_delta: f32,
     confprior: f32,
 ) -> RecogResult<(f32, f32)> {
-    // Search around 0°
-    let opts = SkewDetectOptions {
+    let binary_pix = ensure_binary(pix)?;
+
+    let (angle1, conf1, _) = sweep_and_search_pivot(
+        &binary_pix,
+        redsweep,
+        redsearch,
+        0.0,
         sweep_range,
         sweep_delta,
-        min_bs_delta: minbs_delta,
-        sweep_reduction: redsweep,
-        bs_reduction: redsearch,
-    };
+        minbs_delta,
+        SkewPivot::Corner,
+    )?;
 
-    let result0 = find_skew(pix, &opts)?;
+    // C rotates by one quadrant (90 degrees clockwise) and searches again.
+    let rotated = rotate_orth(&binary_pix, 1)?;
+    let (angle2, conf2, _) = sweep_and_search_pivot(
+        &rotated,
+        redsweep,
+        redsearch,
+        0.0,
+        sweep_range,
+        sweep_delta,
+        minbs_delta,
+        SkewPivot::Corner,
+    )?;
 
-    // Search around 90° by rotating the image
-    let rotated = rotate_by_angle(pix, std::f32::consts::FRAC_PI_2)?;
-    let result90 = find_skew(&rotated, &opts)?;
-
-    // Apply confprior penalty to 90° result
-    let conf90_adjusted = result90.confidence - confprior;
-
-    if result0.confidence >= conf90_adjusted {
-        Ok((result0.angle, result0.confidence))
+    if conf1 > conf2 - confprior {
+        Ok((angle1, conf1))
     } else {
-        // Adjust angle: the 90° search was done on rotated image
-        Ok((result90.angle + 90.0, result90.confidence))
+        Ok((-90.0 + angle2, conf2))
     }
 }
 
@@ -956,11 +826,12 @@ pub fn find_differential_square_sum(pix: &Pix) -> RecogResult<f32> {
     let h = pix.height() as i32;
     // Match C `pixFindDifferentialSquareSum`: skip = min(h/10, 0.05*w),
     // nskip = max(skip/2, 1).
-    let skiph = (0.05 * w as f32) as i32;
+    // C evaluates `0.05 * w` in double, then truncates.
+    let skiph = (0.05 * w as f64) as i32;
     let skip = (h / 10).min(skiph);
     let nskip = (skip / 2).max(1) as usize;
     let n = na.len();
-    if n < 2 * nskip + 2 {
+    if n <= nskip {
         return Ok(0.0);
     }
     let mut sum = 0.0f32;
@@ -1026,7 +897,7 @@ pub fn find_normalized_square_sum(pix: &Pix) -> RecogResult<(f32, f32, f32)> {
 mod tests {
     use super::*;
 
-    fn create_horizontal_lines_image(w: u32, h: u32, line_spacing: u32) -> Pix {
+    pub(super) fn create_horizontal_lines_image(w: u32, h: u32, line_spacing: u32) -> Pix {
         let pix = Pix::new(w, h, PixelDepth::Bit1).unwrap();
         let mut pix_mut = pix.try_into_mut().unwrap();
 
@@ -1065,32 +936,36 @@ mod tests {
     }
 
     #[test]
-    fn test_vertical_shear_zero_angle() {
+    fn test_shear_about_pivot_zero_angle() {
         let pix = Pix::new(50, 50, PixelDepth::Bit1).unwrap();
-        let sheared = vertical_shear(&pix, 0.0).unwrap();
+        let sheared = shear_about_pivot(&pix, 0.0, SkewPivot::Corner).unwrap();
         assert_eq!(sheared.width(), 50);
         assert_eq!(sheared.height(), 50);
     }
 
     #[test]
-    fn test_vertical_shear_nonzero() {
+    fn test_shear_about_pivot_keeps_size() {
+        // C's pixVShear writes into a pix of the same size as the source, so
+        // the sheared image never grows; content shifts out of frame instead.
         let pix = Pix::new(100, 100, PixelDepth::Bit1).unwrap();
-        let sheared = vertical_shear(&pix, 5.0).unwrap();
-        assert_eq!(sheared.width(), 100);
-        assert!(sheared.height() > 100);
+        for pivot in [SkewPivot::Corner, SkewPivot::Center] {
+            let sheared = shear_about_pivot(&pix, 5.0, pivot).unwrap();
+            assert_eq!(sheared.width(), 100);
+            assert_eq!(sheared.height(), 100);
+        }
     }
 
     #[test]
-    fn test_compute_differential_square_sum() {
+    fn test_differential_square_sum_positive() {
         let pix = create_horizontal_lines_image(200, 200, 20);
-        let score = compute_differential_square_sum(&pix);
+        let score = find_differential_square_sum(&pix).unwrap();
         assert!(score > 0.0);
     }
 
     #[test]
-    fn test_reduce_image() {
+    fn test_reduce_for_search() {
         let pix = Pix::new(100, 100, PixelDepth::Bit1).unwrap();
-        let reduced = reduce_image(&pix, 2).unwrap();
+        let reduced = reduce_for_search(&pix, 2).unwrap();
         assert_eq!(reduced.width(), 50);
         assert_eq!(reduced.height(), 50);
     }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -830,7 +830,14 @@ shear2_c.04.png	53ce644a10809831
 shear2_color_samp.02.png	339f0b19dd6b59d4
 shear2_general.02.png	339f0b19dd6b59d4
 shear2_gray_interp.03.png	7366c9f9e594f1f2
-skew.05.tif	a82f76ea1682d511
+skew.05.tif	3ff78f189f17cf5a
+skew_c.01.png	a5f76536068ea322
+skew_c.02.png	d9f9518919780d18
+skew_c.03.png	80ce82daf037efe3
+skew_c.04.png	e1e5c08eed9fdb66
+skew_c.05.png	88f2656557182763
+skew_c.06.png	2e9a2e8bd2624883
+skew_c.07.png	cb705f2ecb3f3f0e
 smallpix_c.01.png	d9479798307abea0
 smallpix_c.02.png	a1a9b01c087770e0
 smallpix_c.03.png	50ee18c22e421e00

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -127,6 +127,13 @@ binmorph1.12.tif	9720f64fd9cc021f
 binmorph3.14.tif	7285e6dddc1bb3ce
 binmorph3.15.tif	7285e6dddc1bb3ce
 binmorph3.16.tif	90603db276f02f1f
+binmorph6_c.01.png	9fe03a143b07586c
+binmorph6_c.02.png	ffd9943b24090b4f
+binmorph6_c.03.png	90cfa2e624ef813e
+binmorph6_c.04.png	95fb32d6d4eb1fff
+binmorph6_c.05.png	d22f1740c4f2f87f
+binmorph6_c.06.png	b7f005730578dbee
+binmorph6_c.07.png	ed2378ed256a8026
 blend1_adapt.03.png	ebd2c98dcc40a402
 blend1_color.03.png	794a317f50b265cf
 blend1_color.05.png	dc72deb98fdce580

--- a/tests/morph/binmorph6_reg.rs
+++ b/tests/morph/binmorph6_reg.rs
@@ -83,3 +83,50 @@ fn binmorph6_reg_sel_from_string() {
 
     assert!(rp.cleanup(), "binmorph6 sel_from_string test failed");
 }
+
+/// C-compat: `prog/binmorph6_reg.c`, all 7 outputs.
+///
+/// Builds a hit-only sel from a clip of `feyn-fract.tif` and applies it with
+/// dilate / open / close-safe. The only input is lossless and C writes every
+/// output as PNG, so the whole program is bit-exactly comparable.
+#[test]
+fn binmorph6_c_compat() {
+    use leptonica::core::Pixa;
+    use leptonica::io::ImageFormat;
+    use leptonica::morph::{Sel, close_safe, dilate, open};
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    let mut rp = RegParams::new("binmorph6_c");
+
+    let pix1 = crate::common::load_test_image("feyn-fract.tif").expect("load feyn-fract.tif");
+    // C: boxCreate(507, 65, 60, 36) then pixClipRectangle.
+    let pix2 = pix1.clip_rectangle(507, 65, 60, 36).expect("clip");
+    // C: selCreateFromPix(pix2, 6, 6, "life") — (cy, cx) in C's order.
+    let sel = Sel::from_pix(&pix2, 6, 6).expect("sel from pix");
+
+    let pix3 = dilate(&pix1, &sel).expect("dilate");
+    let pix4 = open(&pix1, &sel).expect("open");
+    let pix5 = close_safe(&pix1, &sel).expect("close safe");
+    let pix6 = pix3.subtract(&pix1).expect("dilate - src");
+    let pix7 = pix1.subtract(&pix5).expect("src - close");
+
+    for pix in [&pix2, &pix3, &pix4, &pix5, &pix6, &pix7] {
+        rp.write_pix_and_check(pix, ImageFormat::Png)
+            .expect("check: binmorph6 stage");
+    }
+
+    let mut pixa = Pixa::new();
+    for pix in [&pix1, &pix3, &pix4, &pix5, &pix6, &pix7] {
+        pixa.push(pix.clone());
+    }
+    let tiled = pixa
+        .display_tiled_in_columns(2, 0.75, 20, 2)
+        .expect("tile binmorph6");
+    rp.write_pix_and_check(&tiled, ImageFormat::Png)
+        .expect("check: binmorph6 summary");
+
+    assert!(rp.cleanup(), "binmorph6 C-compat test failed");
+}

--- a/tests/morph/binmorph6_reg.rs
+++ b/tests/morph/binmorph6_reg.rs
@@ -104,7 +104,8 @@ fn binmorph6_c_compat() {
     let pix1 = crate::common::load_test_image("feyn-fract.tif").expect("load feyn-fract.tif");
     // C: boxCreate(507, 65, 60, 36) then pixClipRectangle.
     let pix2 = pix1.clip_rectangle(507, 65, 60, 36).expect("clip");
-    // C: selCreateFromPix(pix2, 6, 6, "life") — (cy, cx) in C's order.
+    // C: selCreateFromPix(pix2, 6, 6, "life"). C takes (cy, cx) while this
+    // takes (cx, cy); both are 6 here, so the order does not matter.
     let sel = Sel::from_pix(&pix2, 6, 6).expect("sel from pix");
 
     let pix3 = dilate(&pix1, &sel).expect("dilate");

--- a/tests/recog/skew_reg.rs
+++ b/tests/recog/skew_reg.rs
@@ -178,7 +178,6 @@ fn skew_reg_normalized_square_sum_non_1bpp_errors() {
 /// angle found by `pixFindSkewSweepAndSearchScorePivot` /
 /// `pixFindSkewOrthogonalRange`, so this also pins those search algorithms.
 #[test]
-#[ignore = "not yet implemented"]
 fn skew_c_compat() {
     use leptonica::core::{InitColor, Pix, Pixa, RopOp};
     use leptonica::recog::skew::{
@@ -204,7 +203,7 @@ fn skew_c_compat() {
     let pixs = load_test_image("feyn.tif").expect("load feyn.tif");
     // C: pixSetOrClearBorder(pixs, 100, 250, 100, 0, PIX_CLR)
     let pixs = {
-        let mut m = pixs.try_into_mut().expect("into mut");
+        let mut m = pixs.deep_clone().try_into_mut().expect("into mut");
         m.set_or_clear_border(100, 250, 100, 0, InitColor::White);
         Pix::from(m)
     };
@@ -281,7 +280,7 @@ fn skew_c_compat() {
     let (wd, hd) = (pixd.width(), pixd.height());
     let pixc = Pix::new(w, h, PixelDepth::Bit1).expect("new 1bpp");
     let pixc = {
-        let mut m = pixc.try_into_mut().expect("into mut");
+        let mut m = pixc.deep_clone().try_into_mut().expect("into mut");
         m.rop_region_inplace(
             0,
             0,

--- a/tests/recog/skew_reg.rs
+++ b/tests/recog/skew_reg.rs
@@ -170,3 +170,140 @@ fn skew_reg_normalized_square_sum_non_1bpp_errors() {
     let pix = Pix::new(32, 32, leptonica::PixelDepth::Bit32).expect("new 32bpp");
     assert!(find_normalized_square_sum(&pix).is_err());
 }
+
+/// C-compat: `prog/skew_reg.c`, all 7 outputs.
+///
+/// `feyn.tif` is lossless and C writes every output as PNG, so the whole
+/// program is bit-exactly comparable. Indices 2, 4 and 5 depend on the skew
+/// angle found by `pixFindSkewSweepAndSearchScorePivot` /
+/// `pixFindSkewOrthogonalRange`, so this also pins those search algorithms.
+#[test]
+#[ignore = "not yet implemented"]
+fn skew_c_compat() {
+    use leptonica::core::{InitColor, Pix, Pixa, RopOp};
+    use leptonica::recog::skew::{
+        SkewPivot, find_skew_orthogonal_range, find_skew_sweep_and_search_score_pivot,
+    };
+    use leptonica::transform::{
+        RotateEmbed, RotateFill, RotateMethod, RotateOptions, reduce_rank_binary_cascade, rotate,
+        rotate_by_sampling,
+    };
+
+    if crate::common::is_display_mode() {
+        return;
+    }
+
+    const BORDER: u32 = 150;
+    // C uses the literal 3.1415926535, not M_PI.
+    #[allow(clippy::approx_constant, clippy::excessive_precision)]
+    let deg2rad = 3.1415926535_f32 / 180.0;
+
+    let mut rp = RegParams::new("skew_c");
+    let mut pixa = Pixa::new();
+
+    let pixs = load_test_image("feyn.tif").expect("load feyn.tif");
+    // C: pixSetOrClearBorder(pixs, 100, 250, 100, 0, PIX_CLR)
+    let pixs = {
+        let mut m = pixs.try_into_mut().expect("into mut");
+        m.set_or_clear_border(100, 250, 100, 0, InitColor::White);
+        Pix::from(m)
+    };
+
+    // C: pixReduceRankBinaryCascade(pixs, 2, 2, 0, 0)
+    let pixb1 = reduce_rank_binary_cascade(&pixs, &[2, 2]).expect("rank cascade");
+    rp.write_pix_and_check(&pixb1, ImageFormat::Png)
+        .expect("check: reduced source");
+
+    let pixb2 = pixb1.add_border(BORDER, 0).expect("add border");
+    let (w, h) = (pixb2.width(), pixb2.height());
+    pixa.push(pixb2.clone());
+
+    // C: rotate by sampling, 40 degrees about the center of pixb2.
+    let pixr = rotate_by_sampling(
+        &pixb2,
+        (w / 2) as i32,
+        (h / 2) as i32,
+        deg2rad * 40.0,
+        RotateFill::White,
+    )
+    .expect("rotate 40");
+    rp.write_pix_and_check(&pixr, ImageFormat::Png)
+        .expect("check: rotated 40 deg");
+    pixa.push(pixr.clone());
+
+    // C: pixFindSkewSweepAndSearchScorePivot(pixr, .., 1, 1, 0.0, 45.0, 2.0, 0.03, CENTER)
+    let opts = SkewDetectOptions {
+        sweep_range: 45.0,
+        sweep_delta: 2.0,
+        min_bs_delta: 0.03,
+        sweep_reduction: 1,
+        bs_reduction: 1,
+    };
+    let (angle, _conf, _score) =
+        find_skew_sweep_and_search_score_pivot(&pixr, &opts, SkewPivot::Center)
+            .expect("sweep and search");
+
+    let pixf = rotate_by_sampling(
+        &pixr,
+        (w / 2) as i32,
+        (h / 2) as i32,
+        deg2rad * angle,
+        RotateFill::White,
+    )
+    .expect("deskew rotate");
+    let pixd = pixf.remove_border(BORDER).expect("remove border");
+    rp.write_pix_and_check(&pixd, ImageFormat::Png)
+        .expect("check: deskewed");
+    pixa.push(pixd);
+
+    // C: pixRotate(pixb1, 37 deg, SAMPLING, WHITE, w, h) with pixb1's own dims.
+    let (w, h) = (pixb1.width(), pixb1.height());
+    let ropts = RotateOptions {
+        method: RotateMethod::Sampling,
+        fill: RotateFill::White,
+        center_x: None,
+        center_y: None,
+        embed: RotateEmbed::Explicit(w, h),
+    };
+    let pixr = rotate(&pixb1, deg2rad * 37.0, &ropts).expect("rotate 37");
+    rp.write_pix_and_check(&pixr, ImageFormat::Png)
+        .expect("check: rotated 37 deg");
+    pixa.push(pixr.clone());
+
+    // C: pixFindSkewOrthogonalRange(pixr, .., 2, 1, 47.0, 1.0, 0.03, 0.0)
+    let (angle, _conf) =
+        find_skew_orthogonal_range(&pixr, 2, 1, 47.0, 1.0, 0.03, 0.0).expect("orthogonal range");
+    let pixd = rotate(&pixr, deg2rad * angle, &ropts).expect("orthogonal deskew");
+    rp.write_pix_and_check(&pixd, ImageFormat::Png)
+        .expect("check: orthogonally deskewed");
+
+    // C: crop the (larger) rotated result back to pixb1's size, centered.
+    let (wd, hd) = (pixd.width(), pixd.height());
+    let pixc = Pix::new(w, h, PixelDepth::Bit1).expect("new 1bpp");
+    let pixc = {
+        let mut m = pixc.try_into_mut().expect("into mut");
+        m.rop_region_inplace(
+            0,
+            0,
+            w,
+            h,
+            RopOp::Src,
+            &pixd,
+            (wd as i32 - w as i32) / 2,
+            (hd as i32 - h as i32) / 2,
+        )
+        .expect("rasterop");
+        Pix::from(m)
+    };
+    rp.write_pix_and_check(&pixc, ImageFormat::Png)
+        .expect("check: recentered");
+    pixa.push(pixc);
+
+    let tiled = pixa
+        .display_tiled_in_columns(3, 0.5, 20, 3)
+        .expect("tile skew");
+    rp.write_pix_and_check(&tiled, ImageFormat::Png)
+        .expect("check: skew summary");
+
+    assert!(rp.cleanup(), "skew C-compat test failed");
+}


### PR DESCRIPTION
## Why

plan 902 PR 37。C 版との pixel-level 互換性を検証する semantic マッピングを
広げる。今回の 2 プログラムはどちらも入力が可逆 (`feyn-fract.tif` /
`feyn.tif`) で C の出力が全て PNG なので、hash で完全比較できる。

`skew_reg` は出力 7 件のうち 3 件が skew 探索アルゴリズムの返す角度に
依存するため、マッピングがそのまま探索アルゴリズムの検証になる。

## What

- `binmorph6_c_compat` (morph): C `prog/binmorph6_reg.c` の 7 出力をマップ。
  `selCreateFromPix` で作った hit-only sel での dilate / open / close_safe。
  **実装変更なしで 7/7 Ok**
- `skew_c_compat` (recog): C `prog/skew_reg.c` の 7 出力をマップ。7/7 Ok。
  ただし C 準拠にするため skew 探索をほぼ全面的に書き換えた

### skew で見つかった実装差 (12 件)

| 箇所 | 旧実装 | C |
| --- | --- | --- |
| center pivot | 中央 1/4 を切り出す | `pixVShearCenter` で支点を変えるだけ |
| sweep 用縮小 | 元画像から縮小 | search 用縮小画像をさらに縮小 |
| 縮小方法 | サブサンプリング | `pixReduceRankBinaryCascade` |
| シア | 画像を拡大 | 同サイズに書き込み、はみ出しは捨てる |
| スコア累算 | f64 | l_float32 (仮数部飽和で argmax が変わる) |
| confidence 分母 | sweep 分も含む | 二分探索のスコアのみ |
| confidence 閾値 | 元画像の寸法 | redsearch 縮小後の寸法 |
| sweep 端の最大 | 扱いなし | 警告して angle = conf = 0 |
| 直交探索 | `rotate_by_angle` + `+90` | `pixRotateOrth(1)` + `-90 + angle2` |
| sweep 単独版 | raw argmax | `numaFitMax` の放物線補間 |
| 差分二乗和 | `n < 2*nskip + 2` で 0 | 1 項だけでも加算。`0.05 * w` は double |
| deskew の回転 | embed して拡大 | `pixRotate(.., AREA_MAP, WHITE, 0, 0)` |

## Impact

- C 互換ベースライン: **Ok 371 → 385** (morph 30 → 37、recog 49 → 56)。
  Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100 は変化なし
- 公開 API の変更なし。`find_skew` / `find_skew_sweep` /
  `find_skew_orthogonal_range` / `deskew_by_angle` の**返り値が変わる**
  (C 準拠になる)
- Rust 独自の `skew_reg` は deskew 結果 (index 5) の出力が変わるため
  `tests/golden_manifest.tsv` を再生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg