### PR TITLE
glibc 互換乱数で watershed を完遂 — 22/22 全件 Ok (plan 902 PR 43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-22 実測、plan 902 PR 42 後):
+- 現状ベースライン (As of 2026-08-22 実測、plan 902 PR 43 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 446 / Mismatch 33 / MissingC 0 / Unmapped 389 / Excluded 100**
+  **Ok 450 / Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -1304,7 +1304,7 @@ C 忠実性の判断:
 **次段送り**: check 10/11/22/23 の 4 件は PR 43 (glibc 互換乱数を引数で
 渡す API) で解消する。同じ仕組みは `warper_reg` の 8 件にも使える。
 
-### PR 43: glibc 互換乱数で watershed を完遂 (計画)
+### PR 43: glibc 互換乱数で watershed を完遂 (実施済み)
 
 finding 010 の解消。`watershed` の残り 4 ペア (C check 10/11/22/23) を Ok に
 する。
@@ -1337,6 +1337,24 @@ depth から初期化するため、2 回目以降で色が食い違う。
 `tests/core/overlap_reg.rs` に同等の実装がテストローカルで存在するので、
 ライブラリ側に移して重複を解消する。同じ仕組みは `warper_reg` (8 件、
 `srand(seed)` + `rand()` で歪みパラメータを生成) にも使える。
+
+実施結果:
+
+- **watershed 22/22 全件 Ok** (Ok 446 → 450、region 91 → 95、
+  Mismatch 33 → 29)。finding 010 を解消
+- `tests/core/overlap_reg.rs` のテストローカル実装を削除し統合
+- 引数なしの `create_random` / `display_random_cmap` は種 1 の系列に
+  委譲するようにした。C の 1 回目の呼び出しと一致するため、アドホックな
+  LCG を使っていた従来より厳密になる
+
+**落とし穴**: C から期待値を採る際、3 つの `rand()` を `printf` の引数に
+並べると gcc の右から左への評価順で出力が逆順になる。最初この形で採った
+期待値がテストを誤らせた (実装は正しかった)。値を変数に受けてから表示する。
+
+**再検討候補**: `newspaper` の Excluded 2 件は「`pixaDisplayRandomCmap` が
+`rand()` の色を使う」ことを除外理由の 1 つに挙げている。乱数が再現可能に
+なったので、残る理由 (スケーリング時の colormap 展開) だけで除外が妥当か
+再確認する余地がある。
 
 ### PR 37 以降: semantic マッピングの漸進追加
 

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -1304,6 +1304,40 @@ C 忠実性の判断:
 **次段送り**: check 10/11/22/23 の 4 件は PR 43 (glibc 互換乱数を引数で
 渡す API) で解消する。同じ仕組みは `warper_reg` の 8 件にも使える。
 
+### PR 43: glibc 互換乱数で watershed を完遂 (計画)
+
+finding 010 の解消。`watershed` の残り 4 ペア (C check 10/11/22/23) を Ok に
+する。
+
+C `pixcmapCreateRandom()` は glibc の `rand()` を呼ぶが、これは**プロセス
+全体で共有される 1 本の系列**で、`srand()` が呼ばれなければ種は 1。
+`watershed_reg.c` は `pixaDisplayRandomCmap` を 4 回実行し (各 762 個消費)、
+それぞれ系列の異なる位置を使う。Rust 側は呼び出しごとに同じ LCG を
+depth から初期化するため、2 回目以降で色が食い違う。
+
+事前検証済み: 種 1 の glibc 系列から生成したカラーマップは、C の 1 回目
+(check 7) と 3 回目 (check 19) のパレットと **256/256 完全一致**する。
+2 回目の系列には C が check 10 で塗った色 (91, 3, 160) が index 16 に
+存在する。
+
+方針: グローバル可変状態は入れず、乱数源を引数で明示的に渡す。
+
+| 追加 API | 対応する C |
+| --- | --- |
+| `core::GlibcRand` | glibc `rand()` (TYPE_3 additive-feedback) |
+| `PixColormap::create_random_with` | `pixcmapCreateRandom()` |
+| `Pixa::display_random_cmap_with` | `pixaDisplayRandomCmap()` |
+| `Wshed::render_colors_with` | `wshedRenderColors()` |
+
+引数なしの既存 API は種 1 の新しい系列に委譲する。C で `srand()` を呼ばず
+最初に `rand()` を使った場合と一致するので、現行のアドホック LCG より
+厳密になる。C の 1 本の系列を再現したいテストは `GlibcRand` を 1 つ作って
+全ての呼び出しに渡す。
+
+`tests/core/overlap_reg.rs` に同等の実装がテストローカルで存在するので、
+ライブラリ側に移して重複を解消する。同じ仕組みは `warper_reg` (8 件、
+`srand(seed)` + `rand()` で歪みパラメータを生成) にも使える。
+
 ### PR 37 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。

--- a/docs/porting/c-compat-findings/010-random-cmap-global-rng.md
+++ b/docs/porting/c-compat-findings/010-random-cmap-global-rng.md
@@ -1,8 +1,8 @@
-# C互換性調査 #010: pixaDisplayRandomCmap のグローバル乱数系列 (未解消)
+# C互換性調査 #010: pixaDisplayRandomCmap のグローバル乱数系列 (解消)
 
 plan 902 PR 42 で `watershed_reg` の 22 ペアを張った際、`wshedRenderColors`
 とそれをタイル表示する check (C 10/11 と 22/23 の計 4 件) が Mismatch に
-なった。原因を特定済みで、PR 43 で解消する。
+なった。**PR 43 で解消し、watershed は 22/22 全件 Ok になった。**
 
 ## 症状
 
@@ -47,11 +47,11 @@ Rust の `PixColormap::create_random()` は呼び出しごとに同じ LCG を d
 1 回目 (check 7) は「たまたま」インデックス一致で通り、2 回目以降で
 色が食い違う。
 
-## 対応方針 (PR 43)
+## 対応 (PR 43、実施済み)
 
-グローバル可変状態は入れない。ライブラリ内に glibc 互換の
-`GlibcRand` (TYPE_3 additive-feedback generator。`tests/core/overlap_reg.rs`
-に同等の実装が既にある) を置き、乱数源を引数で明示的に渡せる API を足す:
+グローバル可変状態は入れず、ライブラリ内に glibc 互換の `GlibcRand`
+(TYPE_3 additive-feedback generator) を置き、乱数源を引数で明示的に
+渡せる API を足した:
 
 - `PixColormap::create_random_with(depth, has_black, has_white, &mut rng)`
 - `Pixa::display_random_cmap_with(w, h, &mut rng)`
@@ -61,5 +61,20 @@ Rust の `PixColormap::create_random()` は呼び出しごとに同じ LCG を d
 最初に `rand()` を使った場合と一致する)。C の 1 本の系列を再現したい
 テストは `GlibcRand` を 1 つ作って全ての呼び出しに渡す。
 
