### PR TITLE
ccbord の .ccb シリアライズ往復 — 4 ペア全件 Ok (plan 902 PR 45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ src/
 - ランタイムレポート: `tests/c_compat_report.<binary>.txt`（.gitignore）。
   Rust 出力 hash と C manifest を `scripts/golden_map.tsv` 経由で照合し、
   `Ok / Mismatch / MissingC / Unmapped / Excluded` を記録
-- 現状ベースライン (As of 2026-08-22 実測、plan 902 PR 44 後):
+- 現状ベースライン (As of 2026-08-22 実測、plan 902 PR 45 後):
   `docs/porting/c-compat-status.md` に詳細。
-  **Ok 456 / Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100**
+  **Ok 460 / Mismatch 29 / MissingC 0 / Unmapped 389 / Excluded 100**
 - 除外ルール: `scripts/c_compat_exclude.tsv` (plan 902)。設計上マップ不能な
   キー (JPEG codec 差、非決定的形式) を Unmapped から Excluded に分離
 - 環境変数: `REGTEST_C_COMPAT=off` で無効化、`=strict` で Mismatch を fail

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,10 @@ webp-format = ["image-webp"]
 jp2k-format = ["hayro-jpeg2000"]
 pdf-format  = ["pdf-writer", "miniz_oxide"]
 ps-format   = ["miniz_oxide"]
+ccb-format  = ["miniz_oxide"]
 all-formats = ["bmp", "pnm", "png-format", "jpeg", "gif-format",
                "tiff-format", "webp-format", "jp2k-format",
-               "pdf-format", "ps-format"]
+               "pdf-format", "ps-format", "ccb-format"]
 
 [profile.dev]
 opt-level = 1

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -1416,7 +1416,7 @@ C `nextOnPixelInRasterLow()` は走査を `(xstart, ystart)` から始めるた�
 境界追跡そのもの (位置テーブルによる次画素探索、ステップチェーン、
 seedfill による再構成) には実装差がなかった。
 
-### PR 45: ccbord の `.ccb` シリアライズ往復 (計画)
+### PR 45: ccbord の `.ccb` シリアライズ往復 (実施済み)
 
 C 版ソース: `prog/ccbord_reg.c` の check 3,4 / 10,11。PR 44 で作った
 `CCBORDA` を `.ccb` ファイルに書き出して読み戻し、境界描画 (3,10) と
@@ -1476,6 +1476,24 @@ ccbord.02`、`ccbord.10 == ccbord.07`、`ccbord.11 == ccbord.09`。往復が
 | 8x6 に 3x2 塊と孤立点 | 2 | `4 4 6 0 0 2` / なし | `44 60 02 88` / `88` |
 | 9x9 の 5x5 リング | 1 (穴 1) | 外周 16 個 / 穴 12 個 | 各 `88` |
 | 5x5 の L 字 3 画素 | 1 | `4 7 2` (奇数) | `47 28` |
+
+実施結果:
+
+- **4 ペア全件 Ok** (Ok 456 → 460、region 101 → 105)。実装差は 0 件
+- `feyn-fract.tif` (464 成分、38272 バイト) と `dreyfus1.png`
+  (290 成分、40987 バイト) で、C の `ccbaWrite()` が出す非圧縮ペイロード
+  と Rust の `to_bytes()` がバイト完全一致することを確認した
+- `ccbord_c_compat` の check が 2 つずつ増えたので、dreyfus1 側の Rust
+  index が 4-6 から 6-10 にずれた。`golden_map.tsv` と manifest を更新
+
+**C との意図的な差異** (いずれも rustdoc に記載):
+
+- `to_bytes()` はステップチェーン未生成をエラーにする。C は黙って
+  `ccbaGenerateStepChains()` を呼ぶが、同じモジュールの
+  `step_chains_to_pix_coords` がエラーを返す方針なので揃えた
+- `from_bytes()` は全読み出しを境界検査する。C の `ccbaReadStream()` は
+  ファイル中の個数を信用して `memcpy` するため、切り詰められた入力で
+  バッファ外を読む。個数からの事前確保もしない
 
 ### PR 37 以降: semantic マッピングの漸進追加
 

--- a/docs/plans/902_c-compat-unmapped-reduction.md
+++ b/docs/plans/902_c-compat-unmapped-reduction.md
@@ -1416,6 +1416,67 @@ C `nextOnPixelInRasterLow()` は走査を `(xstart, ystart)` から始めるた�
 境界追跡そのもの (位置テーブルによる次画素探索、ステップチェーン、
 seedfill による再構成) には実装差がなかった。
 
+### PR 45: ccbord の `.ccb` シリアライズ往復 (計画)
+
+C 版ソース: `prog/ccbord_reg.c` の check 3,4 / 10,11。PR 44 で作った
+`CCBORDA` を `.ccb` ファイルに書き出して読み戻し、境界描画 (3,10) と
+画像再構成 (4,11) をやり直す。
+
+移植する C 関数:
+
+| C 関数 | 役割 |
+| --- | --- |
+| `ccbaWriteStream` | ステップチェーン表現を直列化して zlib 圧縮 |
+| `ccbaReadStream` | zlib 展開して直列化データを復元 |
+
+`ccbaWrite` / `ccbaRead` はファイルを開閉するだけの薄い包みなので移植
+しない。`std::fs::write(path, ccba.to_bytes()?)` /
+`CcBorda::from_bytes(&std::fs::read(path)?)` で足りる。`RegionError` に
+`Io` を足さずに済む利点もある。
+
+**形式** (C の doc comment より、実測で確認済み):
+
+```text
+"ccba: %7d cc\n" を 18 バイト  (17 文字 + snprintf の NUL)
+pix width   4B
+pix height  4B
+[成分ごと]
+    ulx 4B / uly 4B / w 4B / h 4B     (w,h は復元に不要だが書かれる)
+    境界数 nb 4B
+    [境界ごと]
+        startx 4B / starty 4B
+        ステップ 2 個を 1 バイトに詰める (上位ニブルが先)
+        終端 1B: n が奇数なら 0xz8 (z = 最後の値)、偶数なら 0x88
+```
+
+全体を zlib 圧縮する。整数は C が native order で書くため、x86 に
+合わせてリトルエンディアンで実装する。
+
+**復元されないもの**: `local` / `global` 座標と穴の bounding box
+(`boxa` の index 1 以降)。読み戻した `CcBorda` は `boxa[0]` / `start` /
+`step` だけを持ち、座標は `step_chains_to_pix_coords` で作り直す。
+C の reg test がまさにその順序で呼ぶ。
+
+**zlib 依存**: `miniz_oxide` は既に optional 依存 (`pdf-format` /
+`ps-format`)。`.ccb` は 1 つのファイル形式なので、他の形式と同じ流儀で
+`ccb-format` feature を足して `all-formats` に含める。テスト
+`ccbord_c_compat` は feature ごと gate する (一部の check だけ落とすと
+check 番号がずれて manifest が壊れるため)。`tests/core/pixa_select_to_pdf_reg.rs`
+が `#![cfg(feature = "pdf-format")]` で同じことをしている前例。
+
+**期待値**: C manifest では `ccbord.03 == ccbord.00`、`ccbord.04 ==
+ccbord.02`、`ccbord.10 == ccbord.07`、`ccbord.11 == ccbord.09`。往復が
+無損失なら自動的に一致するので、この 4 ペアは「往復でデータが落ちない」
+ことの検証になる。
+
+**RED に使う C 実測値** (`ccbaWrite` の出力を `zlibUncompress` して採取):
+
+| 図形 | 成分 | ステップ列 | 終端バイト |
+| --- | --- | --- | --- |
+| 8x6 に 3x2 塊と孤立点 | 2 | `4 4 6 0 0 2` / なし | `44 60 02 88` / `88` |
+| 9x9 の 5x5 リング | 1 (穴 1) | 外周 16 個 / 穴 12 個 | 各 `88` |
+| 5x5 の L 字 3 画素 | 1 | `4 7 2` (奇数) | `47 28` |
+
 ### PR 37 以降: semantic マッピングの漸進追加
 
 Phase 3 と同じ進め方 (1 PR あたり 5〜20 ペア + 必要に応じて finding)。