+`tests/core/overlap_reg.rs` にあったテストローカルの同等実装は削除し、
+ライブラリの `GlibcRand` に統合した。
+
+## 検証
+
+- 種 1 の先頭 8 値、種 45617 の先頭 5 値が glibc の `rand()` と一致
+- 種 1 から生成したカラーマップが C の check 7 / 19 のパレットと
+  256/256 一致
+- `watershed_c_compat` に 1 本の系列を通して **22/22 全件 Ok**
+
 この仕組みは `warper_reg` (8 件、`srand(seed)` + `rand()` で歪みパラメータを
 生成) にもそのまま使える。
+
+## 落とし穴
+
+C から期待値を採る際、3 つの `rand()` を `printf` の引数に並べると gcc の
+右から左への評価順で出力が逆順になる。値を変数に受けてから表示すること。

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,13 +54,13 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        |    件数 | 説明                                                                                                                                                                          |
 | ----------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **446** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +402)                                                                                              |
-| ⚠️ Mismatch |  **33** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + random cmap 4 件 (finding 010) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)            |
+| ✅ Ok       | **450** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +406)                                                                                              |
+| ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                                             |
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                                                  |
 | 📭 Unmapped | **389** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 393 → 389)                                                                                           |
 | 🚫 Excluded | **100** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 + newspaper random cmap 2 |
 
-合計 968 entries がレポート対象 (As of 2026-08-22、plan 902 PR 42 後)。
+合計 968 entries がレポート対象 (As of 2026-08-22、plan 902 PR 43 後)。
 Rust manifest (`tests/golden_manifest.tsv`) 全体は **975 entries** (コメント 2 行を除く)。
 
 ## test binary 別の内訳
@@ -73,7 +73,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **975 entries** (コメン
 | `io`        |     11 |        2 |        0 |       41 |       13 |
 | `morph`     | **37** |   **16** |        0 |        9 |        0 |
 | `recog`     |     68 |        0 |        0 |       41 |        2 |
-| `region`    | **91** |        6 |        0 |       28 |       29 |
+| `region`    | **95** |        2 |        0 |       28 |       29 |
 | `transform` |    135 |        0 |        0 |       74 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:
@@ -105,7 +105,7 @@ C 版と完全一致している領域:
 第三弾で 4 件)。Phase 3 で **core / io / transform / region** の 4 新
 binary が C 比較対象に組み込まれた。
 
-## Mismatch 33 件の内訳
+## Mismatch 29 件の内訳
 
 ### 修正対象外: 既知の JPEG codec 差 (21 件)
 
@@ -120,14 +120,13 @@ binary が C 比較対象に組み込まれた。
 **JPEG codec 差** (libjpeg-turbo vs jpeg-decoder/jpeg-encoder) と仮説判定
 済み。Rust 実装のアルゴリズムは正しいと推定 (確定検証は別途)。
 
-### Phase 3 以降で可視化 (12 件、要追加調査)
+### Phase 3 以降で可視化 (8 件、要追加調査)
 
-| カテゴリ      | 件数 | 根拠                                                                                                                                                            |
-| ------------- | ---: | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `watershed_c` |    4 | [010](c-compat-findings/010-random-cmap-global-rng.md): `pixcmapCreateRandom` が glibc の共有乱数系列を使うため色が一致しない (plan 902 PR 43 で解消予定)       |
-| `dither`      |    4 | [008](c-compat-findings/008-dither-kernel-and-jpeg-input.md): kernel は修正済み・bit 一致証明済み。残差は JPEG 入力 decode 差 (00/02) + scale LI 実装差 (04/05) |
-| `seedspread`  |    2 | [006](c-compat-findings/006-seedspread-output-diff.md): 仮説段階。6 件のうち 4 件は finding 009 の hash 規約修正で Ok 化済み                                    |
-| `gifio`       |    2 | [007](c-compat-findings/007-gifio-quantization-diff.md): FILE_8BPP_3 / FILE_32BPP の GIF round-trip 差                                                          |
+| カテゴリ     | 件数 | 根拠                                                                                                                                                            |
+| ------------ | ---: | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dither`     |    4 | [008](c-compat-findings/008-dither-kernel-and-jpeg-input.md): kernel は修正済み・bit 一致証明済み。残差は JPEG 入力 decode 差 (00/02) + scale LI 実装差 (04/05) |
+| `seedspread` |    2 | [006](c-compat-findings/006-seedspread-output-diff.md): 仮説段階。6 件のうち 4 件は finding 009 の hash 規約修正で Ok 化済み                                    |
+| `gifio`      |    2 | [007](c-compat-findings/007-gifio-quantization-diff.md): FILE_8BPP_3 / FILE_32BPP の GIF round-trip 差                                                          |
 
 `golden_map.tsv` に semantic マッピングを追加するたび、それまで隠れていた
 出力差が Mismatch として表に出る。各々 finding ドキュメントで仮説を

--- a/docs/porting/comparison/region.md
+++ b/docs/porting/comparison/region.md
@@ -121,14 +121,14 @@ C `L_WSHED` の移植は `region/wshed.rs` (`Wshed`)。`watershed_segmentation` 
 `WatershedResult` は C に対応物のない Rust 独自の便宜 API で、別のアルゴリズムを
 使う。
 
-| C関数             | 状態 | Rust対応               | 備考                                |
-| ----------------- | ---- | ---------------------- | ----------------------------------- |
-| wshedCreate       | ✅   | Wshed::new()           | plan 902 PR 42                      |
-| wshedDestroy      | 🚫   | -                      | C構造体管理: RustではDropで自動解放 |
-| wshedApply        | ✅   | Wshed::apply()         | L_HEAP の sift 手順ごと逐語移植     |
-| wshedBasins       | ✅   | Wshed::basins()        | (&Pixa, &Numa) を返す               |
-| wshedRenderFill   | ✅   | Wshed::render_fill()   | C とビット一致                      |
-| wshedRenderColors | ✅   | Wshed::render_colors() | C とビット一致 (乱数源は引数で渡す) |
+| C関数             | 状態 | Rust対応                    | 備考                                                                |
+| ----------------- | ---- | --------------------------- | ------------------------------------------------------------------- |
+| wshedCreate       | ✅   | Wshed::new()                | plan 902 PR 42                                                      |
+| wshedDestroy      | 🚫   | -                           | C構造体管理: RustではDropで自動解放                                 |
+| wshedApply        | ✅   | Wshed::apply()              | L_HEAP の sift 手順ごと逐語移植                                     |
+| wshedBasins       | ✅   | Wshed::basins()             | (&Pixa, &Numa) を返す                                               |
+| wshedRenderFill   | ✅   | Wshed::render_fill()        | C とビット一致                                                      |
+| wshedRenderColors | ✅   | Wshed::render_colors_with() | C とビット一致。引数なしの render_colors() は種 1 の 1 回目のみ一致 |
 
 ### pixlabel.c
 

--- a/docs/porting/comparison/region.md
+++ b/docs/porting/comparison/region.md
@@ -128,7 +128,7 @@ C `L_WSHED` の移植は `region/wshed.rs` (`Wshed`)。`watershed_segmentation` 
 | wshedApply        | ✅   | Wshed::apply()         | L_HEAP の sift 手順ごと逐語移植     |
 | wshedBasins       | ✅   | Wshed::basins()        | (&Pixa, &Numa) を返す               |
 | wshedRenderFill   | ✅   | Wshed::render_fill()   | C とビット一致                      |
-| wshedRenderColors | 🔄   | Wshed::render_colors() | 乱数系列が C と異なる (finding 010) |
+| wshedRenderColors | ✅   | Wshed::render_colors() | C とビット一致 (乱数源は引数で渡す) |
 
 ### pixlabel.c
 

--- a/src/core/colormap/query.rs
+++ b/src/core/colormap/query.rs
@@ -9,6 +9,7 @@
 use super::{PixColormap, RgbaQuad};
 use crate::core::error::{Error, Result};
 use crate::core::pixel;
+use crate::core::rng::GlibcRand;
 
 /// Component selector for range value queries.
 ///
@@ -64,6 +65,33 @@ impl PixColormap {
     /// # See also
     ///
     /// C Leptonica: `pixcmapCreateRandom()` in `colormap.c`
+    /// Create a colormap with random colors, drawing from `rng`.
+    ///
+    /// C `pixcmapCreateRandom()` calls `rand()`, which advances one
+    /// process-wide stream, so consecutive calls in a C program produce
+    /// *different* colormaps. Pass the same [`GlibcRand`] to every call to
+    /// reproduce that.
+    ///
+    /// # Arguments
+    ///
+    /// * `depth` - Image depth (2, 4, or 8)
+    /// * `has_black` - Add black (0,0,0) at index 0
+    /// * `has_white` - Add white (255,255,255) at last index
+    /// * `rng` - Random source; each color consumes three values
+    ///
+    /// # See also
+    ///
+    /// C Leptonica: `pixcmapCreateRandom()` in `colormap.c`
+    pub fn create_random_with(
+        depth: u32,
+        has_black: bool,
+        has_white: bool,
+        rng: &mut GlibcRand,
+    ) -> Result<Self> {
+        let _ = rng;
+        Self::create_random(depth, has_black, has_white)
+    }
+
     pub fn create_random(depth: u32, has_black: bool, has_white: bool) -> Result<Self> {
         if !matches!(depth, 2 | 4 | 8) {
             return Err(Error::InvalidParameter(format!(
@@ -718,6 +746,41 @@ mod tests {
         assert_eq!(cmap.distance_to_color(0, 10, 20, 30), Some(1400));
         assert_eq!(cmap.distance_to_color(0, 0, 0, 0), Some(0));
         assert_eq!(cmap.distance_to_color(1, 0, 0, 0), None); // out of bounds
+    }
+
+    /// C `pixcmapCreateRandom(8, 1, 1)` fills indices 1..255 with
+    /// `rand() & 0xff` triples and consumes 3 * 254 = 762 values.
+    ///
+    /// Expected colors verified against the palette C wrote in
+    /// `prog/watershed_reg.c` check 7 (all 256 entries matched).
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn test_create_random_with_matches_glibc() {
+        let mut rng = GlibcRand::new(1);
+        let cmap = PixColormap::create_random_with(8, true, true, &mut rng).unwrap();
+        assert_eq!(cmap.len(), 256);
+        assert_eq!(cmap.get_rgb(0).unwrap(), (0, 0, 0));
+        assert_eq!(cmap.get_rgb(1).unwrap(), (103, 198, 105));
+        assert_eq!(cmap.get_rgb(2).unwrap(), (115, 81, 255));
+        assert_eq!(cmap.get_rgb(255).unwrap(), (255, 255, 255));
+
+        // The stream is left just past the 762 values this colormap used, so
+        // a second colormap differs — exactly as consecutive C calls do.
+        let cmap2 = PixColormap::create_random_with(8, true, true, &mut rng).unwrap();
+        assert_eq!(cmap2.get_rgb(1).unwrap(), (30, 168, 172));
+        assert_ne!(cmap2.get_rgb(1).unwrap(), cmap.get_rgb(1).unwrap());
+    }
+
+    /// The argument-free entry point behaves like the first `rand()` call of
+    /// a C program that never calls `srand()`, i.e. seed 1.
+    #[test]
+    fn test_create_random_defaults_to_seed_1() {
+        let a = PixColormap::create_random(8, true, true).unwrap();
+        let mut rng = GlibcRand::new(1);
+        let b = PixColormap::create_random_with(8, true, true, &mut rng).unwrap();
+        for i in 0..256 {
+            assert_eq!(a.get_rgb(i).unwrap(), b.get_rgb(i).unwrap(), "index {i}");
+        }
     }
 
     #[test]

--- a/src/core/colormap/query.rs
+++ b/src/core/colormap/query.rs
@@ -88,11 +88,6 @@ impl PixColormap {
         has_white: bool,
         rng: &mut GlibcRand,
     ) -> Result<Self> {
-        let _ = rng;
-        Self::create_random(depth, has_black, has_white)
-    }
-
-    pub fn create_random(depth: u32, has_black: bool, has_white: bool) -> Result<Self> {
         if !matches!(depth, 2 | 4 | 8) {
             return Err(Error::InvalidParameter(format!(
                 "create_random requires depth 2, 4, or 8, got {depth}"
@@ -106,17 +101,13 @@ impl PixColormap {
             cmap.add_color(RgbaQuad::rgb(0, 0, 0))?;
         }
 
+        // C draws r, g and b as three separate statements, so they come off
+        // the stream in that order.
         let random_count = n - usize::from(has_black) - usize::from(has_white);
-        // Simple deterministic "random" using a linear congruential generator
-        // to avoid depending on rand crate. Seed with depth for variety.
-        let mut state: u32 = 1_103_515_245u32.wrapping_mul(depth).wrapping_add(12345);
         for _ in 0..random_count {
-            state = state.wrapping_mul(1_103_515_245).wrapping_add(12345);
-            let r = ((state >> 16) & 0xff) as u8;
-            state = state.wrapping_mul(1_103_515_245).wrapping_add(12345);
-            let g = ((state >> 16) & 0xff) as u8;
-            state = state.wrapping_mul(1_103_515_245).wrapping_add(12345);
-            let b = ((state >> 16) & 0xff) as u8;
+            let r = rng.next_byte();
+            let g = rng.next_byte();
+            let b = rng.next_byte();
             cmap.add_color(RgbaQuad::rgb(r, g, b))?;
         }
 
@@ -125,6 +116,15 @@ impl PixColormap {
         }
 
         Ok(cmap)
+    }
+
+    pub fn create_random(depth: u32, has_black: bool, has_white: bool) -> Result<Self> {
+        // A C program that never calls `srand()` behaves as if seeded with 1,
+        // so this matches C's *first* `pixcmapCreateRandom()`. Later calls in
+        // the same C program continue the one process-wide stream; use
+        // [`PixColormap::create_random_with`] to reproduce those.
+        let mut rng = GlibcRand::new(1);
+        Self::create_random_with(depth, has_black, has_white, &mut rng)
     }
 
     /// Check if the number of colors is valid for the depth.
@@ -754,7 +754,6 @@ mod tests {
     /// Expected colors verified against the palette C wrote in
     /// `prog/watershed_reg.c` check 7 (all 256 entries matched).
     #[test]
-    #[ignore = "not yet implemented"]
     fn test_create_random_with_matches_glibc() {
         let mut rng = GlibcRand::new(1);
         let cmap = PixColormap::create_random_with(8, true, true, &mut rng).unwrap();

--- a/src/core/colormap/query.rs
+++ b/src/core/colormap/query.rs
@@ -54,17 +54,6 @@ pub struct RangeValues {
 }
 
 impl PixColormap {
-    /// Create a colormap with random colors.
-    ///
-    /// # Arguments
-    ///
-    /// * `depth` - Image depth (2, 4, or 8)
-    /// * `has_black` - Add black (0,0,0) at index 0
-    /// * `has_white` - Add white (255,255,255) at last index
-    ///
-    /// # See also
-    ///
-    /// C Leptonica: `pixcmapCreateRandom()` in `colormap.c`
     /// Create a colormap with random colors, drawing from `rng`.
     ///
     /// C `pixcmapCreateRandom()` calls `rand()`, which advances one
@@ -90,7 +79,7 @@ impl PixColormap {
     ) -> Result<Self> {
         if !matches!(depth, 2 | 4 | 8) {
             return Err(Error::InvalidParameter(format!(
-                "create_random requires depth 2, 4, or 8, got {depth}"
+                "a random colormap requires depth 2, 4, or 8, got {depth}"
             )));
         }
 
@@ -118,6 +107,22 @@ impl PixColormap {
         Ok(cmap)
     }
 
+    /// Create a colormap with random colors.
+    ///
+    /// Equivalent to C's *first* `pixcmapCreateRandom()` in a program that
+    /// never calls `srand()`. Later calls in such a program continue the one
+    /// process-wide `rand()` stream and get different colors; use
+    /// [`PixColormap::create_random_with`] to reproduce those.
+    ///
+    /// # Arguments
+    ///
+    /// * `depth` - Image depth (2, 4, or 8)
+    /// * `has_black` - Add black (0,0,0) at index 0
+    /// * `has_white` - Add white (255,255,255) at last index
+    ///
+    /// # See also
+    ///
+    /// C Leptonica: `pixcmapCreateRandom()` in `colormap.c`
     pub fn create_random(depth: u32, has_black: bool, has_white: bool) -> Result<Self> {
         // A C program that never calls `srand()` behaves as if seeded with 1,
         // so this matches C's *first* `pixcmapCreateRandom()`. Later calls in

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -31,6 +31,7 @@ pub mod pixcomp;
 pub mod pixtiling;
 pub mod pta;
 pub mod ptra;
+pub mod rng;
 pub mod sarray;
 
 pub use bmf::{Bmf, TextLocation, bmf_get_line_strings, bmf_get_string_width, bmf_get_word_widths};
@@ -69,6 +70,7 @@ pub use pixcomp::{PixComp, PixaComp};
 pub use pixtiling::PixTiling;
 pub use pta::{Pta, Ptaa};
 pub use ptra::{Compaction, DownShift, Ptra};
+pub use rng::GlibcRand;
 pub use sarray::{Sarray, Sarraya};
 
 pub mod pixel;

--- a/src/core/pixa/mod.rs
+++ b/src/core/pixa/mod.rs
@@ -1061,6 +1061,30 @@ impl Pixa {
     ///
     /// C equivalent: `pixaDisplayRandomCmap()` in `pixafunc2.c`
     pub fn display_random_cmap(&self, w: u32, h: u32) -> Result<Pix> {
+        // A C program that never calls `srand()` behaves as if seeded with 1,
+        // so this matches C's *first* call. Later calls in the same C program
+        // continue the one process-wide stream; use
+        // [`Pixa::display_random_cmap_with`] to reproduce those.
+        let mut rng = crate::core::GlibcRand::new(1);
+        self.display_random_cmap_with(w, h, &mut rng)
+    }
+
+    /// Same as [`Pixa::display_random_cmap`], but drawing the colormap from
+    /// `rng`.
+    ///
+    /// C `pixaDisplayRandomCmap()` builds its colormap with
+    /// `pixcmapCreateRandom()`, which reads glibc's single process-wide
+    /// `rand()` stream. Consecutive calls in a C program therefore get
+    /// *different* colormaps. Pass the same [`GlibcRand`](crate::core::GlibcRand)
+    /// to every call to reproduce that.
+    ///
+    /// C equivalent: `pixaDisplayRandomCmap()` in `pixafunc2.c`
+    pub fn display_random_cmap_with(
+        &self,
+        w: u32,
+        h: u32,
+        rng: &mut crate::core::GlibcRand,
+    ) -> Result<Pix> {
         use crate::core::pix::{PixelDepth, RopOp};
 
         if self.pix.is_empty() {
@@ -1088,8 +1112,8 @@ impl Pixa {
 
         let pixd = Pix::new(w, h, PixelDepth::Bit8)?;
         let mut dm = pixd.try_into_mut().unwrap();
-        dm.set_colormap(Some(crate::core::PixColormap::create_random(
-            8, true, true,
+        dm.set_colormap(Some(crate::core::PixColormap::create_random_with(
+            8, true, true, rng,
         )?))?;
 
         for (i, pixs) in self.pix.iter().enumerate() {

--- a/src/core/rng.rs
+++ b/src/core/rng.rs
@@ -1,0 +1,172 @@
+//! glibc-compatible pseudo-random generator.
+//!
+//! Several C Leptonica routines draw from `rand()` — `pixcmapCreateRandom()`
+//! for random colormaps, `pixRandomHarmonicWarp()` for warp parameters, and
+//! the `prog/*_reg.c` programs that synthesise their own inputs. Reproducing
+//! their output bit for bit means reproducing glibc's generator, not just
+//! "some" pseudo-random sequence.
+//!
+//! # Why the sequence has to be passed around
+//!
+//! In C, `rand()` reads and advances one process-wide stream. A program that
+//! calls `pixaDisplayRandomCmap()` four times gets four *different* colormaps,
+//! each continuing where the last stopped. Rust code that re-seeds per call
+//! would return the same colormap every time and diverge from C after the
+//! first call.
+//!
+//! Rather than introduce global mutable state, the C-compatible entry points
+//! take `&mut GlibcRand` (see [`crate::core::PixColormap::create_random_with`]
+//! and [`crate::core::Pixa::display_random_cmap_with`]). Reproducing a whole
+//! C program means creating one generator and threading it through every call
+//! in the same order.
+
+/// glibc's `rand()`, the TYPE_3 additive-feedback generator.
+///
+/// `GlibcRand::new(seed)` corresponds to `srand(seed)`. A C program that
+/// never calls `srand()` behaves as if seeded with 1.
+///
+/// # Examples
+///
+/// ```
+/// use leptonica::core::GlibcRand;
+///
+/// // The classic glibc sequence for seed 1.
+/// let mut rng = GlibcRand::new(1);
+/// assert_eq!(rng.next_u32(), 1_804_289_383);
+/// assert_eq!(rng.next_u32(), 846_930_886);
+/// ```
+#[derive(Debug, Clone)]
+pub struct GlibcRand {
+    /// Ring over the last 31 values of the recurrence.
+    r: [u32; DEG],
+    /// Position of `r[i - 31]` for the next output.
+    pos: usize,
+}
+
+/// Degree of the feedback polynomial (glibc `DEG_3`).
+const DEG: usize = 31;
+/// Separation of the feedback tap (glibc `SEP_3`).
+const SEP: usize = 3;
+/// Outputs glibc discards after seeding (`10 * DEG_3`).
+const DISCARD: usize = 10 * DEG;
+
+impl GlibcRand {
+    /// Seed the generator, equivalent to C `srand(seed)`.
+    pub fn new(seed: u32) -> Self {
+        // glibc seeds 31 words with a Lehmer generator, mirrors the first
+        // three, then runs the additive recurrence for 310 discarded steps.
+        let mut r = vec![0u32; DEG + SEP + DISCARD];
+        r[0] = seed;
+        for i in 1..DEG {
+            // r[i] = (16807 * r[i-1]) % 2147483647, via Schrage's trick to
+            // stay inside 32 bits.
+            let prev = i64::from(r[i - 1]);
+            let hi = prev / 127_773;
+            let lo = prev % 127_773;
+            let mut word = 16_807 * lo - 2_836 * hi;
+            if word < 0 {
+                word += 2_147_483_647;
+            }
+            r[i] = word as u32;
+        }
+        for i in DEG..DEG + SEP {
+            r[i] = r[i - DEG];
+        }
+        for i in DEG + SEP..r.len() {
+            r[i] = r[i - DEG].wrapping_add(r[i - SEP]);
+        }
+
+        // Keep only the last DEG values. The next output needs r[len - DEG]
+        // and r[len - SEP], which are the first and the SEP-th-from-last
+        // entries of that window, so the read position starts at 0.
+        let mut ring = [0u32; DEG];
+        ring.copy_from_slice(&r[r.len() - DEG..]);
+        Self { r: ring, pos: 0 }
+    }
+
+    /// Produce the next value, equivalent to C `rand()`.
+    ///
+    /// Named `next_u32` rather than `next` so it is not mistaken for
+    /// [`Iterator::next`].
+    ///
+    /// The result is in `0..=RAND_MAX` (`i32::MAX`).
+    pub fn next_u32(&mut self) -> u32 {
+        // r[i] = r[i - DEG] + r[i - SEP]; the output is the high 31 bits.
+        let back = self.r[self.pos];
+        let tap = self.r[(self.pos + DEG - SEP) % DEG];
+        let v = back.wrapping_add(tap);
+        self.r[self.pos] = v;
+        self.pos = (self.pos + 1) % DEG;
+        v >> 1
+    }
+
+    /// The low byte of the next value, as C's colormap code uses it
+    /// (`(l_uint32)rand() & 0xff`).
+    pub fn next_byte(&mut self) -> u8 {
+        (self.next_u32() & 0xff) as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The first outputs of glibc `rand()` after `srand(1)`, which is also
+    /// the state a C program starts in when it never calls `srand()`.
+    /// Values taken from a C program compiled against glibc.
+    #[test]
+    fn test_matches_glibc_seed_1() {
+        let mut rng = GlibcRand::new(1);
+        let got: Vec<u32> = (0..8).map(|_| rng.next_u32()).collect();
+        assert_eq!(
+            got,
+            vec![
+                1_804_289_383,
+                846_930_886,
+                1_681_692_777,
+                1_714_636_915,
+                1_957_747_793,
+                424_238_335,
+                719_885_386,
+                1_649_760_492,
+            ]
+        );
+    }
+
+    /// `overlap_reg.c` uses `srand(45617)`; values dumped from C.
+    #[test]
+    fn test_matches_glibc_seed_45617() {
+        let mut rng = GlibcRand::new(45617);
+        let got: Vec<u32> = (0..5).map(|_| rng.next_u32()).collect();
+        assert_eq!(
+            got,
+            vec![
+                1_484_474_668,
+                554_040_094,
+                799_607_895,
+                760_240_358,
+                155_811_871
+            ]
+        );
+    }
+
+    /// The stream must keep advancing across long runs: a colormap consumes
+    /// 3 * 254 = 762 values, and the next caller continues from there. Both
+    /// figures come from C.
+    #[test]
+    fn test_stream_advances_across_a_full_colormap() {
+        let mut rng = GlibcRand::new(1);
+        let sum: u32 = (0..762).map(|_| u32::from(rng.next_byte())).sum();
+        assert_eq!(sum, 99_666, "low-byte sum of the first 762 values");
+
+        // C, with the three calls sequenced into separate statements —
+        // passing them as printf arguments prints them in gcc's
+        // right-to-left evaluation order, which is not the stream order.
+        let second: Vec<u8> = (0..3).map(|_| rng.next_byte()).collect();
+        assert_eq!(
+            second,
+            vec![30, 168, 172],
+            "first RGB of the second colormap"
+        );
+    }
+}

--- a/src/core/rng.rs
+++ b/src/core/rng.rs
@@ -55,7 +55,8 @@ impl GlibcRand {
     pub fn new(seed: u32) -> Self {
         // glibc seeds 31 words with a Lehmer generator, mirrors the first
         // three, then runs the additive recurrence for 310 discarded steps.
-        let mut r = vec![0u32; DEG + SEP + DISCARD];
+        const LEN: usize = DEG + SEP + DISCARD;
+        let mut r = [0u32; LEN];
         r[0] = seed;
         for i in 1..DEG {
             // r[i] = (16807 * r[i-1]) % 2147483647, via Schrage's trick to
@@ -72,15 +73,15 @@ impl GlibcRand {
         for i in DEG..DEG + SEP {
             r[i] = r[i - DEG];
         }
-        for i in DEG + SEP..r.len() {
+        for i in DEG + SEP..LEN {
             r[i] = r[i - DEG].wrapping_add(r[i - SEP]);
         }
 
-        // Keep only the last DEG values. The next output needs r[len - DEG]
-        // and r[len - SEP], which are the first and the SEP-th-from-last
+        // Keep only the last DEG values. The next output needs r[LEN - DEG]
+        // and r[LEN - SEP], which are the first and the SEP-th-from-last
         // entries of that window, so the read position starts at 0.
         let mut ring = [0u32; DEG];
-        ring.copy_from_slice(&r[r.len() - DEG..]);
+        ring.copy_from_slice(&r[LEN - DEG..]);
         Self { r: ring, pos: 0 }
     }
 

--- a/src/region/wshed.rs
+++ b/src/region/wshed.rs
@@ -21,12 +21,13 @@
 //! is reproduced here rather than corrected, because agreeing with C is the
 //! point of the port.
 //!
-//! [`Wshed::render_colors`] is the exception. It tints the basins with
-//! [`Pixa::display_random_cmap`], whose colormap comes from a per-call
-//! generator, while C's `pixcmapCreateRandom()` draws from glibc's single
-//! process-wide `rand()` stream. The basin masks are identical but the
-//! colours are not, so `render_colors` output does not match C today. See
-//! `docs/porting/c-compat-findings/010-random-cmap-global-rng.md`.
+//! [`Wshed::render_colors`] matches too, but only when the random colormap
+//! is drawn from the right place in the sequence. C's `pixcmapCreateRandom()`
+//! reads glibc's single process-wide `rand()` stream, so a program that also
+//! calls `pixaDisplayRandomCmap()` elsewhere shifts the colours here. Use
+//! [`Wshed::render_colors_with`] and thread one
+//! [`GlibcRand`](crate::core::GlibcRand) through every call in program order.
+//! See `docs/porting/c-compat-findings/010-random-cmap-global-rng.md`.
 
 use crate::core::pta::pix_generate_from_pta;
 use crate::core::{Box, Numa, Pix, Pixa, PixelDepth, Pta};
@@ -599,6 +600,24 @@ impl Wshed {
     ///
     /// C Leptonica: `wshedRenderColors()` in `watershed.c`
     pub fn render_colors(&self) -> RegionResult<Pix> {
+        // Matches C's *first* call in a program; see `render_colors_with`.
+        let mut rng = crate::core::GlibcRand::new(1);
+        self.render_colors_with(&mut rng)
+    }
+
+    /// Same as [`Wshed::render_colors`], but drawing the basin colours from
+    /// `rng`.
+    ///
+    /// C `wshedRenderColors()` tints the basins with
+    /// `pixaDisplayRandomCmap()`, whose colormap comes from glibc's single
+    /// process-wide `rand()` stream. Reproducing a C program that also calls
+    /// `pixaDisplayRandomCmap()` elsewhere means threading the same
+    /// [`GlibcRand`](crate::core::GlibcRand) through every call in order.
+    ///
+    /// # See also
+    ///
+    /// C Leptonica: `wshedRenderColors()` in `watershed.c`
+    pub fn render_colors_with(&self, rng: &mut crate::core::GlibcRand) -> RegionResult<Pix> {
         let (w, h) = (self.w, self.h);
         let pixd = self.pixs.convert_to_32().map_err(RegionError::Core)?;
         if self.pixad.is_empty() {
@@ -611,7 +630,7 @@ impl Wshed {
         }
         let pixt = self
             .pixad
-            .display_random_cmap(w, h)
+            .display_random_cmap_with(w, h, rng)
             .map_err(RegionError::Core)?;
         let pixc = pixt.convert_to_32().map_err(RegionError::Core)?;
         let pixm = self.pixad.display(w, h).map_err(RegionError::Core)?;

--- a/tests/core/overlap_reg.rs
+++ b/tests/core/overlap_reg.rs
@@ -12,6 +12,7 @@
 //! C Leptonica: `prog/overlap_reg.c`
 
 use crate::common::{RegParams, load_test_image};
+use leptonica::core::GlibcRand;
 use leptonica::{Box, Boxa};
 
 /// Test combine_overlaps: boxes that overlap are merged into bounding regions.
@@ -220,49 +221,20 @@ fn texturefill_reg_fill() {
     //    pixTextureFillMap(pixa, boxa, ...);
 }
 
-/// Reproduces glibc's `rand()` (the TYPE_3 additive-feedback generator), so
-/// the test can build exactly the same pseudo-random boxes that C's
-/// `overlap_reg` does. Without this the inputs — and therefore every output —
-/// would differ.
-struct GlibcRand {
-    state: Vec<u32>,
-    idx: usize,
-}
+/// `overlap_reg.c` builds every box from `srand(45617)` plus glibc's
+/// `rand()`, so the inputs — and therefore every output — depend on
+/// reproducing that generator. [`GlibcRand`] does; this wraps the scaling
+/// idiom the C program uses at each call site.
+struct ScaledRand(GlibcRand);
 
-impl GlibcRand {
+impl ScaledRand {
     fn new(seed: u32) -> Self {
-        let mut r = vec![0u32; 344];
-        r[0] = seed;
-        for i in 1..31 {
-            // r[i] = (16807 * r[i-1]) % 2147483647, via Schrage's trick.
-            let prev = r[i - 1] as i64;
-            let hi = prev / 127_773;
-            let lo = prev % 127_773;
-            let mut word = 16_807 * lo - 2_836 * hi;
-            if word < 0 {
-                word += 2_147_483_647;
-            }
-            r[i] = word as u32;
-        }
-        for i in 31..34 {
-            r[i] = r[i - 31];
-        }
-        for i in 34..344 {
-            r[i] = r[i - 31].wrapping_add(r[i - 3]);
-        }
-        Self { state: r, idx: 344 }
-    }
-
-    fn next(&mut self) -> u32 {
-        let v = self.state[self.idx - 31].wrapping_add(self.state[self.idx - 3]);
-        self.state.push(v);
-        self.idx += 1;
-        v >> 1
+        Self(GlibcRand::new(seed))
     }
 
     /// C: `(l_int32)(scale * (l_float64)rand() / (l_float64)RAND_MAX)`
     fn scaled(&mut self, scale: f64) -> i32 {
-        (scale * self.next() as f64 / 2_147_483_647.0) as i32
+        (scale * self.0.next_u32() as f64 / 2_147_483_647.0) as i32
     }
 }
 
@@ -332,9 +304,9 @@ fn overlap_c_compat() {
     // C 0-6: percolation-style display at each maximum box size. C re-seeds
     // at the top of every iteration, so the generator is left 2000 draws past
     // the seed when the loop ends — the later blocks continue from there.
-    let mut rng = GlibcRand::new(45617);
+    let mut rng = ScaledRand::new(45617);
     for &maxsize in MAXSIZE.iter() {
-        rng = GlibcRand::new(45617);
+        rng = ScaledRand::new(45617);
         let mut pixa1 = Pixa::new();
         let mut boxa1 = Boxa::new();
         for _ in 0..500 {

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -649,9 +649,9 @@ newspaper_c.06.tif	cf1d3985de869e97
 newspaper_c.07.tif	01c4f43215f80127
 newspaper_c.08.tif	4216efe2a572d64d
 newspaper_c.09.tif	ed5159c3e38ac54b
-newspaper_c.10.png	8f053aa17b9a357e
+newspaper_c.10.png	80973652156f94e6
 newspaper_c.11.png	1687ac003fe74482
-newspaper_c.12.png	aa32b26446a0ceef
+newspaper_c.12.png	c594c4ef90c4b090
 newspaper_lines.03.tif	30620ceb35782ebc
 newspaper_removal.05.tif	c117aea8f18571ad
 newspaper_scale.03.png	621e15c491d8ef3e
@@ -936,8 +936,8 @@ watershed_c.06.png	b570752c8b60e4cc
 watershed_c.08.png	a79d1d877c2e3469
 watershed_c.09.na	6baff1e7e113a19d
 watershed_c.10.png	0c7ec17b7c8cc0f2
-watershed_c.11.png	ff8a940f609b6a43
-watershed_c.12.png	2b38e6e08afd270a
+watershed_c.11.png	2d063c0e5ec093f4
+watershed_c.12.png	63e3817f11f1843f
 watershed_c.13.png	f048ad07310f67e7
 watershed_c.14.png	0daa11e043677024
 watershed_c.15.png	bd6ae5cc5afebfbc
@@ -947,8 +947,8 @@ watershed_c.18.png	b570752c8b60e4cc
 watershed_c.20.png	e9b4bf6cd5ad88e6
 watershed_c.21.na	41f2c455027d86f3
 watershed_c.22.png	0ea4570ed96d26bd
-watershed_c.23.png	16e7e229e9e5deae
-watershed_c.24.png	7b7c4085c4f013e5
+watershed_c.23.png	63f675260fb717eb
+watershed_c.24.png	14310a73a1652dc6
 watershed_gradient.05.png	ecc0b15f4960923d
 watershed_gradient.07.png	4b250d323a25fd07
 watershed_gradient.09.png	4b250d323a25fd07

--- a/tests/region/watershed_reg.rs
+++ b/tests/region/watershed_reg.rs
@@ -262,9 +262,9 @@ fn watershed_error_handling() {
 /// C-compatible port of `DoWatershed()` in `prog/watershed_reg.c`, covering
 /// every check it emits (C indices 0-11 and 12-23).
 ///
-/// Checks 10/11 and 22/23 currently mismatch C: they carry the colours from
-/// `pixaDisplayRandomCmap`, whose colormap comes from a per-call generator
-/// here but from glibc's single process-wide `rand()` stream in C. See
+/// The colours in checks 7/10 and 19/22 come from `pixaDisplayRandomCmap`,
+/// which in C draws from one process-wide `rand()` stream. `rng` carries that
+/// stream across all four calls; see
 /// `docs/porting/c-compat-findings/010-random-cmap-global-rng.md`.
 fn do_watershed_c(rp: &mut crate::common::RegParams, pixs: &Pix, rng: &mut GlibcRand) {
     use leptonica::core::Pixa;

--- a/tests/region/watershed_reg.rs
+++ b/tests/region/watershed_reg.rs
@@ -9,6 +9,7 @@
 //! 4. Error handling for invalid input depths
 
 use crate::common::RegParams;
+use leptonica::core::GlibcRand;
 use leptonica::io::ImageFormat;
 use leptonica::region::{
     ConnectivityType, WatershedOptions, compute_gradient, find_local_maxima, find_local_minima,
@@ -265,7 +266,7 @@ fn watershed_error_handling() {
 /// `pixaDisplayRandomCmap`, whose colormap comes from a per-call generator
 /// here but from glibc's single process-wide `rand()` stream in C. See
 /// `docs/porting/c-compat-findings/010-random-cmap-global-rng.md`.
-fn do_watershed_c(rp: &mut crate::common::RegParams, pixs: &Pix) {
+fn do_watershed_c(rp: &mut crate::common::RegParams, pixs: &Pix, rng: &mut GlibcRand) {
     use leptonica::core::Pixa;
     use leptonica::core::pix::InitColor;
     use leptonica::core::pixel::compose_rgba;
@@ -342,7 +343,7 @@ fn do_watershed_c(rp: &mut crate::common::RegParams, pixs: &Pix) {
     wshed.apply().expect("wshed apply");
     let (pixad, nalevels) = wshed.basins();
     let pix6 = pixad
-        .display_random_cmap(w, h)
+        .display_random_cmap_with(w, h, rng)
         .expect("display_random_cmap");
     // 7
     rp.write_pix_and_check(&pix6, ImageFormat::Png)
@@ -354,7 +355,7 @@ fn do_watershed_c(rp: &mut crate::common::RegParams, pixs: &Pix) {
     // 9
     rp.write_pix_and_check(&pix7, ImageFormat::Png)
         .expect("write render_fill");
-    let pix8 = wshed.render_colors().expect("render_colors");
+    let pix8 = wshed.render_colors_with(rng).expect("render_colors");
     // 10
     rp.write_pix_and_check(&pix8, ImageFormat::Png)
         .expect("write render_colors");
@@ -376,10 +377,17 @@ fn do_watershed_c(rp: &mut crate::common::RegParams, pixs: &Pix) {
 fn watershed_c_compat() {
     let mut rp = crate::common::RegParams::new("watershed_c");
 
+    // C draws every random colormap from one process-wide `rand()` stream,
+    // seeded implicitly with 1 because `watershed_reg.c` never calls
+    // `srand()`. The four `pixaDisplayRandomCmap()` calls (check 7 and the
+    // one inside `wshedRenderColors` for each image) therefore use four
+    // different stretches of it. Thread a single generator through them all.
+    let mut rng = GlibcRand::new(1);
+
     let pix1 = create_synthetic_image(0);
-    do_watershed_c(&mut rp, &pix1);
+    do_watershed_c(&mut rp, &pix1, &mut rng);
     let pix2 = create_synthetic_image(1);
-    do_watershed_c(&mut rp, &pix2);
+    do_watershed_c(&mut rp, &pix2, &mut rng);
 
     assert!(rp.cleanup(), "watershed c-compat test failed");
 }


### PR DESCRIPTION
## Why

finding 010 の解消。PR 42 で残った `watershed` の 4 ペア (C check 10/11/22/23)
を Ok にする。

C `pixcmapCreateRandom()` は glibc の `rand()` を読むが、これは**プロセス
全体で共有される 1 本の系列**で、`srand()` が呼ばれなければ種は 1。
`watershed_reg.c` は `pixaDisplayRandomCmap` を 4 回実行し (各 762 個消費)、
それぞれ系列の異なる位置を使う。Rust 側は呼び出しごとに同じ LCG を depth
から初期化していたため、2 回目以降で色が食い違っていた。

check 7/19 が一致していたのは、ピクセルハッシュがカラーマップではなく
インデックスを対象にするため。`wshedRenderColors` が色を 32bpp に焼き込んで
初めて差が出る。

## What

グローバル可変状態は入れず、乱数源を引数で明示的に渡す。

| 追加 | 対応する C |
| --- | --- |
| `core::GlibcRand` | glibc `rand()` (TYPE_3 additive-feedback) |
| `PixColormap::create_random_with` | `pixcmapCreateRandom()` |
| `Pixa::display_random_cmap_with` | `pixaDisplayRandomCmap()` |
| `Wshed::render_colors_with` | `wshedRenderColors()` |

引数なしの既存 API は種 1 の新しい系列に委譲する。C で `srand()` を呼ばず
最初に `rand()` を使った場合と一致するので、アドホックな LCG を使っていた
従来より厳密になる。

`tests/core/overlap_reg.rs` にあったテストローカルの glibc 乱数実装は削除し、
ライブラリの `GlibcRand` に統合した。

### 検証

- 種 1 の先頭 8 値、種 45617 の先頭 5 値が glibc の `rand()` と一致
  (glibc でコンパイルした C から採取)
- 種 1 から生成したカラーマップが C の check 7 / 19 のパレットと
  **256/256 一致**
- `watershed_c_compat` に 1 本の系列を通して **22/22 全件 Ok**

### 落とし穴

C から期待値を採る際、3 つの `rand()` を `printf` の引数に並べると gcc の
右から左への評価順で出力が逆順になる。最初この形で採った期待値がテストを
誤らせた (実装は正しかった)。値を変数に受けてから表示すること。finding と
plan の両方に記録した。

## Impact

- **watershed 22/22 全件 Ok** (Ok 446 → 450、region 91 → 95)
- **Mismatch 33 → 29** (finding 010 の 4 件を解消)
- `create_random` / `display_random_cmap` の色が変わるため、`watershed_c` と
  `newspaper_c` の golden hash を再生成。`newspaper` の 2 件は色以外の理由
  (スケーリング時の colormap 展開) でも除外されているため Excluded のまま
- `GlibcRand` は `warper_reg` (8 件、`srand(seed)` + `rand()` で歪みパラメータ
  を生成) にもそのまま使える

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMdj14c397rffZ6NZLJg