--- a/docs/porting/c-compat-status.md
+++ b/docs/porting/c-compat-status.md
@@ -54,14 +54,14 @@ Phase 1 / Phase 1.5 / Phase 2 / Phase 2.5 / Phase 3 (一連の PR #377〜) で
 
 | 状態        |    件数 | 説明                                                                                                                                                                          |
 | ----------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Ok       | **456** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +412)                                                                                              |
+| ✅ Ok       | **460** | C 版と pixel-level 完全一致 (Phase 2.5 で +10、Phase 3 で +12、plan 902 で +416)                                                                                              |
 | ⚠️ Mismatch |  **29** | 内訳: JPEG codec 差 21 件 (finding 001) + dither 4 件 (finding 008) + seedspread 2 件 (finding 006 残) + gifio 2 件 (finding 007)                                             |
 | ⛔ MissingC |   **0** | (PR #381 / Phase 1.5 で解消)                                                                                                                                                  |
 | 📭 Unmapped | **389** | `scripts/golden_map.tsv` 未登録かつマップ可能 (Phase 3 進行中、520 → … → 393 → 389)                                                                                           |
 | 🚫 Excluded | **100** | 設計上マップ不能 (`scripts/c_compat_exclude.tsv`)。jpg/jpeg 45 + pdf/ps 8 + distance 系 26 + falsecolor 4 + iomisc alpha blend 3 + boxa3 display 12 + newspaper random cmap 2 |
 
-合計 974 entries がレポート対象 (As of 2026-08-22、plan 902 PR 44 後)。
-Rust manifest (`tests/golden_manifest.tsv`) 全体は **981 entries** (コメント 2 行を除く)。
+合計 978 entries がレポート対象 (As of 2026-08-22、plan 902 PR 45 後)。
+Rust manifest (`tests/golden_manifest.tsv`) 全体は **985 entries** (コメント 2 行を除く)。
 
 ## test binary 別の内訳
 
@@ -73,7 +73,7 @@ Rust manifest (`tests/golden_manifest.tsv`) 全体は **981 entries** (コメン
 | `io`        |      11 |        2 |        0 |       41 |       13 |
 | `morph`     |  **37** |   **16** |        0 |        9 |        0 |
 | `recog`     |      68 |        0 |        0 |       41 |        2 |
-| `region`    | **101** |    **2** |        0 |       28 |       29 |
+| `region`    | **105** |    **2** |        0 |       28 |       29 |
 | `transform` |     135 |        0 |        0 |       74 |        0 |
 
 **morph** が現状最も Ok/Mismatch が集中している binary。これは:

--- a/docs/porting/comparison/region.md
+++ b/docs/porting/comparison/region.md
@@ -47,25 +47,27 @@ Rust 独自の便宜 API で、表現も直列化形式も C とは異なる。
 
 #### region/ccborda.rs (ccbord.c) — C 対応の移植
 
-| C関数                     | 状態 | Rust対応                            | 備考                      |
-| ------------------------- | ---- | ----------------------------------- | ------------------------- |
-| pixGetAllCCBorders        | ✅   | CcBorda::from_pix                   | plan 902 PR 44            |
-| pixGetCCBorders           | ✅   | cc_borders (private)                | -                         |
-| pixGetOuterBorder         | ✅   | get_outer_border (private)          | -                         |
-| pixGetHoleBorder          | ✅   | get_hole_border (private)           | -                         |
-| findNextBorderPixel       | ✅   | find_next_border_pixel (private)    | 位置テーブルごと移植      |
-| locateOutsideSeedPixel    | ✅   | locate_outside_seed_pixel (private) | -                         |
-| ccbaGenerateGlobalLocs    | ✅   | CcBorda::generate_global_locs       | C とビット一致            |
-| ccbaGenerateStepChains    | ✅   | CcBorda::generate_step_chains       | C とビット一致            |
-| ccbaStepChainsToPixCoords | ✅   | CcBorda::step_chains_to_pix_coords  | Local / Global 両方       |
-| ccbaDisplayBorder         | ✅   | CcBorda::display_border             | C とビット一致            |
-| ccbaDisplayImage2         | ✅   | CcBorda::display_image              | C とビット一致            |
-| ccbaWrite / ccbaRead      | 🔄   | -                                   | plan 902 PR 45 で移植予定 |
-| ccbaGenerateSinglePath    | 🔄   | -                                   | plan 902 PR 46 で移植予定 |
-| ccbaGenerateSPGlobalLocs  | 🔄   | -                                   | 同上                      |
-| ccbaDisplaySPBorder       | 🔄   | -                                   | 同上                      |
-| ccbaWriteSVGString        | 🔄   | -                                   | 同上                      |
-| ccbaDisplayImage1         | 🚫   | -                                   | C の reg テストが使わない |
+| C関数                     | 状態 | Rust対応                            | 備考                       |
+| ------------------------- | ---- | ----------------------------------- | -------------------------- |
+| pixGetAllCCBorders        | ✅   | CcBorda::from_pix                   | plan 902 PR 44             |
+| pixGetCCBorders           | ✅   | cc_borders (private)                | -                          |
+| pixGetOuterBorder         | ✅   | get_outer_border (private)          | -                          |
+| pixGetHoleBorder          | ✅   | get_hole_border (private)           | -                          |
+| findNextBorderPixel       | ✅   | find_next_border_pixel (private)    | 位置テーブルごと移植       |
+| locateOutsideSeedPixel    | ✅   | locate_outside_seed_pixel (private) | -                          |
+| ccbaGenerateGlobalLocs    | ✅   | CcBorda::generate_global_locs       | C とビット一致             |
+| ccbaGenerateStepChains    | ✅   | CcBorda::generate_step_chains       | C とビット一致             |
+| ccbaStepChainsToPixCoords | ✅   | CcBorda::step_chains_to_pix_coords  | Local / Global 両方        |
+| ccbaDisplayBorder         | ✅   | CcBorda::display_border             | C とビット一致             |
+| ccbaDisplayImage2         | ✅   | CcBorda::display_image              | C とビット一致             |
+| ccbaWriteStream           | ✅   | CcBorda::to_bytes                   | C とバイト一致 (PR 45)     |
+| ccbaReadStream            | ✅   | CcBorda::from_bytes                 | plan 902 PR 45             |
+| ccbaWrite / ccbaRead      | 🚫   | -                                   | ファイル開閉のみの薄い包み |
+| ccbaGenerateSinglePath    | 🔄   | -                                   | plan 902 PR 46 で移植予定  |
+| ccbaGenerateSPGlobalLocs  | 🔄   | -                                   | 同上                       |
+| ccbaDisplaySPBorder       | 🔄   | -                                   | 同上                       |
+| ccbaWriteSVGString        | 🔄   | -                                   | 同上                       |
+| ccbaDisplayImage1         | 🚫   | -                                   | C の reg テストが使わない  |
 
 C の `CCBORDA` パイプラインの移植は `region/ccborda.rs` (`CcBorda`)。
 `region/ccbord.rs` の `Border` / `ComponentBorders` は C に一対一対応の

--- a/docs/porting/comparison/region.md
+++ b/docs/porting/comparison/region.md
@@ -69,10 +69,7 @@ Rust 独自の便宜 API で、表現も直列化形式も C とは異なる。
 | ccbaWriteSVGString        | 🔄   | -                                   | 同上                       |
 | ccbaDisplayImage1         | 🚫   | -                                   | C の reg テストが使わない  |
 
-C の `CCBORDA` パイプラインの移植は `region/ccborda.rs` (`CcBorda`)。
-`region/ccbord.rs` の `Border` / `ComponentBorders` は C に一対一対応の
-ない Rust 独自の便宜 API で、表現も直列化形式も C とは異なる。両方に
-対応がある関数は、C 対応の実装で状態を判定している。
+両方に対応がある関数は、C 対応の実装で状態を判定している。
 
 #### region/ccborda.rs + region/ccbord.rs (ccbord.c) — Rust 独自 API
 

--- a/scripts/golden_map.tsv
+++ b/scripts/golden_map.tsv
@@ -346,9 +346,13 @@ region	watershed	23	watershed_c	24	watershed image 2 tiled stages
 region	ccbord	0	ccbord_c	1	ccbord feyn-fract border pixels (global locs)
 region	ccbord	1	ccbord_c	2	ccbord feyn-fract border pixels (via step chains)
 region	ccbord	2	ccbord_c	3	ccbord feyn-fract image reconstruction
-region	ccbord	7	ccbord_c	4	ccbord dreyfus1 border pixels (global locs)
-region	ccbord	8	ccbord_c	5	ccbord dreyfus1 border pixels (via step chains)
-region	ccbord	9	ccbord_c	6	ccbord dreyfus1 image reconstruction
+region	ccbord	3	ccbord_c	4	ccbord feyn-fract border pixels after .ccb round trip
+region	ccbord	4	ccbord_c	5	ccbord feyn-fract image reconstruction after .ccb round trip
+region	ccbord	7	ccbord_c	6	ccbord dreyfus1 border pixels (global locs)
+region	ccbord	8	ccbord_c	7	ccbord dreyfus1 border pixels (via step chains)
+region	ccbord	9	ccbord_c	8	ccbord dreyfus1 image reconstruction
+region	ccbord	10	ccbord_c	9	ccbord dreyfus1 border pixels after .ccb round trip
+region	ccbord	11	ccbord_c	10	ccbord dreyfus1 image reconstruction after .ccb round trip
 
 # lineremoval_reg.c (plan 902 PR 20): dave-orig.png line removal pipeline
 recog	lineremoval	0	lineremoval_c	1	threshold to binary 170

--- a/src/region/ccborda.rs
+++ b/src/region/ccborda.rs
@@ -16,6 +16,8 @@ use crate::core::{Box, Boxa, Numa, Numaa, Pix, PixelDepth, Pta, Ptaa};
 use crate::region::conncomp::{ConnectivityType, conncomp_pixa, next_on_pixel_in_raster};
 use crate::region::error::{RegionError, RegionResult};
 use crate::region::seedfill::{holes_by_filling, seedfill_binary_restricted};
+#[cfg(feature = "ccb-format")]
+use miniz_oxide::{deflate::compress_to_vec_zlib, inflate::decompress_to_vec_zlib};
 
 /// Upper bound on the points a single border trace may record.
 ///
@@ -586,6 +588,49 @@ fn pta_get_ipt(pta: &Pta, index: usize) -> (i32, i32) {
     ((x + 0.5) as i32, (y + 0.5) as i32)
 }
 
+/// Bytes of the `.ccb` header: `"ccba: %7d cc\n"` is 17 characters, and C
+/// takes an 18th byte from its `snprintf` buffer, which is the NUL.
+#[cfg(feature = "ccb-format")]
+const CCB_HEADER_SIZE: usize = 18;
+
+/// Cursor over an uncompressed `.ccb` stream.
+///
+/// C's `ccbaReadStream()` trusts the counts in the file and `memcpy`s past
+/// the end of a truncated one; every read here is bounds-checked instead.
+#[cfg(feature = "ccb-format")]
+struct CcbReader<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+#[cfg(feature = "ccb-format")]
+impl<'a> CcbReader<'a> {
+    fn take(&mut self, n: usize) -> RegionResult<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(n)
+            .filter(|&end| end <= self.data.len())
+            .ok_or_else(|| {
+                RegionError::InvalidParameters(format!(
+                    "ccba stream is truncated: wanted {n} bytes at offset {}, have {}",
+                    self.offset,
+                    self.data.len()
+                ))
+            })?;
+        let out = &self.data[self.offset..end];
+        self.offset = end;
+        Ok(out)
+    }
+
+    fn take4(&mut self) -> RegionResult<[u8; 4]> {
+        Ok(self.take(4)?.try_into().expect("four bytes"))
+    }
+
+    fn byte(&mut self) -> RegionResult<u8> {
+        Ok(self.take(1)?[0])
+    }
+}
+
 /// Serialization of the C `.ccb` format.
 ///
 /// The stream holds only the step chain representation: image size, and per
@@ -615,7 +660,50 @@ impl CcBorda {
     ///
     /// C Leptonica: `ccbaWriteStream()` in `ccbord.c`
     pub fn to_bytes(&self) -> RegionResult<Vec<u8>> {
-        Err(RegionError::NotImplemented)
+        let mut buf = format!("ccba: {:7} cc\n", self.ccb.len()).into_bytes();
+        buf.resize(CCB_HEADER_SIZE, 0);
+        buf.extend_from_slice(&self.w.to_le_bytes());
+        buf.extend_from_slice(&self.h.to_le_bytes());
+
+        for (i, ccb) in self.ccb.iter().enumerate() {
+            let b = ccb.boxa.get(0).ok_or_else(|| {
+                RegionError::InvalidParameters(format!("component {i} has no bounding box"))
+            })?;
+            if ccb.step.is_empty() {
+                return Err(RegionError::InvalidParameters(format!(
+                    "component {i} has no step chains; call generate_step_chains first"
+                )));
+            }
+            // C writes w and h too, though reconstruction does not need them.
+            for v in [b.x, b.y, b.w, b.h, ccb.step.len() as i32] {
+                buf.extend_from_slice(&v.to_le_bytes());
+            }
+
+            for j in 0..ccb.step.len() {
+                let na = ccb.step.get(j).expect("border in range");
+                let (startx, starty) = pta_get_ipt(&ccb.start, j);
+                buf.extend_from_slice(&startx.to_le_bytes());
+                buf.extend_from_slice(&starty.to_le_bytes());
+
+                // Two steps per byte, the earlier one in the high nibble.
+                let mut bval = 0u8;
+                for k in 0..na.len() {
+                    let val = (na.get_i32(k).unwrap_or(0) as u8) & 0xf;
+                    if k % 2 == 0 {
+                        bval = val << 4;
+                    } else {
+                        bval |= val;
+                        buf.push(bval);
+                    }
+                }
+                // 8 is not a step direction, so it terminates: after an odd
+                // count the last step keeps the high nibble, otherwise both
+                // nibbles are the sentinel.
+                buf.push(if na.len() % 2 == 1 { bval | 0x8 } else { 0x88 });
+            }
+        }
+
+        Ok(compress_to_vec_zlib(&buf, 6))
     }
 
     /// Parse the zlib-compressed C `.ccb` format.
@@ -628,8 +716,72 @@ impl CcBorda {
     /// # See also
     ///
     /// C Leptonica: `ccbaReadStream()` in `ccbord.c`
-    pub fn from_bytes(_data: &[u8]) -> RegionResult<Self> {
-        Err(RegionError::NotImplemented)
+    pub fn from_bytes(data: &[u8]) -> RegionResult<Self> {
+        let data = decompress_to_vec_zlib(data).map_err(|e| {
+            RegionError::InvalidParameters(format!("ccba stream is not zlib data: {e}"))
+        })?;
+        let mut r = CcbReader {
+            data: &data,
+            offset: 0,
+        };
+
+        let header = r.take(CCB_HEADER_SIZE)?;
+        let ncc = std::str::from_utf8(&header[..CCB_HEADER_SIZE - 1])
+            .ok()
+            .and_then(|s| s.strip_prefix("ccba:"))
+            .and_then(|s| s.strip_suffix(" cc\n"))
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .ok_or_else(|| {
+                RegionError::InvalidParameters("data is not a ccba stream".to_string())
+            })?;
+
+        let w = u32::from_le_bytes(r.take4()?);
+        let h = u32::from_le_bytes(r.take4()?);
+
+        // The counts come from the file, so they are not trusted for
+        // preallocation; the bounds checks in `take` are what limit growth.
+        let mut ccba = Self {
+            w,
+            h,
+            ccb: Vec::new(),
+        };
+        for _ in 0..ncc {
+            let mut ccb = CcBord::default();
+            let bx = i32::from_le_bytes(r.take4()?);
+            let by = i32::from_le_bytes(r.take4()?);
+            let bw = i32::from_le_bytes(r.take4()?);
+            let bh = i32::from_le_bytes(r.take4()?);
+            ccb.boxa
+                .push(Box::new(bx, by, bw, bh).map_err(RegionError::Core)?);
+
+            let nb = i32::from_le_bytes(r.take4()?);
+            let nb = usize::try_from(nb).map_err(|_| {
+                RegionError::InvalidParameters(format!("negative border count {nb}"))
+            })?;
+            for _ in 0..nb {
+                let startx = i32::from_le_bytes(r.take4()?);
+                let starty = i32::from_le_bytes(r.take4()?);
+                ccb.start.push(startx as f32, starty as f32);
+
+                let mut na = Numa::new();
+                loop {
+                    let bval = r.byte()?;
+                    let (nib1, nib2) = (bval >> 4, bval & 0xf);
+                    if nib1 == 8 {
+                        break;
+                    }
+                    na.push(f32::from(nib1));
+                    if nib2 == 8 {
+                        break;
+                    }
+                    na.push(f32::from(nib2));
+                }
+                ccb.step.push(na);
+            }
+            ccba.ccb.push(ccb);
+        }
+
+        Ok(ccba)
     }
 }
 
@@ -820,7 +972,6 @@ mod tests {
     /// Compare against the uncompressed payload, not the file: the compressed
     /// bytes depend on the deflate implementation, the payload does not.
     #[test]
-    #[ignore = "not yet implemented"]
     #[cfg(feature = "ccb-format")]
     fn test_to_bytes_matches_c() {
         let mut ccba = CcBorda::from_pix(&ring_and_dot()).unwrap();
@@ -830,7 +981,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     #[cfg(feature = "ccb-format")]
     fn test_to_bytes_odd_step_chain_matches_c() {
         let mut ccba = CcBorda::from_pix(&l_triomino()).unwrap();
@@ -840,7 +990,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     #[cfg(feature = "ccb-format")]
     fn test_to_bytes_without_step_chains_is_an_error() {
         let ccba = CcBorda::from_pix(&ring_and_dot()).unwrap();
@@ -850,7 +999,6 @@ mod tests {
     /// Parse C's own stream, so the reader is checked against C's writer
     /// rather than only against our own.
     #[test]
-    #[ignore = "not yet implemented"]
     #[cfg(feature = "ccb-format")]
     fn test_from_bytes_reads_c_stream() {
         let ccba = CcBorda::from_bytes(&deflate(C_STREAM_RING_AND_DOT)).expect("from_bytes");
@@ -884,7 +1032,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     #[cfg(feature = "ccb-format")]
     fn test_from_bytes_reads_odd_step_chain() {
         let ccba = CcBorda::from_bytes(&deflate(C_STREAM_L_TRIOMINO)).expect("from_bytes");
@@ -893,7 +1040,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "not yet implemented"]
     #[cfg(feature = "ccb-format")]
     fn test_from_bytes_rejects_foreign_data() {
         let not_ccba = deflate(b"nope: not a ccba stream at all");
@@ -907,7 +1053,6 @@ mod tests {
     /// The round trip is what `prog/ccbord_reg.c` checks 3 and 4 rely on: the
     /// borders drawn after a write/read must be identical to the originals.
     #[test]
-    #[ignore = "not yet implemented"]
     #[cfg(feature = "ccb-format")]
     fn test_round_trip_reproduces_borders_and_image() {
         let pixs = ring_and_dot();

--- a/src/region/ccborda.rs
+++ b/src/region/ccborda.rs
@@ -254,9 +254,21 @@ impl CcBorda {
                 let mut y = yul + ystart;
                 pta.push(x as f32, y as f32);
                 for k in 0..na.len() {
-                    let stepdir = na.get(k).unwrap_or(0.0) as usize;
-                    x += XPOSTAB[stepdir];
-                    y += YPOSTAB[stepdir];
+                    // `step` is public and can also come from a `.ccb` file,
+                    // so a direction outside the tables must not index it.
+                    // C indexes `xpostab` unchecked and reads out of bounds.
+                    let stepdir = na.get_i32(k).unwrap_or(-1);
+                    let dir = usize::try_from(stepdir)
+                        .ok()
+                        .filter(|&d| d < XPOSTAB.len())
+                        .ok_or_else(|| {
+                            RegionError::InvalidParameters(format!(
+                                "component {i} border {j} has step direction {stepdir}, \
+                                 which is not one of 0-7"
+                            ))
+                        })?;
+                    x += XPOSTAB[dir];
+                    y += YPOSTAB[dir];
                     pta.push(x as f32, y as f32);
                 }
                 out.push(pta);
@@ -688,7 +700,17 @@ impl CcBorda {
                 // Two steps per byte, the earlier one in the high nibble.
                 let mut bval = 0u8;
                 for k in 0..na.len() {
-                    let val = (na.get_i32(k).unwrap_or(0) as u8) & 0xf;
+                    // 8 is the terminator, so only 0-7 are representable.
+                    let stepdir = na.get_i32(k).unwrap_or(-1);
+                    let val = u8::try_from(stepdir)
+                        .ok()
+                        .filter(|&v| v < 8)
+                        .ok_or_else(|| {
+                            RegionError::InvalidParameters(format!(
+                                "component {i} border {j} has step direction {stepdir}, \
+                             which is not one of 0-7"
+                            ))
+                        })?;
                     if k % 2 == 0 {
                         bval = val << 4;
                     } else {
@@ -764,17 +786,21 @@ impl CcBorda {
                 ccb.start.push(startx as f32, starty as f32);
 
                 let mut na = Numa::new();
-                loop {
+                'steps: loop {
                     let bval = r.byte()?;
-                    let (nib1, nib2) = (bval >> 4, bval & 0xf);
-                    if nib1 == 8 {
-                        break;
+                    for nib in [bval >> 4, bval & 0xf] {
+                        match nib {
+                            // 8 is not a direction, so it terminates the chain.
+                            8 => break 'steps,
+                            0..=7 => na.push(f32::from(nib)),
+                            _ => {
+                                return Err(RegionError::InvalidParameters(format!(
+                                    "ccba stream has step direction {nib}, \
+                                     which is not one of 0-7"
+                                )));
+                            }
+                        }
                     }
-                    na.push(f32::from(nib1));
-                    if nib2 == 8 {
-                        break;
-                    }
-                    na.push(f32::from(nib2));
                 }
                 ccb.step.push(na);
             }
@@ -1067,5 +1093,41 @@ mod tests {
 
         back.step_chains_to_pix_coords(CcbCoords::Local).unwrap();
         assert!(back.display_image().unwrap().equals(&pixs));
+    }
+
+    /// 9 is neither a direction (0-7) nor the terminator (8). C would index
+    /// `xpostab` out of bounds; this must be an error, not a panic.
+    #[test]
+    #[cfg(feature = "ccb-format")]
+    fn test_from_bytes_rejects_invalid_step_direction() {
+        let mut stream = C_STREAM_L_TRIOMINO.to_vec();
+        let steps = stream.len() - 2; // the byte holding steps 4 and 7
+        assert_eq!(stream[steps], 0x47);
+        stream[steps] = 0x97;
+        assert!(CcBorda::from_bytes(&deflate(&stream)).is_err());
+    }
+
+    /// `CcBord::step` is public, so a direction outside the tables can reach
+    /// `step_chains_to_pix_coords` without going through `from_bytes`.
+    #[test]
+    fn test_step_chains_reject_invalid_step_direction() {
+        let mut ccba = CcBorda::from_pix(&ring_and_dot()).unwrap();
+        ccba.generate_step_chains();
+        ccba.ccb[0].step.get_mut(0).unwrap().set(0, 9.0).unwrap();
+        assert!(ccba.step_chains_to_pix_coords(CcbCoords::Local).is_err());
+
+        ccba.ccb[0].step.get_mut(0).unwrap().set(0, -1.0).unwrap();
+        assert!(ccba.step_chains_to_pix_coords(CcbCoords::Local).is_err());
+    }
+
+    /// The format reserves 8 as the terminator, so a chain that a reader
+    /// would reject must not be writable either.
+    #[test]
+    #[cfg(feature = "ccb-format")]
+    fn test_to_bytes_rejects_invalid_step_direction() {
+        let mut ccba = CcBorda::from_pix(&ring_and_dot()).unwrap();
+        ccba.generate_step_chains();
+        ccba.ccb[0].step.get_mut(0).unwrap().set(0, 9.0).unwrap();
+        assert!(ccba.to_bytes().is_err());
     }
 }

--- a/src/region/ccborda.rs
+++ b/src/region/ccborda.rs
@@ -586,6 +586,53 @@ fn pta_get_ipt(pta: &Pta, index: usize) -> (i32, i32) {
     ((x + 0.5) as i32, (y + 0.5) as i32)
 }
 
+/// Serialization of the C `.ccb` format.
+///
+/// The stream holds only the step chain representation: image size, and per
+/// component its bounding box, border start points, and step chains. Local
+/// and global pixel coordinates, and the bounding boxes of hole borders, are
+/// not written; rebuild the coordinates with
+/// [`CcBorda::step_chains_to_pix_coords`] after reading.
+///
+/// C's file-level `ccbaWrite()` / `ccbaRead()` are thin `fopen`/`fclose`
+/// wrappers and are not ported: use
+/// `std::fs::write(path, ccba.to_bytes()?)` and
+/// `CcBorda::from_bytes(&std::fs::read(path)?)`.
+#[cfg(feature = "ccb-format")]
+impl CcBorda {
+    /// Serialize to the zlib-compressed C `.ccb` format.
+    ///
+    /// Unlike C, which quietly calls `ccbaGenerateStepChains()` when a
+    /// component has none, this reports the omission, matching
+    /// [`CcBorda::step_chains_to_pix_coords`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the step chains have not been generated yet, or if
+    /// a component has no bounding box.
+    ///
+    /// # See also
+    ///
+    /// C Leptonica: `ccbaWriteStream()` in `ccbord.c`
+    pub fn to_bytes(&self) -> RegionResult<Vec<u8>> {
+        Err(RegionError::NotImplemented)
+    }
+
+    /// Parse the zlib-compressed C `.ccb` format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data is not zlib, does not start with the
+    /// `ccba:` magic, or ends in the middle of a record.
+    ///
+    /// # See also
+    ///
+    /// C Leptonica: `ccbaReadStream()` in `ccbord.c`
+    pub fn from_bytes(_data: &[u8]) -> RegionResult<Self> {
+        Err(RegionError::NotImplemented)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -720,5 +767,160 @@ mod tests {
         assert_eq!((b.x, b.y), (10, 8));
         let g = dot.global.get(0).expect("global border");
         assert_eq!(pta_get_ipt(g, 0), (10, 8));
+    }
+
+    /// The uncompressed `.ccb` payload C writes for [`ring_and_dot`], taken
+    /// verbatim from `ccbaWrite()` piped through `zlibUncompress()`.
+    ///
+    /// It exercises two components, a hole border, and both an even-length
+    /// and an empty step chain.
+    #[cfg(feature = "ccb-format")]
+    const C_STREAM_RING_AND_DOT: &[u8] = &[
+        0x63, 0x63, 0x62, 0x61, 0x3a, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x32, 0x20, 0x63,
+        0x63, 0x0a, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x44, 0x44, 0x46, 0x66, 0x60, 0x00,
+        0x00, 0x22, 0x22, 0x88, 0x05, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0x00, 0x76,
+        0x65, 0x44, 0x43, 0x22, 0x88, 0x0a, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x88,
+    ];
+
+    /// A 3-pixel L, the smallest shape whose step chain has odd length, so the
+    /// stream ends with the `0xz8` half-byte terminator rather than `0x88`.
+    /// Steps are `4 7 2`, packed as `0x47` then `0x2 | 0x8`.
+    #[cfg(feature = "ccb-format")]
+    const C_STREAM_L_TRIOMINO: &[u8] = &[
+        0x63, 0x63, 0x62, 0x61, 0x3a, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x31, 0x20, 0x63,
+        0x63, 0x0a, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x47, 0x28,
+    ];
+
+    #[cfg(feature = "ccb-format")]
+    fn l_triomino() -> Pix {
+        let pix = Pix::new(5, 5, PixelDepth::Bit1).unwrap();
+        let mut pm = pix.try_into_mut().unwrap();
+        pm.set_pixel_unchecked(1, 1, 1);
+        pm.set_pixel_unchecked(2, 1, 1);
+        pm.set_pixel_unchecked(1, 2, 1);
+        pm.into()
+    }
+
+    #[cfg(feature = "ccb-format")]
+    fn inflate(data: &[u8]) -> Vec<u8> {
+        miniz_oxide::inflate::decompress_to_vec_zlib(data).expect("zlib data")
+    }
+
+    #[cfg(feature = "ccb-format")]
+    fn deflate(data: &[u8]) -> Vec<u8> {
+        miniz_oxide::deflate::compress_to_vec_zlib(data, 6)
+    }
+
+    /// Compare against the uncompressed payload, not the file: the compressed
+    /// bytes depend on the deflate implementation, the payload does not.
+    #[test]
+    #[ignore = "not yet implemented"]
+    #[cfg(feature = "ccb-format")]
+    fn test_to_bytes_matches_c() {
+        let mut ccba = CcBorda::from_pix(&ring_and_dot()).unwrap();
+        ccba.generate_step_chains();
+        let written = ccba.to_bytes().expect("to_bytes");
+        assert_eq!(inflate(&written), C_STREAM_RING_AND_DOT);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    #[cfg(feature = "ccb-format")]
+    fn test_to_bytes_odd_step_chain_matches_c() {
+        let mut ccba = CcBorda::from_pix(&l_triomino()).unwrap();
+        ccba.generate_step_chains();
+        let written = ccba.to_bytes().expect("to_bytes");
+        assert_eq!(inflate(&written), C_STREAM_L_TRIOMINO);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    #[cfg(feature = "ccb-format")]
+    fn test_to_bytes_without_step_chains_is_an_error() {
+        let ccba = CcBorda::from_pix(&ring_and_dot()).unwrap();
+        assert!(ccba.to_bytes().is_err());
+    }
+
+    /// Parse C's own stream, so the reader is checked against C's writer
+    /// rather than only against our own.
+    #[test]
+    #[ignore = "not yet implemented"]
+    #[cfg(feature = "ccb-format")]
+    fn test_from_bytes_reads_c_stream() {
+        let ccba = CcBorda::from_bytes(&deflate(C_STREAM_RING_AND_DOT)).expect("from_bytes");
+        assert_eq!((ccba.width(), ccba.height()), (12, 10));
+        assert_eq!(ccba.len(), 2);
+
+        let ring = ccba.get(0).expect("ring");
+        assert_eq!(ring.boxa.len(), 1, "hole boxes are not serialized");
+        let b = ring.boxa.get(0).unwrap();
+        assert_eq!((b.x, b.y, b.w, b.h), (1, 1, 6, 5));
+        assert_eq!(ring.step.len(), 2);
+        assert_eq!(
+            ring.step.get(0).unwrap().as_slice(),
+            [
+                4., 4., 4., 4., 4., 6., 6., 6., 6., 0., 0., 0., 0., 0., 2., 2., 2., 2.
+            ]
+        );
+        assert_eq!(
+            ring.step.get(1).unwrap().as_slice(),
+            [1., 0., 0., 0., 7., 6., 6., 5., 4., 4., 4., 3., 2., 2.]
+        );
+        assert_eq!(pta_get_ipt(&ring.start, 0), (0, 0));
+        assert_eq!(pta_get_ipt(&ring.start, 1), (5, 1));
+
+        let dot = ccba.get(1).expect("dot");
+        assert_eq!(dot.step.len(), 1);
+        assert!(dot.step.get(0).unwrap().is_empty());
+
+        // Only the step representation survives; coordinates are rebuilt.
+        assert!(ring.local.is_empty() && ring.global.is_empty());
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    #[cfg(feature = "ccb-format")]
+    fn test_from_bytes_reads_odd_step_chain() {
+        let ccba = CcBorda::from_bytes(&deflate(C_STREAM_L_TRIOMINO)).expect("from_bytes");
+        let ccb = ccba.get(0).expect("component");
+        assert_eq!(ccb.step.get(0).unwrap().as_slice(), [4., 7., 2.]);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    #[cfg(feature = "ccb-format")]
+    fn test_from_bytes_rejects_foreign_data() {
+        let not_ccba = deflate(b"nope: not a ccba stream at all");
+        assert!(CcBorda::from_bytes(&not_ccba).is_err());
+        assert!(CcBorda::from_bytes(b"not even zlib").is_err());
+        // Truncated in the middle of a component record.
+        let short = deflate(&C_STREAM_RING_AND_DOT[..40]);
+        assert!(CcBorda::from_bytes(&short).is_err());
+    }
+
+    /// The round trip is what `prog/ccbord_reg.c` checks 3 and 4 rely on: the
+    /// borders drawn after a write/read must be identical to the originals.
+    #[test]
+    #[ignore = "not yet implemented"]
+    #[cfg(feature = "ccb-format")]
+    fn test_round_trip_reproduces_borders_and_image() {
+        let pixs = ring_and_dot();
+        let mut ccba = CcBorda::from_pix(&pixs).unwrap();
+        ccba.generate_step_chains();
+        ccba.step_chains_to_pix_coords(CcbCoords::Global).unwrap();
+        let border = ccba.display_border().unwrap();
+
+        let mut back = CcBorda::from_bytes(&ccba.to_bytes().unwrap()).unwrap();
+        back.step_chains_to_pix_coords(CcbCoords::Global).unwrap();
+        assert!(back.display_border().unwrap().equals(&border));
+
+        back.step_chains_to_pix_coords(CcbCoords::Local).unwrap();
+        assert!(back.display_image().unwrap().equals(&pixs));
     }
 }

--- a/tests/golden_manifest.tsv
+++ b/tests/golden_manifest.tsv
@@ -192,9 +192,13 @@ bw_white.03.png	f6995f80dec29e85
 ccbord_c.01.png	f1227f0520f8693f
 ccbord_c.02.png	f1227f0520f8693f
 ccbord_c.03.png	f29e3849aca2341e
-ccbord_c.04.png	67d6a01b4ddf8d4d
-ccbord_c.05.png	67d6a01b4ddf8d4d
-ccbord_c.06.png	04384b46fe18700c
+ccbord_c.04.png	f1227f0520f8693f
+ccbord_c.05.png	f29e3849aca2341e
+ccbord_c.06.png	67d6a01b4ddf8d4d
+ccbord_c.07.png	67d6a01b4ddf8d4d
+ccbord_c.08.png	04384b46fe18700c
+ccbord_c.09.png	67d6a01b4ddf8d4d
+ccbord_c.10.png	04384b46fe18700c
 ccbord_dreyfus1.04.tif	6eea4bcb33f79204
 checkerboard.01.png	0eaabb629dcecc61
 checkerboard.02.png	2eca0d318c854fc0

--- a/tests/region/ccbord_reg.rs
+++ b/tests/region/ccbord_reg.rs
@@ -172,10 +172,16 @@ fn ccbord_reg_dreyfus1_smoke() {
 }
 
 /// C-compatible port of `RunCCBordTest()` in `prog/ccbord_reg.c`, covering the
-/// border-following and reconstruction stage (C indices 0-2 and 7-9).
+/// border-following, reconstruction, and serialization stages (C indices 0-4
+/// and 7-11).
 ///
-/// The serialization round-trip (3,4 / 10,11) and the single-path/SVG stage
-/// (5,6 / 12,13) need more of the `CCBORDA` API and follow in later PRs.
+/// The single-path/SVG stage (5,6 / 12,13) needs more of the `CCBORDA` API and
+/// follows in a later PR.
+///
+/// Gated on `ccb-format` as a whole rather than per check: dropping only the
+/// serialization checks would renumber the ones after them and break the
+/// golden manifest.
+#[cfg(feature = "ccb-format")]
 fn do_ccbord_c(rp: &mut RegParams, fname: &str) {
     use leptonica::region::{CcBorda, CcbCoords};
 
@@ -204,9 +210,35 @@ fn do_ccbord_c(rp: &mut RegParams, fname: &str) {
     // 2 / 9
     rp.write_pix_and_check(&pixc, ImageFormat::Png)
         .expect("write reconstruction");
+
+    // Write the step data out and read it back. Only the step representation
+    // survives, so both coordinate frames have to be rebuilt from it.
+    let serialized = ccba.to_bytes().expect("to_bytes");
+    let mut ccba2 = CcBorda::from_bytes(&serialized).expect("from_bytes");
+
+    ccba2
+        .step_chains_to_pix_coords(CcbCoords::Global)
+        .expect("read-back step chains to global");
+    let pixd2 = ccba2
+        .display_border()
+        .expect("display_border after round trip");
+    // 3 / 10
+    rp.write_pix_and_check(&pixd2, ImageFormat::Png)
+        .expect("write border after round trip");
+
+    ccba2
+        .step_chains_to_pix_coords(CcbCoords::Local)
+        .expect("read-back step chains to local");
+    let pixc2 = ccba2
+        .display_image()
+        .expect("display_image after round trip");
+    // 4 / 11
+    rp.write_pix_and_check(&pixc2, ImageFormat::Png)
+        .expect("write reconstruction after round trip");
 }
 
 #[test]
+#[cfg(feature = "ccb-format")]
 fn ccbord_c_compat() {
     let mut rp = RegParams::new("ccbord_c");
     do_ccbord_c(&mut rp, "feyn-fract.tif");


### PR DESCRIPTION
## Why

plan 902 の Unmapped 削減キャンペーン。PR 44 で `CCBORDA` の境界追跡と
再構成を移植したので、続けて C の `ccbord_reg` check 3,4 / 10,11 に
対応する `.ccb` シリアライズの往復を移植する。

## What

- `CcBorda::to_bytes()` / `from_bytes()` として C の `ccbaWriteStream()` /
  `ccbaReadStream()` を移植 (RED/GREEN)
- zlib は既存の optional 依存 `miniz_oxide` を使い、他の形式と同じ流儀で
  `ccb-format` feature を追加 (`all-formats` に含める)
- `ccbord_c_compat` に往復後の境界描画・画像再構成の 2 check を追加。
  `golden_map.tsv` と manifest を更新

## 検証

C の `ccbaWrite()` 出力を `zlibUncompress()` して採取した非圧縮ペイロード
を期待値に使っている (圧縮後のバイト列は deflate 実装に依存するので比較
しない)。

- 単体テスト: 2 成分・穴あり・空チェーン・偶数長終端 `0x88`、および
  奇数長終端 `0xz8` の 2 パターンでバイト一致
- 実画像: `feyn-fract.tif` (464 成分、38272 バイト) と `dreyfus1.png`
  (290 成分、40987 バイト) でも C とバイト完全一致することを確認

**実装差は 0 件**。C 互換ベースラインは **Ok 456 → 460**、Mismatch 29
のまま (region 101 → 105)。

## C との意図的な差異

いずれも rustdoc と計画書に記載:

- `to_bytes()` はステップチェーン未生成をエラーにする。C は黙って
  `ccbaGenerateStepChains()` を呼ぶが、同じモジュールの
  `step_chains_to_pix_coords` がエラーを返す方針なので揃えた
- `from_bytes()` は全読み出しを境界検査する。C の `ccbaReadStream()` は
  ファイル中の個数を信用して `memcpy` するため、切り詰められた入力で
  バッファ外を読む。個数からの事前確保もしない
- `ccbaWrite()` / `ccbaRead()` はファイル開閉のみの薄い包みなので移植
  しない (`std::fs` で足りる。`RegionError` に `Io` を足さずに済む)

## Impact

`region` モジュールへの追加のみ。既存の公開 API は変更なし。
`ccbord_c_compat` は feature ごと gate している (一部の check だけ落とすと
check 番号がずれて manifest が壊れるため)。dreyfus1 側の Rust index が
4-6 から 6-10 にずれる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpY4vHyo3qhBSWDXCtCo4E